### PR TITLE
Expand Cap Color to be more customizable

### DIFF
--- a/_RELEASE/Packs/cube/Styles/apeirogon.json
+++ b/_RELEASE/Packs/cube/Styles/apeirogon.json
@@ -20,6 +20,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [253, 253, 253, 255], "pulse": [0, 0, 0, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/babysteps.json
+++ b/_RELEASE/Packs/cube/Styles/babysteps.json
@@ -24,6 +24,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [0, 0, 0, 255], "pulse": [0, 0, 0, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/commando.json
+++ b/_RELEASE/Packs/cube/Styles/commando.json
@@ -24,6 +24,7 @@
 
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [28, 20, 13, 225], "pulse": [0, 0, 0, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/euclideanpc.json
+++ b/_RELEASE/Packs/cube/Styles/euclideanpc.json
@@ -24,7 +24,8 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [253, 253, 253, 255], "pulse": [0, 0, 0, 0] },
-
+	"cap_color": {"legacy": true, "index": 0},
+	
 	// Background colors
 	"colors":
 	[

--- a/_RELEASE/Packs/cube/Styles/flatteringshape.json
+++ b/_RELEASE/Packs/cube/Styles/flatteringshape.json
@@ -20,6 +20,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [255, 0, 0, 255], "pulse": [0, 50, 0, 0] },
+	"cap_color": "main_darkened",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/goldenratio.json
+++ b/_RELEASE/Packs/cube/Styles/goldenratio.json
@@ -20,6 +20,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [0, 0, 0, 225], "pulse": [25, 50, 75, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/labyrinth.json
+++ b/_RELEASE/Packs/cube/Styles/labyrinth.json
@@ -21,6 +21,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [255, 255, 255, 225], "pulse": [0, 0, 0, 0] },
+	"cap_color": "main_darkened",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/pi.json
+++ b/_RELEASE/Packs/cube/Styles/pi.json
@@ -20,6 +20,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [0, 0, 0, 225], "pulse": [99, 30, 165, 0] },
+	"cap_color": "main",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/cube/Styles/pointless.json
+++ b/_RELEASE/Packs/cube/Styles/pointless.json
@@ -20,7 +20,8 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [255, 0, 0, 255], "pulse": [-80, 75, 65, 0] },
-
+	"cap_color": "main_darkened",
+	
 	// Background colors
 	"colors":
 	[

--- a/_RELEASE/Packs/cube/Styles/seconddimension.json
+++ b/_RELEASE/Packs/cube/Styles/seconddimension.json
@@ -24,6 +24,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [0, 0, 0, 255], "pulse": [0, 0, 0, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/acceleradiant.json
+++ b/_RELEASE/Packs/hypercube/Styles/acceleradiant.json
@@ -23,6 +23,7 @@
 
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [255, 155, 155, 230], "pulse": [50, -75, 125, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/centrifugal.json
+++ b/_RELEASE/Packs/hypercube/Styles/centrifugal.json
@@ -24,6 +24,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [190, 190, 190, 225], "pulse": [99, 30, 165, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/disc-o.json
+++ b/_RELEASE/Packs/hypercube/Styles/disc-o.json
@@ -23,6 +23,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [0, 0, 0, 0], "pulse": [25, 25, 25, 0] },
+	"cap_color": "main_darkened",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/evotutorial.json
+++ b/_RELEASE/Packs/hypercube/Styles/evotutorial.json
@@ -23,6 +23,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [45, 25, 25, 255], "pulse": [25, 25, 50, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/g-force.json
+++ b/_RELEASE/Packs/hypercube/Styles/g-force.json
@@ -23,6 +23,7 @@
 	
 	// Main color
 	"main": { "main": false, "dynamic": false, "value": [245, 245, 245, 245], "pulse": [25, 25, 25, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/incongruence.json
+++ b/_RELEASE/Packs/hypercube/Styles/incongruence.json
@@ -23,6 +23,7 @@
 
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [255, 155, 155, 230], "pulse": [50, -75, 125, 0] },
+	"cap_color": "main_darkened",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/massacre.json
+++ b/_RELEASE/Packs/hypercube/Styles/massacre.json
@@ -24,6 +24,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [253, 253, 200, 255], "pulse": [0, 0, 0, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/polyhedrug.json
+++ b/_RELEASE/Packs/hypercube/Styles/polyhedrug.json
@@ -23,6 +23,7 @@
 
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [255, 0, 0, 255], "pulse": [-80, 75, 65, 0] },
+	"cap_color": "main",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/reppaws.json
+++ b/_RELEASE/Packs/hypercube/Styles/reppaws.json
@@ -20,6 +20,7 @@
 
 	// Main color
 	"main": { "main": true, "dynamic": true, "value": [0, 0, 0, 225], "pulse": [99, 30, 165, 0] },
+	"cap_color": "main_darkened",
 
 	// Background colors
 	"colors":

--- a/_RELEASE/Packs/hypercube/Styles/slither.json
+++ b/_RELEASE/Packs/hypercube/Styles/slither.json
@@ -23,6 +23,7 @@
 	
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [230, 230, 230, 230], "pulse": [25, 25, 25, 0] },
+	"cap_color": "main_darkened",
 
 	// Background colors
 	"colors":

--- a/include/SSVOpenHexagon/Data/CapColor.hpp
+++ b/include/SSVOpenHexagon/Data/CapColor.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "SSVOpenHexagon/Global/Common.hpp"
+#include "SSVOpenHexagon/Data/ColorData.hpp"
 #include "SSVOpenHexagon/SSVUtilsJson/SSVUtilsJson.hpp"
 
 #include <variant>
@@ -25,7 +27,8 @@ struct ByIndex      { int index; };
 using CapColor = std::variant<  //
     CapColorMode::Main,         //
     CapColorMode::MainDarkened, //
-    CapColorMode::ByIndex       //
+    CapColorMode::ByIndex,       //
+    ColorData
     >;
 
 [[nodiscard]] CapColor parseCapColor(const ssvuj::Obj& obj) noexcept;

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -11,7 +11,7 @@ struct ColorData
     sf::Color color, pulse;
 
     ColorData() = default;
-    ColorData(const ssvuj::Obj& mRoot)
+    ColorData(const ssvuj::Obj& mRoot) 
         : main{ssvuj::getExtr<bool>(mRoot, "main", false)},
           dynamic{ssvuj::getExtr<bool>(mRoot, "dynamic", false)},
           dynamicOffset{
@@ -22,7 +22,7 @@ struct ColorData
           offset{ssvuj::getExtr<float>(mRoot, "offset", 0.f)},
           color{
               ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::White)},
-          pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)};
+          pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)} {};
 
     ColorData(const bool mMain, const bool mDynamic, const bool mDynamicOffset,
                 const float mDynamicDarkness, const float mHueShift, const float mOffset,
@@ -34,5 +34,5 @@ struct ColorData
                 hueShift{mHueShift},
                 offset{mOffset},
                 color{mColor},
-                pulse{mPulse};
-};
+                pulse{mPulse} {};
+}

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -22,5 +22,17 @@ struct ColorData
           offset{ssvuj::getExtr<float>(mRoot, "offset", 0.f)},
           color{
               ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::White)},
