### PR TITLE
Make functions previously exclusive in JSON events into Lua functions

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -163,6 +163,7 @@ private:
     // Data-related methods
     void setLevelData(const LevelData& mLevelData, bool mMusicFirstPlay);
     void playLevelMusic();
+    void playLevelMusicAtTime(float mSeconds);
     void stopLevelMusic();
 
     // Message-related methods

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -168,6 +168,7 @@ private:
 
     // Message-related methods
     void addMessage(const std::string& mMessage, float mDuration);
+    void clearMessages();
 
     // Level/menu loading/unloading/changing
     void checkAndSaveScore();

--- a/include/SSVOpenHexagon/Data/MusicData.hpp
+++ b/include/SSVOpenHexagon/Data/MusicData.hpp
@@ -40,6 +40,11 @@ public:
     {
     }
 
+    float getSegment(int index) 
+    {
+        return segments[index];
+    }
+
     void addSegment(float mSeconds)
     {
         segments.emplace_back(mSeconds);

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -31,6 +31,16 @@ void HexagonGame::initLua_Utils()
         stopLevelMusic();
         playLevelMusic();
     });
+    lua.writeVariable("u_setMusicSegment", [=](string mId, int segment) {
+        musicData = assets.getMusicData(mId);
+        stopLevelMusic();
+        playLevelMusicAtTime(musicData.getSegment[segment]);
+    });
+    lua.writeVariable("u_setMusicSeconds", [=](string mId, float mTime) {
+        musicData = assets.getMusicData(mId);
+        stopLevelMusic();
+        playLevelMusicAtTime(mTime);
+    });
     lua.writeVariable("u_isKeyPressed",
         [=](int mKey) { return window.getInputState()[KKey(mKey)]; });
 

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -83,6 +83,8 @@ void HexagonGame::initLua_Messages()
                 }
             });
         });
+
+    lua.writeVariable("m_clearMessages", [=] { clearMessages();});
 }
 
 void HexagonGame::initLua_MainTimeline()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -43,15 +43,16 @@ void HexagonGame::initLua_Utils()
     });
     lua.writeVariable("u_isKeyPressed",
         [=](int mKey) { return window.getInputState()[KKey(mKey)]; });
