### PR TITLE
Fix wallAcc with new caps

### DIFF
--- a/_RELEASE/Packs/hypercube/Scripts/nextpatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/nextpatterns.lua
@@ -134,7 +134,7 @@ function pACBarrageMulti()
 	startSide = math.random(0, 10)
 	for i = 0, currentSides - 2 do
 		currentSide = startSide + i
-		wallSAcc(currentSide, 10, -1.09, 0.31, 10)
+		wallSAcc(currentSide, 10, -1.09, 0.47, 10)
 		wallSAcc(currentSide, 0, 0.05, 0, 4.0)
 		wallSAcc(currentSide, 0, 0.09, 0, 4.0)
 		wallSAcc(currentSide, 0, 0.12, 0, 4.0)
@@ -145,7 +145,7 @@ end
 function pACBarrageMultiAltDir()
 	currentSides = l_getSides()
 	delay = getPerfectDelayDM(THICKNESS) * 4
-	mdiff = u_getDifficultyMult() / (u_getDifficultyMult()^1.6)
+	mdiff = u_getDifficultyMult() / (u_getDifficultyMult()^1.3)
 	startSide = math.random(0, 10)
 	loopDir = getRandomDir()
 	for i = 0, currentSides + getHalfSides() do

--- a/_RELEASE/Packs/hypercube/Scripts/nextpatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/nextpatterns.lua
@@ -145,13 +145,13 @@ end
 function pACBarrageMultiAltDir()
 	currentSides = l_getSides()
 	delay = getPerfectDelayDM(THICKNESS) * 4
-	mdiff = 1 + math.abs(1 - u_getDifficultyMult())
+	mdiff = u_getDifficultyMult() / (u_getDifficultyMult()^1.6)
 	startSide = math.random(0, 10)
 	loopDir = getRandomDir()
 	for i = 0, currentSides + getHalfSides() do
 		currentSide = startSide + i * loopDir
 		wallSAcc(currentSide, 10, -1.095, 0.40, 10)
-		t_wait((delay / 2.21) * (mdiff * 1.29))
+		t_wait((delay / 2.21) / mdiff)
 		wallSAcc(currentSide + (getHalfSides() * loopDir), 0, 0.128, 0, 1.4)
 	end
 	t_wait(delay * 8)

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -523,7 +523,8 @@ void HexagonGame::initLua_WallCreation()
             float mAcceleration, float mMinSpeed, float mMaxSpeed) {
             timeline.append_do([=, this] {
                 createWall(mSide, mThickness,
-                    {mSpeedAdj * getSpeedMultDM(), mAcceleration,
+                    {mSpeedAdj * getSpeedMultDM(), 
+                        mAcceleration / difficultyMult,
                         mMinSpeed * getSpeedMultDM(),
                         mMaxSpeed * getSpeedMultDM()});
             });

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -524,7 +524,7 @@ void HexagonGame::initLua_WallCreation()
             timeline.append_do([=, this] {
                 createWall(mSide, mThickness,
                     {mSpeedAdj * getSpeedMultDM(), 
-                        mAcceleration / difficultyMult,
+                        mAcceleration / (std::pow(difficultyMult, 0.65f)),
                         mMinSpeed * getSpeedMultDM(),
                         mMaxSpeed * getSpeedMultDM()});
             });


### PR DESCRIPTION
This is a quick fix to impossible outcomes in Acceleradiant by reprogramming wallAcc to adjust the acceleration of the walls based on the difficulty multiplier. This does not heavily affect any other levels as far as I know and no difference is made when played on normal difficulty.

Also made a slight tweak to some of the next patterns to adjust to this new code (especially acceleradiant).