-          pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)}
+          pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)};
+
+    ColorData(const bool mMain, const bool mDynamic, const bool mDynamicOffset,
+                const float mDynamicDarkness, const float mHueShift, const float mOffset,
+                sf::Color mColor, sf::Color mPulse)
+                : main{mMain},
+                dynamic{mDynamic},
+                dynamicOffset{mDynamicOffset},
+                dynamicDarkness{mDynamicDarkness},
+                hueShift{mHueShift},
+                offset{mOffset},
+                color{mColor},
+                pulse{mPulse};
 };

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -2,6 +2,8 @@
 // License: Academic Free License ("AFL") v. 3.0
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
+#pragma once
+
 #include "SSVOpenHexagon/Global/Common.hpp"
 
 struct ColorData

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2013-2020 Vittorio Romeo
+// License: Academic Free License ("AFL") v. 3.0
+// AFL License page: http://opensource.org/licenses/AFL-3.0
+
+#include "SSVOpenHexagon/Global/Common.hpp"
+
+struct ColorData
+{
+   bool main, dynamic, dynamicOffset;
+    float dynamicDarkness, hueShift, offset;
+    sf::Color color, pulse;
+
+    ColorData() = default;
+    ColorData(const ssvuj::Obj& mRoot)
+        : main{ssvuj::getExtr<bool>(mRoot, "main", false)},
+          dynamic{ssvuj::getExtr<bool>(mRoot, "dynamic", false)},
+          dynamicOffset{
+              ssvuj::getExtr<bool>(mRoot, "dynamic_offset", false)},
+          dynamicDarkness{
+              ssvuj::getExtr<float>(mRoot, "dynamic_darkness", 1.f)},
+          hueShift{ssvuj::getExtr<float>(mRoot, "hue_shift", 0.f)},
+          offset{ssvuj::getExtr<float>(mRoot, "offset", 0.f)},
+          color{
+              ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::White)},
+          pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)}
+};

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "SSVOpenHexagon/Global/Common.hpp"
+#include "SSVOpenHexagon/Data/ColorData.hpp"
 #include "SSVOpenHexagon/Data/CapColor.hpp"
 
 namespace hg
