### PR TITLE
Fix zero rotation issue

### DIFF
--- a/_RELEASE/Packs/cube/Scripts/Levels/goldenratio.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/goldenratio.lua
@@ -24,7 +24,7 @@ function onInit()
 	l_setSpeedMult(1.7)
 	l_setSpeedInc(0.1)
 	l_setSpeedMax(3.1) -- I would do pi, but I think there will be some cases that may be impossible
-	l_setRotationSpeed(0.0001)
+	l_setRotationSpeed(0)
 	l_setRotationSpeedMax(1)
 	l_setRotationSpeedInc(0.1)
 	l_setDelayMult(1.0)

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -190,8 +190,10 @@ void HexagonGame::incrementDifficulty()
 {
     assets.playSound("levelUp.ogg");
 
+    const int signMult = ssvu::getSign(levelStatus.rotationSpeed) == 0 ? 1 : ssvu::getSign(levelStatus.rotationSpeed);
+
     levelStatus.rotationSpeed +=
-        levelStatus.rotationSpeedInc * ssvu::getSign(levelStatus.rotationSpeed);
+        levelStatus.rotationSpeedInc * signMult;
 
     levelStatus.rotationSpeed *= -1.f;
 

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -190,7 +190,7 @@ void HexagonGame::incrementDifficulty()
 {
     assets.playSound("levelUp.ogg");
 
-    const int signMult = ssvu::getSign(levelStatus.rotationSpeed) == 0 ? 1 : ssvu::getSign(levelStatus.rotationSpeed);
+    const float signMult = (levelStatus.rotationSpeed > 0.f) ? 1.f : -1.f;
 
     levelStatus.rotationSpeed +=
         levelStatus.rotationSpeedInc * signMult;

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -201,7 +201,7 @@ void HexagonGame::incrementDifficulty()
     if(status.fastSpin < 0 && abs(levelStatus.rotationSpeed) > rotationSpeedMax)
     {
         levelStatus.rotationSpeed =
-            rotationSpeedMax * ssvu::getSign(levelStatus.rotationSpeed);
+            rotationSpeedMax * signMult;
     }
 
     status.fastSpin = levelStatus.fastSpin;


### PR DESCRIPTION
Fixes #191.

As a result, I set Golden Ratios beginning speed equal to 0. Now it is how it was intended to be.