### PR TITLE
Fix: cannot exit the game if the configured exit key is not escape

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -394,7 +394,6 @@ namespace hg
 
 		updateLeaderboard(); updateFriends();
 
-		if(!window.isKeyPressed(Keyboard::Escape)) exitTimer = 0;
 		if(exitTimer > 20) window.stop();
 
 		if(isEnteringText())


### PR DESCRIPTION
This is really annoying when you don't have the escape key, like on my arcade machine...
Don't know why this is hardcoded, but removing this line seems to works well :)
