### PR TITLE
Fix Scaling Bug On Message Text

### DIFF
--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -228,6 +228,8 @@ void HexagonGame::updateText()
         ssvu::toNum<unsigned int>(25.f / Config::getZoomFactor()));
     text.setOrigin(0, 0);
 
+    messageText.setCharacterSize(
+        ssvu::toNum<unsigned int>(38.f / Config::getZoomFactor()));
     messageText.setOrigin(getGlobalWidth(messageText) / 2.f, 0);
 }
 


### PR DESCRIPTION
This one line of code fixes the bug where the message text doesn't scale accordingly to the resolution of the window, leading to the text being huge on smaller resolution screens, and being smaller on higher resolutions.