-
-    lua.writeVariable(
-        "u_getPlayerAngle", [=] { return player.getPlayerAngle(); });
-    lua.writeVariable("u_setPlayerAngle",
-        [=](float newAng) { player.setPlayerAngle(newAng); });
-
-    lua.writeVariable("u_isMouseButtonPressed",
-        [=](int mKey) { return window.getInputState()[MBtn(mKey)]; });
-
+    lua.writeVariable("u_haltTime", [=] (float mDuration) {
+        status.timeStop = mDuration;
+    });
+    lua.writeVariable("u_timelineWait", [=] (float mDuration) {
+        timeline.append<Wait>(mDuration);
+    });
+    lua.writeVairable("u_clearTimeline", [=] { timeline.clear(); timeline.reset();});
+    lua.writeVariable("u_getPlayerAngle", [=] { return player.getPlayerAngle(); });
+    lua.writeVariable("u_setPlayerAngle",[=](float newAng) { player.setPlayerAngle(newAng); });
+    lua.writeVariable("u_isMouseButtonPressed",[=](int mKey) { return window.getInputState()[MBtn(mKey)]; });
     lua.writeVariable("u_isFastSpinning", [=] { return status.fastSpin > 0; });
     lua.writeVariable("u_forceIncrement", [=] { incrementDifficulty(); });
     lua.writeVariable(

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -49,7 +49,7 @@ void HexagonGame::initLua_Utils()
     lua.writeVariable("u_timelineWait", [=] (float mDuration) {
         timeline.append<Wait>(mDuration);
     });
-    lua.writeVariable("u_clearTimeline", [=] { timeline.clear(); timeline.reset();});
+    lua.writeVariable("u_clearWalls", [=] { walls.clear()});
     lua.writeVariable("u_getPlayerAngle", [=] { return player.getPlayerAngle(); });
     lua.writeVariable("u_setPlayerAngle",[=](float newAng) { player.setPlayerAngle(newAng); });
     lua.writeVariable("u_isMouseButtonPressed",[=](int mKey) { return window.getInputState()[MBtn(mKey)]; });

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -34,7 +34,7 @@ void HexagonGame::initLua_Utils()
     lua.writeVariable("u_setMusicSegment", [=](string mId, int segment) {
         musicData = assets.getMusicData(mId);
         stopLevelMusic();
-        playLevelMusicAtTime(musicData.getSegment[segment]);
+        playLevelMusicAtTime(musicData.getSegment(segment));
     });
     lua.writeVariable("u_setMusicSeconds", [=](string mId, float mTime) {
         musicData = assets.getMusicData(mId);
@@ -49,7 +49,7 @@ void HexagonGame::initLua_Utils()
     lua.writeVariable("u_timelineWait", [=] (float mDuration) {
         timeline.append<Wait>(mDuration);
     });
-    lua.writeVairable("u_clearTimeline", [=] { timeline.clear(); timeline.reset();});
+    lua.writeVariable("u_clearTimeline", [=] { timeline.clear(); timeline.reset();});
     lua.writeVariable("u_getPlayerAngle", [=] { return player.getPlayerAngle(); });
     lua.writeVariable("u_setPlayerAngle",[=](float newAng) { player.setPlayerAngle(newAng); });
     lua.writeVariable("u_isMouseButtonPressed",[=](int mKey) { return window.getInputState()[MBtn(mKey)]; });

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -291,6 +291,15 @@ void HexagonGame::playLevelMusic()
         musicData.playRandomSegment(assets);
     }
 }
+
+void HexagonGame::playLevelMusicAtTime(float mSeconds)
+{
+    if(!Config::getNoMusic())
+    {
+        musicData.playSeconds(assets, mSeconds);
+    }
+}
+
 void HexagonGame::stopLevelMusic()
 {
     if(!Config::getNoMusic())

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -274,6 +274,10 @@ void HexagonGame::addMessage(const string& mMessage, float mDuration)
     messageTimeline.append<Wait>(mDuration);
     messageTimeline.append<Do>([=] { messageText.setString(""); });
 }
+void HexagonGame::clearMessages() 
+{
+    messageTimeline.clear();
+}
 void HexagonGame::setLevelData(
     const LevelData& mLevelData, bool mMusicFirstPlay)
 {

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -549,6 +549,7 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
     mLua.writeVariable("u_getDifficultyMult", [] { return 1; });
     mLua.writeVariable("u_getSpeedMultDM", [] { return 1; });
     mLua.writeVariable("u_getDelayMultDM", [] { return 1; });
+    mLua.writeVariable("u_getPlayerAngle", [] { return 0; });
     mLua.writeVariable("l_setRotationSpeed",
         [this](float mValue) { levelStatus.rotationSpeed = mValue; });
     mLua.writeVariable("l_setSides",
@@ -574,8 +575,11 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "l_setSwapEnabled", "l_setTutorialMode", "l_setIncEnabled",
             "l_enableRndSideChanges", "l_darkenUnevenBackgroundChunk",
             "l_getSpeedMult", "l_getDelayMult", "l_addTracked", "u_playSound",
-            "u_isKeyPressed", "u_isFastSpinning", "u_forceIncrement", "u_kill",
-            "u_eventKill", "m_messageAdd", "m_messageAddImportant", "t_wait",
+            "u_isKeyPressed", "u_isMouseButtonPressed", "u_isFastSpinning", 
+            "u_setPlayerAngle", "u_forceIncrement", "u_kill", "u_eventKill",
+            "u_haltTime", "u_timelineWait", "u_clearWalls", "u_setMusic",
+            "u_setMusicSegment", "u_setMusicSeconds",
+            "m_messageAdd", "m_messageAddImportant", "m_clearMessages", "t_wait",
             "t_waitS", "t_waitUntilS", "e_eventStopTime", "e_eventStopTimeS",
             "e_eventWait", "e_eventWaitS", "e_eventWaitUntilS", "w_wall",
             "w_wallAdj", "w_wallAcc", "w_wallHModSpeedData",


### PR DESCRIPTION
This is an addition of several new Lua functions into the Lua library. A lot of these functions were based off event functions that were exclusive to JSON in 1.92, which means that anybody who wants to port their packs from 1.92 can do this more easily if their levels were very reliant on events. 

I didn't do menu, because that can be substituted for "kill" and clearTimeline has been completely replaced with clearWalls, which provides much more useful functionality of clearing out all of the walls in a current level (because clearTimeline was pointless). 

Sorry for the merge issues. This probably has to do with the fact I have to add all the new Lua functions to the whitelist so the debugger doesn't make pointless errors.