### PR TITLE
cmake args fix

### DIFF
--- a/build-repository-rel.sh
+++ b/build-repository-rel.sh
@@ -114,7 +114,7 @@ function buildLib
   	mkdir "build"; cd "build" # Create and move to the build directory
 
 	# Run CMake, make and (optionally) sudo make install
-	cmake ../ "${cmakeFlags}" || die 1 "cmake failed"
+	cmake ../ ${cmakeFlags} || die 1 "cmake failed"
 	make "-j${makeJobs}" || die 1 "make failed"
 
 	if [ "$flagSuperuser" == true ]; then
@@ -152,7 +152,7 @@ echo "final cmakeFlags: $cmakeFlags"
 askContinue
 
 ## Run CMake, make and make install
-cmake ../ "${cmakeFlags}"
+cmake ../ ${cmakeFlags}
 make "-j${makeJobs}"; make install "-j${makeJobs}"
 
 cd ".."

--- a/old_scripts/build-repository-oh.sh
+++ b/old_scripts/build-repository-oh.sh
@@ -37,7 +37,7 @@ function buildLib
   	mkdir "build"; cd "build" # Create and move to the build directory
 
 	# Run CMake, make and make install
-	cmake ../ "${cmakeFlags}" || die 1 "cmake failed"
+	cmake ../ ${cmakeFlags} || die 1 "cmake failed"
 
 	make "-j${makeJobs}" || die 1 "make failed"
 	make install "-j${makeJobs}" || die 1 "make install failed"
@@ -53,7 +53,7 @@ echo "Building ${projectName}..."
 mkdir "build"; cd "build" # Create and move to the build directory
 
 ## Run CMake, make and make install
-cmake ../ "${cmakeFlags}"
+cmake ../ ${cmakeFlags}
 make "-j${makeJobs}"; make install "-j${makeJobs}"
 
 echo "Successfully finished building ${projectName}."


### PR DESCRIPTION
I found cmake doesn't parse -D argument well.
I guess "" at cmake command escape space character.

Original result CMakeCache.txt :

	//Path to a program.
	CMAKE_AR:FILEPATH=/usr/bin/ar

	//Choose the type of build, options are: None(CMAKE_CXX_FLAGS or
	// CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel.
	CMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INCLUDE_PATH=/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVUtils:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVUtils/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVMenuSystem:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVMenuSystem/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVEntitySystem:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVEntitySystem/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVLuaWrapper:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVLuaWrapper/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVStart:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVStart/include:

	//Enable/Disable color output during build.
	CMAKE_COLOR_MAKEFILE:BOOL=ON


Fixed result CMakeCache.txt :

	//Path to a program.
	CMAKE_AR:FILEPATH=/usr/bin/ar

	//Choose the type of build, options are: None(CMAKE_CXX_FLAGS or
	// CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel.
	CMAKE_BUILD_TYPE:STRING=Release

	//Enable/Disable color output during build.
	CMAKE_COLOR_MAKEFILE:BOOL=ON

	//CXX compiler.
	CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/c++

	CMAKE_CXX_FLAGS:STRING=-std=c++1y -pthread -Wall -Wextra -Wpedantic -Wundef -Wshadow -Wno-missing-field-initializers -Wpointer-arith -Wcast-align -Wwrite-strings -Wno-unreachable-code -Wnon-virtual-dtor -Woverloaded-virtual

...

	//Enable/Disable output of compile commands during generation.
	CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF

	//No help, variable specified on the command line.
	CMAKE_INCLUDE_PATH:UNINITIALIZED=/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVUtils:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVUtils/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVMenuSystem:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVMenuSystem/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVEntitySystem:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVEntitySystem/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVLuaWrapper:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVLuaWrapper/include:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVStart:/home/pusnow/Develop/SSVOpenHexagon/extlibs/SSVStart/include:

	//Install path prefix, prepended onto install directories.
	CMAKE_INSTALL_PREFIX:PATH=/usr/local






CMAKE_BUILD_TYPE and CMAKE_INCLUDE_PATH are parsed well.