@@ -15,29 +16,6 @@ struct LevelStatus;
 class StyleData
 {
 private:
-    struct ColorData
-    {
-        bool main, dynamic, dynamicOffset;
-        float dynamicDarkness, hueShift, offset;
-        sf::Color color, pulse;
-
-        ColorData() = default;
-        ColorData(const ssvuj::Obj& mRoot)
-            : main{ssvuj::getExtr<bool>(mRoot, "main", false)},
-              dynamic{ssvuj::getExtr<bool>(mRoot, "dynamic", false)},
-              dynamicOffset{
-                  ssvuj::getExtr<bool>(mRoot, "dynamic_offset", false)},
-              dynamicDarkness{
-                  ssvuj::getExtr<float>(mRoot, "dynamic_darkness", 1.f)},
-              hueShift{ssvuj::getExtr<float>(mRoot, "hue_shift", 0.f)},
-              offset{ssvuj::getExtr<float>(mRoot, "offset", 0.f)},
-              color{
-                  ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::White)},
-              pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)}
-        {
-        }
-    };
-
     float currentHue, currentSwapTime{0}, pulseFactor{0};
     Path rootPath;
     sf::Color currentMainColor, current3DOverrideColor;

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -48,7 +48,7 @@ void HexagonGame::initLua_Utils()
         "u_haltTime", [=](float mDuration) { status.timeStop = mDuration; });
     lua.writeVariable("u_timelineWait",
         [=](float mDuration) { timeline.append<Wait>(mDuration); });
-    lua.writeVariable("u_clearWalls", [=] { walls.clear() });
+    lua.writeVariable("u_clearWalls", [=] { walls.clear(); });
     lua.writeVariable(
         "u_getPlayerAngle", [=] { return player.getPlayerAngle(); });
     lua.writeVariable("u_setPlayerAngle",

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -194,12 +194,13 @@ void HexagonGame::initLua_LevelControl()
     lsVar("SwapEnabled", &LevelStatus::swapEnabled);
     lsVar("TutorialMode", &LevelStatus::tutorialMode);
     lsVar("IncEnabled", &LevelStatus::incEnabled);
-    lsVar("RndSideChangesEnabled", &LevelStatus::rndSideChangesEnabled);
     lsVar("DarkenUnevenBackgroundChunk",
         &LevelStatus::darkenUnevenBackgroundChunk);
     lsVar("CurrentIncrements", &LevelStatus::currentIncrements);
     lsVar("MaxInc", &LevelStatus::maxIncrements); // backwards-compatible
     lsVar("MaxIncrements", &LevelStatus::maxIncrements);
+
+	lua.writeVariable("l_enableRndSideChanges", [=](bool mValue) { levelStatus.rndSideChangesEnabled = mValue; });
 
     lua.writeVariable("l_addTracked", [this](string mVar, string mName) {
         levelStatus.trackedVariables.emplace_back(mVar, mName);

--- a/src/SSVOpenHexagon/Data/CapColor.cpp
+++ b/src/SSVOpenHexagon/Data/CapColor.cpp
@@ -30,8 +30,22 @@ namespace hg
 
     if(ssvuj::isObj(obj))
     {
-        const int index = ssvuj::getExtr<int>(obj, "index", 0);
-        return CapColorMode::ByIndex{index};
+        const bool legacy = ssvuj::getExtr<bool>(obj, "legacy", true);
+        if (legacy) {
+            const int index = ssvuj::getExtr<int>(obj, "index", 0);
+            return CapColorMode::ByIndex{index};
+        } else {
+            return ColorData {
+                false, 
+                ssvuj::getExtr<bool>(obj, "dynamic", false), 
+                ssvuj::getExtr<bool>(obj, "dynamic_offset", false),
+                ssvuj::getExtr<float>(obj, "dynamic_darkness", 1.f), 
+                ssvuj::getExtr<float>(obj, "hue_shift", 0.f), 
+                ssvuj::getExtr<float>(obj, "offset", 0.f),
+                ssvuj::getExtr<sf::Color>(obj, "value", sf::Color::White), 
+                ssvuj::getExtr<sf::Color>(obj, "pulse", sf::Color::White)
+            };
+        }
     }
 
     // Fallback case:

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -183,7 +183,7 @@ sf::Color StyleData::getCapColorResult() const noexcept
         },                                                            //
         [this](CapColorMode::ByIndex x) { return getColor(x.index); }, //
         [this](ColorData data) {
-            return getColor(data);
+            return calculateColor(data);
         }
     );
 }

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -181,7 +181,10 @@ sf::Color StyleData::getCapColorResult() const noexcept
         [this](CapColorMode::MainDarkened) {
             return Utils::getColorDarkened(getMainColor(), 1.4f);
         },                                                            //
-        [this](CapColorMode::ByIndex x) { return getColor(x.index); } //
+        [this](CapColorMode::ByIndex x) { return getColor(x.index); }, //
+        [this](ColorData data) {
+            return getColor(data);
+        }
     );
 }
 


### PR DESCRIPTION
This expands upon the Cap Color code that was originally introduced to now accept color data, such as how it is done when configuring the main color or the colors for your background panels. 

1.92 style colorization is known as "legacy" and can be switched on and off. Also includes one quick fix of C++ code and also updates all of the level styles to have cap color configurations that seem to be most ideal for them.