### PR TITLE
Fix spirals not randomizing direction in common patterns

### DIFF
--- a/_RELEASE/Packs/cube/Scripts/alternativepatterns.lua
+++ b/_RELEASE/Packs/cube/Scripts/alternativepatterns.lua
@@ -1,11 +1,11 @@
 u_execScript("common.lua")
 
 function pAltMirrorSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
 	for k = 1, #mTimes do
 		for i = 1, mTimes[k] do
 			rWallEx(startSide, mExtra)
@@ -24,7 +24,7 @@ function pAltMirrorSpiral(mTimes, mExtra)
 end
 
 function randomArray(mNumber,mLower,mUpper)
-	a = {}
+	local a = {}
 	for k = 1, mNumber do
 		a[k] = math.random(mLower,mUpper)
 	end
@@ -32,11 +32,11 @@ function randomArray(mNumber,mLower,mUpper)
 end
 
 function pAltTunnel(mTimes,mFree)
-	oldThickness = THICKNESS
-	myThickness = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(myThickness) * 5
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
 	
 	THICKNESS = myThickness
 	
@@ -55,8 +55,8 @@ function pAltTunnel(mTimes,mFree)
 end
 
 function cycle(mSides)
-	eArray = {}
-	j = getRandomSide()
+	local eArray = {}
+	local j = getRandomSide()
 	for i = 1, mSides do 
 		eArray[i] = (i + j) % mSides + 1
 	end
@@ -65,15 +65,15 @@ end
 
 function pLadder(mTimes,mArray,myThickness)
 
-	delay = getPerfectDelay(myThickness)
+	local delay = getPerfectDelay(myThickness)
 
 	local eArray = {}
-	l = 1
-	s = #mArray/l_getSides()
-	t = math.random(0,100)
+	local l = 1
+	local s = #mArray/l_getSides()
+	local t = math.random(0,100)
 
 	for i = 1, mTimes do
-		q = (i+t) % s + 1
+		local q = (i+t) % s + 1
 		for k = 1, l_getSides() do
 			if(mArray[(q-1)*l_getSides() + k] ~= 0) then
 				eArray[l] = 1
@@ -103,10 +103,10 @@ function pLadder(mTimes,mArray,myThickness)
 end
 
 function patternizer(mArray,myThickness)
-	delay = getPerfectDelay(myThickness)
-	eArray = cycle(l_getSides())
+	local delay = getPerfectDelay(myThickness)
+	local eArray = cycle(l_getSides())
 
-	j = math.floor((#mArray) / l_getSides())
+	local j = math.floor((#mArray) / l_getSides())
 	
 	for i = 1, j do
 		for k = 1, l_getSides() do

--- a/_RELEASE/Packs/cube/Scripts/common.lua
+++ b/_RELEASE/Packs/cube/Scripts/common.lua
@@ -68,10 +68,10 @@ end
 -- cWallEx: creates a wall with mExtra walls attached to it 
 function cWallEx(mSide, mExtra)
 	cWall(mSide);
-	loopDir = 1;
+	local exLoopDir = 1;
 	
-	if mExtra < 0 then loopDir = -1 end
-	for i = 0, mExtra, loopDir do cWall(mSide + i) end
+	if mExtra < 0 then exLoopDir = -1 end
+	for i = 0, mExtra, exLoopDir do cWall(mSide + i) end
 end
 
 -- oWallEx: creates a wall with mExtra walls opposite to mSide

--- a/_RELEASE/Packs/cube/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/cube/Scripts/commonpatterns.lua
@@ -12,7 +12,7 @@ function pAltBarrage(mTimes, mStep)
 	t_wait(delay)
 end
 
--- pSpiral: spawns a spiral of cWall
+-- pSpiral: spawns a spiral of cWallEx
 function pSpiral(mTimes, mExtra)
 	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
@@ -22,7 +22,7 @@ function pSpiral(mTimes, mExtra)
 	local j = 0
 	
 	for i = 0, mTimes do
-		cWall(startSide + j, mExtra)
+		cWallEx(startSide + j, mExtra)
 		j = j + loopDir
 		t_wait(delay)
 	end

--- a/_RELEASE/Packs/cube/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/cube/Scripts/commonpatterns.lua
@@ -2,7 +2,7 @@ u_execScript("common.lua")
 
 -- pAltBarrage: spawns a series of cAltBarrage
 function pAltBarrage(mTimes, mStep)
-	delay = getPerfectDelayDM(THICKNESS) * 5.6
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6
 	
 	for i = 0, mTimes do
 		cAltBarrage(i, mStep)
@@ -14,12 +14,12 @@ end
 
 -- pSpiral: spawns a spiral of cWall
 function pSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
-	j = 0
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cWall(startSide + j, mExtra)
@@ -34,11 +34,11 @@ end
 
 -- pMirrorSpiral: spawns a spiral of rWallEx
 function pMirrorSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
 	j = 0
 	
 	for i = 0, mTimes do
@@ -54,12 +54,12 @@ end
 
 -- pMirrorSpiralDouble: spawns a spiral of rWallEx where you need to change direction
 function pMirrorSpiralDouble(mTimes, mExtra)
-    oldThickness = THICKNESS
+    local oldThickness = THICKNESS
     THICKNESS = getPerfectThickness(THICKNESS)
-    delay = getPerfectDelayDM(THICKNESS)
-    startSide = getRandomSide()
-    loopDir = getRandomDir()    
-    j = 0
+    local delay = getPerfectDelayDM(THICKNESS)
+    local startSide = getRandomSide()
+    local loopDir = getRandomDir()    
+    local j = 0
     
     for i = 0, mTimes do
         rWallEx(startSide + j, mExtra)
@@ -82,10 +82,10 @@ end
 
 -- pBarrageSpiral: spawns a spiral of cBarrage
 function pBarrageSpiral(mTimes, mDelayMult, mStep)
-	delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cBarrage(startSide + j)
@@ -99,10 +99,10 @@ end
 
 -- pDMBarrageSpiral: spawns a spiral of cBarrage, with static delay
 function pDMBarrageSpiral(mTimes, mDelayMult, mStep)
-	delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cBarrage(startSide + j)
@@ -116,10 +116,10 @@ end
 
 -- pWallExVortex: spawns left-left right-right spiral patters
 function pWallExVortex(mTimes, mStep, mExtraMult)
-	delay = getPerfectDelayDM(THICKNESS) * 5.0 
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
-	currentSide = startSide
+	local delay = getPerfectDelayDM(THICKNESS) * 5.0 
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
+	local currentSide = startSide
 	
 	for j = 0, mTimes do
 		for i = 0, mStep do
@@ -142,8 +142,8 @@ end
 
 -- pInverseBarrage: spawns two barrages who force you to turn 180 degrees
 function pInverseBarrage(mTimes)
-	delay = getPerfectDelayDM(THICKNESS) * 9.9
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 9.9
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		cBarrage(startSide)
@@ -158,8 +158,8 @@ end
 
 -- pRandomBarrage: spawns barrages with random side, and waits humanly-possible times depending on the sides distance
 function pRandomBarrage(mTimes, mDelayMult)
-	side = getRandomSide()
-	oldSide = 0
+	local side = getRandomSide()
+	local oldSide = 0
 	
 	for i = 0, mTimes do	
 		cBarrage(side)
@@ -173,8 +173,8 @@ end
 
 -- pMirrorWallStrip: spawns rWalls close to one another on the same side
 function pMirrorWallStrip(mTimes, mExtra)
-	delay = getPerfectDelayDM(THICKNESS) * 3.65
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.65
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		rWallEx(startSide, mExtra)
@@ -186,11 +186,11 @@ end
 
 -- pTunnel: forces you to circle around a very thick wall
 function pTunnel(mTimes)
-	oldThickness = THICKNESS
-	myThickness = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(myThickness) * 5
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
 	
 	THICKNESS = myThickness
 	

--- a/_RELEASE/Packs/experimental/Scripts/alternativepatterns.lua
+++ b/_RELEASE/Packs/experimental/Scripts/alternativepatterns.lua
@@ -1,11 +1,11 @@
 u_execScript("common.lua")
 
 function pAltMirrorSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
 	for k = 1, #mTimes do
 		for i = 1, mTimes[k] do
 			rWallEx(startSide, mExtra)
@@ -24,7 +24,7 @@ function pAltMirrorSpiral(mTimes, mExtra)
 end
 
 function randomArray(mNumber,mLower,mUpper)
-	a = {}
+	local a = {}
 	for k = 1, mNumber do
 		a[k] = math.random(mLower,mUpper)
 	end
@@ -32,11 +32,11 @@ function randomArray(mNumber,mLower,mUpper)
 end
 
 function pAltTunnel(mTimes,mFree)
-	oldThickness = THICKNESS
-	myThickness = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(myThickness) * 5
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
 	
 	THICKNESS = myThickness
 	
@@ -55,8 +55,8 @@ function pAltTunnel(mTimes,mFree)
 end
 
 function cycle(mSides)
-	eArray = {}
-	j = getRandomSide()
+	local eArray = {}
+	local j = getRandomSide()
 	for i = 1, mSides do 
 		eArray[i] = (i + j) % mSides + 1
 	end
@@ -65,15 +65,15 @@ end
 
 function pLadder(mTimes,mArray,myThickness)
 
-	delay = getPerfectDelay(myThickness)
+	local delay = getPerfectDelay(myThickness)
 
 	local eArray = {}
-	l = 1
-	s = (#mArray)/l_getSides()
-	t = math.random(0,100)
+	local l = 1
+	local s = #mArray/l_getSides()
+	local t = math.random(0,100)
 
 	for i = 1, mTimes do
-		q = (i+t) % s + 1
+		local q = (i+t) % s + 1
 		for k = 1, l_getSides() do
 			if(mArray[(q-1)*l_getSides() + k] ~= 0) then
 				eArray[l] = 1
@@ -103,10 +103,10 @@ function pLadder(mTimes,mArray,myThickness)
 end
 
 function patternizer(mArray,myThickness)
-	delay = getPerfectDelay(myThickness)
-	eArray = cycle(l_getSides())
+	local delay = getPerfectDelay(myThickness)
+	local eArray = cycle(l_getSides())
 
-	j = math.floor(#mArray / l_getSides())
+	local j = math.floor((#mArray) / l_getSides())
 	
 	for i = 1, j do
 		for k = 1, l_getSides() do

--- a/_RELEASE/Packs/experimental/Scripts/common.lua
+++ b/_RELEASE/Packs/experimental/Scripts/common.lua
@@ -82,10 +82,10 @@ end
 -- cWallEx: creates a wall with mExtra walls attached to it 
 function cWallEx(mSide, mExtra)
 	cWall(mSide);
-	loopDir = 1;
+	local exLoopDir = 1;
 	
-	if mExtra < 0 then loopDir = -1 end
-	for i = 0, mExtra, loopDir do cWall(mSide + i) end
+	if mExtra < 0 then exLoopDir = -1 end
+	for i = 0, mExtra, exLoopDir do cWall(mSide + i) end
 end
 
 -- oWallEx: creates a wall with mExtra walls opposite to mSide

--- a/_RELEASE/Packs/experimental/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/experimental/Scripts/commonpatterns.lua
@@ -2,7 +2,7 @@ u_execScript("common.lua")
 
 -- pAltBarrage: spawns a series of cAltBarrage
 function pAltBarrage(mTimes, mStep)
-	delay = getPerfectDelayDM(THICKNESS) * 5.6
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6
 	
 	for i = 0, mTimes do
 		cAltBarrage(i, mStep)
@@ -12,13 +12,33 @@ function pAltBarrage(mTimes, mStep)
 	t_wait(delay)
 end
 
+-- pSpiral: spawns a spiral of cWall
+function pSpiral(mTimes, mExtra)
+	local oldThickness = THICKNESS
+	THICKNESS = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
+	local j = 0
+	
+	for i = 0, mTimes do
+		cWall(startSide + j, mExtra)
+		j = j + loopDir
+		t_wait(delay)
+	end
+	
+	THICKNESS = oldThickness
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * 6.5)
+end
+
 -- pMirrorSpiral: spawns a spiral of rWallEx
 function pMirrorSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
 	j = 0
 	
 	for i = 0, mTimes do
@@ -34,45 +54,38 @@ end
 
 -- pMirrorSpiralDouble: spawns a spiral of rWallEx where you need to change direction
 function pMirrorSpiralDouble(mTimes, mExtra)
-	oldThickness = THICKNESS
-	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelayDM(THICKNESS)
-	startSide = getRandomSide()
-	currentSide = startSide
-	loopDir = getRandomDir()	
-	j = 0
-	
-	for i = 0, mTimes do
-		rWallEx(startSide + j, mExtra)
-		j = j + loopDir
-		t_wait(delay)
-	end
-	
-	rWallEx(startSide + j, mExtra)
-	t_wait(delay * 0.9)
-	
-	rWallEx(startSide + j, mExtra)
-	t_wait(delay * 0.9)
-	
-	loopDir = loopDir * -1
-	
-	for i = 0, mTimes + 1 do
-		currentSide = currentSide + loopDir;
-		rWallEx(currentSide + j - 1, mExtra)
-		j = j + loopDir
-		t_wait(delay)
-	end
-	
-	THICKNESS = oldThickness
-	t_wait(getPerfectDelayDM(THICKNESS) * 7.5)
+    local oldThickness = THICKNESS
+    THICKNESS = getPerfectThickness(THICKNESS)
+    local delay = getPerfectDelayDM(THICKNESS)
+    local startSide = getRandomSide()
+    local loopDir = getRandomDir()    
+    local j = 0
+    
+    for i = 0, mTimes do
+        rWallEx(startSide + j, mExtra)
+        j = j + loopDir
+        t_wait(delay)
+    end
+    
+    rWallEx(startSide + j, mExtra)
+    t_wait(delay * 0.9)
+    
+    for i = 0, mTimes + 1 do
+        rWallEx(startSide + j, mExtra)
+        j = j - loopDir
+        t_wait(delay)
+    end
+    
+    THICKNESS = oldThickness
+    t_wait(getPerfectDelayDM(THICKNESS) * 7.5)
 end
 
 -- pBarrageSpiral: spawns a spiral of cBarrage
 function pBarrageSpiral(mTimes, mDelayMult, mStep)
-	delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cBarrage(startSide + j)
@@ -86,10 +99,10 @@ end
 
 -- pDMBarrageSpiral: spawns a spiral of cBarrage, with static delay
 function pDMBarrageSpiral(mTimes, mDelayMult, mStep)
-	delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cBarrage(startSide + j)
@@ -103,10 +116,10 @@ end
 
 -- pWallExVortex: spawns left-left right-right spiral patters
 function pWallExVortex(mTimes, mStep, mExtraMult)
-	delay = getPerfectDelayDM(THICKNESS) * 5.0 
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
-	currentSide = startSide
+	local delay = getPerfectDelayDM(THICKNESS) * 5.0 
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
+	local currentSide = startSide
 	
 	for j = 0, mTimes do
 		for i = 0, mStep do
@@ -129,8 +142,8 @@ end
 
 -- pInverseBarrage: spawns two barrages who force you to turn 180 degrees
 function pInverseBarrage(mTimes)
-	delay = getPerfectDelayDM(THICKNESS) * 9.9
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 9.9
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		cBarrage(startSide)
@@ -145,8 +158,8 @@ end
 
 -- pRandomBarrage: spawns barrages with random side, and waits humanly-possible times depending on the sides distance
 function pRandomBarrage(mTimes, mDelayMult)
-	side = getRandomSide()
-	oldSide = 0
+	local side = getRandomSide()
+	local oldSide = 0
 	
 	for i = 0, mTimes do	
 		cBarrage(side)
@@ -160,8 +173,8 @@ end
 
 -- pMirrorWallStrip: spawns rWalls close to one another on the same side
 function pMirrorWallStrip(mTimes, mExtra)
-	delay = getPerfectDelayDM(THICKNESS) * 3.65
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.65
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		rWallEx(startSide, mExtra)
@@ -173,11 +186,11 @@ end
 
 -- pTunnel: forces you to circle around a very thick wall
 function pTunnel(mTimes)
-	oldThickness = THICKNESS
-	myThickness = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(myThickness) * 5
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
 	
 	THICKNESS = myThickness
 	

--- a/_RELEASE/Packs/experimental/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/experimental/Scripts/commonpatterns.lua
@@ -12,7 +12,7 @@ function pAltBarrage(mTimes, mStep)
 	t_wait(delay)
 end
 
--- pSpiral: spawns a spiral of cWall
+-- pSpiral: spawns a spiral of cWallEx
 function pSpiral(mTimes, mExtra)
 	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
@@ -22,7 +22,7 @@ function pSpiral(mTimes, mExtra)
 	local j = 0
 	
 	for i = 0, mTimes do
-		cWall(startSide + j, mExtra)
+		cWallEx(startSide + j, mExtra)
 		j = j + loopDir
 		t_wait(delay)
 	end

--- a/_RELEASE/Packs/experimental/Scripts/evolutionpatterns.lua
+++ b/_RELEASE/Packs/experimental/Scripts/evolutionpatterns.lua
@@ -4,12 +4,12 @@ u_execScript("utils.lua")
 u_execScript("alternativepatterns.lua")
 u_execScript("nextpatterns.lua")
 
-hueModifier = 0.2
-sync = false
-syncRndMin = 0
-syncRndMax = 0
+local hueModifier = 0.2
+local sync = false
+local syncRndMin = 0
+local syncRndMax = 0
 
-curveMult = 1
+local curveMult = 1
 
 function syncCurveWithRotationSpeed(mRndMin, mRndMax)
 	sync = true
@@ -62,13 +62,13 @@ end
 
 
 function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
-	startSide = getRandomSide()
-	currentSide = startSide
-	loopDir = getRandomDir()
-	delay = getPerfectDelayDM(THICKNESS) * 5.7
-	j = 0
+	local startSide = getRandomSide()
+	local currentSide = startSide
+	local loopDir = getRandomDir()
+	local delay = getPerfectDelayDM(THICKNESS) * 5.7
+	local j = 0
 	
-	currentCurve = mCurve	
+	local currentCurve = mCurve	
 
 	for i = 0, mTimes do
 		hmcSimpleBarrageS(startSide + j, currentCurve)
@@ -79,22 +79,22 @@ function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
 end
 
 function hmcSimpleCage(mCurve, mDir)
-	side = getRandomSide()
-	oppositeSide = side + getHalfSides()
+	local side = getRandomSide()
+	local oppositeSide = side + getHalfSides()
 
 	wallHMCurve(side, mCurve)
 	wallHMCurve(oppositeSide, mCurve * mDir)
 end
 
 function hmcSimpleCageS(mCurve, mDir, mSide)
-	oppositeSide = mSide + getHalfSides()
+	local oppositeSide = mSide + getHalfSides()
 
 	wallHMCurve(mSide, mCurve)
 	wallHMCurve(oppositeSide, mCurve * mDir)
 end
 
 function hmcSimpleSpinner(mCurve)
-	side = getRandomSide()
+	local side = getRandomSide()
 
 	for i = 0, l_getSides() / 2, 1 do
 		wallHMCurve(side + i * 2, mCurve)
@@ -127,8 +127,8 @@ end
 
 function hmcDef2Cage()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-	side = getRandomSide()
-	rndspd = math.random(10, 20) / 10.0
+	local side = getRandomSide()
+	local rndspd = math.random(10, 20) / 10.0
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 	hmcSimpleCageS(rndspd, -1, side)
@@ -142,9 +142,9 @@ end
 function hmcDef2CageD()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
 
-	side = getRandomSide()
-	oppositeSide = getHalfSides() + side
-	rndspd = math.random(10, 17) / 10.0
+	local side = getRandomSide()
+	local oppositeSide = getHalfSides() + side
+	local rndspd = math.random(10, 17) / 10.0
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 	hmcSimpleCageS(rndspd, -1, side)
@@ -162,10 +162,10 @@ function hmcDef2CageD()
 end
 
 function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
-	delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
@@ -178,8 +178,8 @@ function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
 end
 
 function hmcSimpleBarrageSpiralRnd(mTimes, mDelayMult, mCurve, mNeighbors)
-	delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		hmcSimpleBarrageSNeigh(getRandomSide(), mCurve, mNeighbors)
@@ -191,10 +191,10 @@ function hmcSimpleBarrageSpiralRnd(mTimes, mDelayMult, mCurve, mNeighbors)
 end
 
 function hmcSimpleBarrageSpiralStatic(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
-	delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
@@ -224,10 +224,10 @@ end
 
 function hmcDefBarrageInv()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.0)
-	delay = getPerfectDelay(THICKNESS) * 5.6 
-	side = getRandomSide()
-	rndspd = math.random(10, 20) / 10.0
-	oppositeSide = getRandomSide() + getHalfSides()
+	local delay = getPerfectDelay(THICKNESS) * 5.6 
+	local side = getRandomSide()
+	local rndspd = math.random(10, 20) / 10.0
+	local oppositeSide = getRandomSide() + getHalfSides()
 
 	hmcSimpleBarrageSNeigh(side, rndspd * getRandomDir(), 0)
 	t_wait(delay)
@@ -238,28 +238,28 @@ end
 
 function hmcDefAccelBarrage()
 	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-	c = math.random(50, 100) / 1000.0 * getRandomDir()
-	min = math.random(5, 35) / 10.0 * -1
-	max = math.random(5, 35) / 10.0
-	hmcBarrage(0, c, min, max, true)
+	local c = math.random(50, 100) / 1000.0 * getRandomDir()
+	local minimum = math.random(5, 35) / 10.0 * -1
+	local maximum = math.random(5, 35) / 10.0
+	hmcBarrage(0, c, minimum, maximum, true)
 	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
 end
 
 function hmcDefAccelBarrageDouble()
 	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-	c = math.random(50, 100) / 1000.0 * getRandomDir()
-	min = math.random(5, 35) / 10.0 * -1
-	max = math.random(5, 35) / 10.0
-	hmcBarrage(0, c, min, max, true)
+	local c = math.random(50, 100) / 1000.0 * getRandomDir()
+	local minimum = math.random(5, 35) / 10.0 * -1
+	local maximum = math.random(5, 35) / 10.0
+	hmcBarrage(0, c, minimum, maximum, true)
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-	hmcBarrage(0, c, min, max, true)
+	hmcBarrage(0, c, minimum, maximum, true)
 	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
 end
 
 function hmcDefSpinnerSpiral()
 	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-	side = getRandomSide()
-	c = math.random(10, 20) / 10.0 * getRandomDir()
+	local side = getRandomSide()
+	local c = math.random(10, 20) / 10.0 * getRandomDir()
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 
@@ -282,18 +282,18 @@ end
 function hmcDefSpinnerSpiralAcc()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-	side = getRandomSide()
+	local side = getRandomSide()
 
-	acc = math.random(getRndMinDM(50), getRndMaxDM(100)) / 1000.0 * getRandomDir()
-	min = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0 * -1
-	max = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0
+	local acc = math.random(getRndMinDM(50), getRndMaxDM(100)) / 1000.0 * getRandomDir()
+	local minimum = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0 * -1
+	local maximum = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0
 
 	
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 
 	for i = 0, math.random(4, 8) do
-		hmcSimpleSpinnerSAcc(side, 0, acc, min, max, true)
+		hmcSimpleSpinnerSAcc(side, 0, acc, minimum, maximum, true)
 		t_wait(getPerfectDelay(THICKNESS) * 0.8)
 	end
 

--- a/_RELEASE/Packs/experimental/Scripts/nextpatterns.lua
+++ b/_RELEASE/Packs/experimental/Scripts/nextpatterns.lua
@@ -7,7 +7,7 @@ function wallSAdj(mSide, mAdj) w_wallAdj(mSide, THICKNESS, mAdj) end
 function wallSAcc(mSide, mAdj, mAcc, mMinSpd, mMaxSpd) w_wallAcc(mSide, THICKNESS, mAdj, mAcc * (u_getDifficultyMult()), mMinSpd, mMaxSpd) end
 
 function pTrapBarrage(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 		
 	cBarrage(mSide)
 	t_wait(delay * 3)
@@ -17,11 +17,11 @@ function pTrapBarrage(mSide)
 end
 
 function pTrapBarrageDouble(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	side2 = mSide + getHalfSides();
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local side2 = mSide + getHalfSides();
 	
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if((currentSide ~= mSide) and (currentSide ~= side2)) then cWall(currentSide) end
 	end
 
@@ -33,13 +33,13 @@ function pTrapBarrageDouble(mSide)
 end
 
 function pTrapBarrageInverse(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 	
 	cWall(mSide)	
 	t_wait(delay * 3)
 
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if(currentSide ~= mSide) then wallSAdj(currentSide, 1.9) end
 	end
 
@@ -47,17 +47,17 @@ function pTrapBarrageInverse(mSide)
 end
 
 function pTrapBarrageAlt(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if(currentSide % 2 ~= 0) then cWall(currentSide) end
 	end
 
 	t_wait(delay * 3)
 
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if(currentSide % 2 == 0) then wallSAdj(currentSide, 1.9) end
 	end
 
@@ -65,13 +65,13 @@ function pTrapBarrageAlt(mSide)
 end
 
 function pTrapSpiral(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	loopDir = getRandomDir()		
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local loopDir = getRandomDir()		
 
 	if(l_getSides() < 6) then delay = delay + 4 end
 
 	for i = 0, l_getSides() + getHalfSides() do
-		currentSide = (mSide + i) * loopDir
+		local currentSide = (mSide + i) * loopDir
 		for j = 0, getHalfSides() do wallSAdj(currentSide + j, 1.2 + (i / 7.9)) end
 		t_wait((delay * 0.75) - (i * 0.45) + 3)
 	end
@@ -80,36 +80,39 @@ function pTrapSpiral(mSide)
 end
 
 function pRCBarrage()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+	
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
+		local currentSide = startSide + i
 		cWall(currentSide)
 	end
 	t_wait(delay * 2.5)
 end
 
 function pRCBarrageDouble()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
-		holeSide = startSide + i + (currentSides / 2)
+		local currentSide = startSide + i
+		local holeSide = startSide + i + (currentSides / 2)
 		if(i ~= holeSide) then cWall(currentSide) end
 	end
 	t_wait(delay * 2.5)
 end
 
 function pRCBarrageSpin()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
-	loopDir = getRandomDir()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+	local loopDir = getRandomDir()
+
 	for j = 0, 2 do
 		for i = 0, currentSides - 2 do
-			currentSide = startSide + i
+			local currentSide = startSide + i
 			cWall(currentSide + (j * loopDir))
 		end
 		t_wait(delay + 1)
@@ -118,22 +121,24 @@ function pRCBarrageSpin()
 end
 
 function pACBarrage()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
+		local currentSide = startSide + i
 		wallSAcc(currentSide, 9 + math.random(0, 1), -1.1, 1, 12)
 	end
 	t_wait(delay * 2.5)
 end
 
 function pACBarrageMulti()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
+		local currentSide = startSide + i
 		wallSAcc(currentSide, 10, -1.09, 0.31, 10)
 		wallSAcc(currentSide, 0, 0.05, 0, 4.0)
 		wallSAcc(currentSide, 0, 0.09, 0, 4.0)
@@ -143,13 +148,14 @@ function pACBarrageMulti()
 end
 
 function pACBarrageMultiAltDir()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 4
-	mdiff = 1 + math.abs(1 - u_getDifficultyMult())
-	startSide = math.random(0, 10)
-	loopDir = getRandomDir()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 4
+	local mdiff = 1 + math.abs(1 - u_getDifficultyMult())
+	local startSide = math.random(0, 10)
+	local loopDir = getRandomDir()
+
 	for i = 0, currentSides + getHalfSides() do
-		currentSide = startSide + i * loopDir
+		local currentSide = startSide + i * loopDir
 		wallSAcc(currentSide, 10, -1.095, 0.40, 10)
 		t_wait((delay / 2.21) * (mdiff * 1.29))
 		wallSAcc(currentSide + (getHalfSides() * loopDir), 0, 0.128, 0, 1.4)

--- a/_RELEASE/Packs/hypercube/Scripts/alternativepatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/alternativepatterns.lua
@@ -1,11 +1,11 @@
 u_execScript("common.lua")
 
 function pAltMirrorSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
 	for k = 1, #mTimes do
 		for i = 1, mTimes[k] do
 			rWallEx(startSide, mExtra)
@@ -24,7 +24,7 @@ function pAltMirrorSpiral(mTimes, mExtra)
 end
 
 function randomArray(mNumber,mLower,mUpper)
-	a = {}
+	local a = {}
 	for k = 1, mNumber do
 		a[k] = math.random(mLower,mUpper)
 	end
@@ -32,11 +32,11 @@ function randomArray(mNumber,mLower,mUpper)
 end
 
 function pAltTunnel(mTimes,mFree)
-	oldThickness = THICKNESS
-	myThickness = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(myThickness) * 5
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
 	
 	THICKNESS = myThickness
 	
@@ -55,8 +55,8 @@ function pAltTunnel(mTimes,mFree)
 end
 
 function cycle(mSides)
-	eArray = {}
-	j = getRandomSide()
+	local eArray = {}
+	local j = getRandomSide()
 	for i = 1, mSides do 
 		eArray[i] = (i + j) % mSides + 1
 	end
@@ -65,15 +65,15 @@ end
 
 function pLadder(mTimes,mArray,myThickness)
 
-	delay = getPerfectDelay(myThickness)
+	local delay = getPerfectDelay(myThickness)
 
 	local eArray = {}
-	l = 1
-	s = (#mArray)/l_getSides()
-	t = math.random(0,100)
+	local l = 1
+	local s = #mArray/l_getSides()
+	local t = math.random(0,100)
 
 	for i = 1, mTimes do
-		q = (i+t) % s + 1
+		local q = (i+t) % s + 1
 		for k = 1, l_getSides() do
 			if(mArray[(q-1)*l_getSides() + k] ~= 0) then
 				eArray[l] = 1
@@ -103,10 +103,10 @@ function pLadder(mTimes,mArray,myThickness)
 end
 
 function patternizer(mArray,myThickness)
-	delay = getPerfectDelay(myThickness)
-	eArray = cycle(l_getSides())
+	local delay = getPerfectDelay(myThickness)
+	local eArray = cycle(l_getSides())
 
-	j = math.floor(#mArray / l_getSides())
+	local j = math.floor((#mArray) / l_getSides())
 	
 	for i = 1, j do
 		for k = 1, l_getSides() do

--- a/_RELEASE/Packs/hypercube/Scripts/common.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/common.lua
@@ -68,10 +68,10 @@ end
 -- cWallEx: creates a wall with mExtra walls attached to it 
 function cWallEx(mSide, mExtra)
 	cWall(mSide);
-	loopDir = 1;
+	local exLoopDir = 1;
 	
-	if mExtra < 0 then loopDir = -1 end
-	for i = 0, mExtra, loopDir do cWall(mSide + i) end
+	if mExtra < 0 then exLoopDir = -1 end
+	for i = 0, mExtra, exLoopDir do cWall(mSide + i) end
 end
 
 -- oWallEx: creates a wall with mExtra walls opposite to mSide

--- a/_RELEASE/Packs/hypercube/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/commonpatterns.lua
@@ -12,7 +12,7 @@ function pAltBarrage(mTimes, mStep)
 	t_wait(delay)
 end
 
--- pSpiral: spawns a spiral of cWall
+-- pSpiral: spawns a spiral of cWallEx
 function pSpiral(mTimes, mExtra)
 	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
@@ -22,7 +22,7 @@ function pSpiral(mTimes, mExtra)
 	local j = 0
 	
 	for i = 0, mTimes do
-		cWall(startSide + j, mExtra)
+		cWallEx(startSide + j, mExtra)
 		j = j + loopDir
 		t_wait(delay)
 	end

--- a/_RELEASE/Packs/hypercube/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/commonpatterns.lua
@@ -2,7 +2,7 @@ u_execScript("common.lua")
 
 -- pAltBarrage: spawns a series of cAltBarrage
 function pAltBarrage(mTimes, mStep)
-	delay = getPerfectDelayDM(THICKNESS) * 5.6
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6
 	
 	for i = 0, mTimes do
 		cAltBarrage(i, mStep)
@@ -14,12 +14,12 @@ end
 
 -- pSpiral: spawns a spiral of cWall
 function pSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
-	j = 0
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cWall(startSide + j, mExtra)
@@ -34,11 +34,11 @@ end
 
 -- pMirrorSpiral: spawns a spiral of rWallEx
 function pMirrorSpiral(mTimes, mExtra)
-	oldThickness = THICKNESS
+	local oldThickness = THICKNESS
 	THICKNESS = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(THICKNESS)
-	startSide = getRandomSide()
-	loopDir = getRandomDir()	
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()	
 	j = 0
 	
 	for i = 0, mTimes do
@@ -54,12 +54,12 @@ end
 
 -- pMirrorSpiralDouble: spawns a spiral of rWallEx where you need to change direction
 function pMirrorSpiralDouble(mTimes, mExtra)
-    oldThickness = THICKNESS
+    local oldThickness = THICKNESS
     THICKNESS = getPerfectThickness(THICKNESS)
-    delay = getPerfectDelayDM(THICKNESS)
-    startSide = getRandomSide()
-    loopDir = getRandomDir()    
-    j = 0
+    local delay = getPerfectDelayDM(THICKNESS)
+    local startSide = getRandomSide()
+    local loopDir = getRandomDir()    
+    local j = 0
     
     for i = 0, mTimes do
         rWallEx(startSide + j, mExtra)
@@ -82,10 +82,10 @@ end
 
 -- pBarrageSpiral: spawns a spiral of cBarrage
 function pBarrageSpiral(mTimes, mDelayMult, mStep)
-	delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cBarrage(startSide + j)
@@ -99,10 +99,10 @@ end
 
 -- pDMBarrageSpiral: spawns a spiral of cBarrage, with static delay
 function pDMBarrageSpiral(mTimes, mDelayMult, mStep)
-	delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		cBarrage(startSide + j)
@@ -116,10 +116,10 @@ end
 
 -- pWallExVortex: spawns left-left right-right spiral patters
 function pWallExVortex(mTimes, mStep, mExtraMult)
-	delay = getPerfectDelayDM(THICKNESS) * 5.0 
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
-	currentSide = startSide
+	local delay = getPerfectDelayDM(THICKNESS) * 5.0 
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
+	local currentSide = startSide
 	
 	for j = 0, mTimes do
 		for i = 0, mStep do
@@ -142,8 +142,8 @@ end
 
 -- pInverseBarrage: spawns two barrages who force you to turn 180 degrees
 function pInverseBarrage(mTimes)
-	delay = getPerfectDelayDM(THICKNESS) * 9.9
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 9.9
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		cBarrage(startSide)
@@ -158,8 +158,8 @@ end
 
 -- pRandomBarrage: spawns barrages with random side, and waits humanly-possible times depending on the sides distance
 function pRandomBarrage(mTimes, mDelayMult)
-	side = getRandomSide()
-	oldSide = 0
+	local side = getRandomSide()
+	local oldSide = 0
 	
 	for i = 0, mTimes do	
 		cBarrage(side)
@@ -173,8 +173,8 @@ end
 
 -- pMirrorWallStrip: spawns rWalls close to one another on the same side
 function pMirrorWallStrip(mTimes, mExtra)
-	delay = getPerfectDelayDM(THICKNESS) * 3.65
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.65
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		rWallEx(startSide, mExtra)
@@ -186,11 +186,11 @@ end
 
 -- pTunnel: forces you to circle around a very thick wall
 function pTunnel(mTimes)
-	oldThickness = THICKNESS
-	myThickness = getPerfectThickness(THICKNESS)
-	delay = getPerfectDelay(myThickness) * 5
-	startSide = getRandomSide()
-	loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
 	
 	THICKNESS = myThickness
 	

--- a/_RELEASE/Packs/hypercube/Scripts/evolutionpatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/evolutionpatterns.lua
@@ -4,12 +4,12 @@ u_execScript("utils.lua")
 u_execScript("alternativepatterns.lua")
 u_execScript("nextpatterns.lua")
 
-hueModifier = 0.2
-sync = false
-syncRndMin = 0
-syncRndMax = 0
+local hueModifier = 0.2
+local sync = false
+local syncRndMin = 0
+local syncRndMax = 0
 
-curveMult = 1
+local curveMult = 1
 
 function syncCurveWithRotationSpeed(mRndMin, mRndMax)
 	sync = true
@@ -62,13 +62,13 @@ end
 
 
 function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
-	startSide = getRandomSide()
-	currentSide = startSide
-	loopDir = getRandomDir()
-	delay = getPerfectDelayDM(THICKNESS) * 5.7
-	j = 0
+	local startSide = getRandomSide()
+	local currentSide = startSide
+	local loopDir = getRandomDir()
+	local delay = getPerfectDelayDM(THICKNESS) * 5.7
+	local j = 0
 	
-	currentCurve = mCurve	
+	local currentCurve = mCurve	
 
 	for i = 0, mTimes do
 		hmcSimpleBarrageS(startSide + j, currentCurve)
@@ -79,22 +79,22 @@ function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
 end
 
 function hmcSimpleCage(mCurve, mDir)
-	side = getRandomSide()
-	oppositeSide = side + getHalfSides()
+	local side = getRandomSide()
+	local oppositeSide = side + getHalfSides()
 
 	wallHMCurve(side, mCurve)
 	wallHMCurve(oppositeSide, mCurve * mDir)
 end
 
 function hmcSimpleCageS(mCurve, mDir, mSide)
-	oppositeSide = mSide + getHalfSides()
+	local oppositeSide = mSide + getHalfSides()
 
 	wallHMCurve(mSide, mCurve)
 	wallHMCurve(oppositeSide, mCurve * mDir)
 end
 
 function hmcSimpleSpinner(mCurve)
-	side = getRandomSide()
+	local side = getRandomSide()
 
 	for i = 0, l_getSides() / 2, 1 do
 		wallHMCurve(side + i * 2, mCurve)
@@ -127,8 +127,8 @@ end
 
 function hmcDef2Cage()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-	side = getRandomSide()
-	rndspd = math.random(10, 20) / 10.0
+	local side = getRandomSide()
+	local rndspd = math.random(10, 20) / 10.0
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 	hmcSimpleCageS(rndspd, -1, side)
@@ -142,9 +142,9 @@ end
 function hmcDef2CageD()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
 
-	side = getRandomSide()
-	oppositeSide = getHalfSides() + side
-	rndspd = math.random(10, 17) / 10.0
+	local side = getRandomSide()
+	local oppositeSide = getHalfSides() + side
+	local rndspd = math.random(10, 17) / 10.0
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 	hmcSimpleCageS(rndspd, -1, side)
@@ -162,10 +162,10 @@ function hmcDef2CageD()
 end
 
 function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
-	delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
@@ -178,8 +178,8 @@ function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
 end
 
 function hmcSimpleBarrageSpiralRnd(mTimes, mDelayMult, mCurve, mNeighbors)
-	delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
-	startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
+	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
 		hmcSimpleBarrageSNeigh(getRandomSide(), mCurve, mNeighbors)
@@ -191,10 +191,10 @@ function hmcSimpleBarrageSpiralRnd(mTimes, mDelayMult, mCurve, mNeighbors)
 end
 
 function hmcSimpleBarrageSpiralStatic(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
-	delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
-	startSide = getRandomSide()
-	loopDir = mStep * getRandomDir()	
-	j = 0
+	local delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
 	
 	for i = 0, mTimes do
 		hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
@@ -224,10 +224,10 @@ end
 
 function hmcDefBarrageInv()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.0)
-	delay = getPerfectDelay(THICKNESS) * 5.6 
-	side = getRandomSide()
-	rndspd = math.random(10, 20) / 10.0
-	oppositeSide = getRandomSide() + getHalfSides()
+	local delay = getPerfectDelay(THICKNESS) * 5.6 
+	local side = getRandomSide()
+	local rndspd = math.random(10, 20) / 10.0
+	local oppositeSide = getRandomSide() + getHalfSides()
 
 	hmcSimpleBarrageSNeigh(side, rndspd * getRandomDir(), 0)
 	t_wait(delay)
@@ -238,28 +238,28 @@ end
 
 function hmcDefAccelBarrage()
 	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-	c = math.random(50, 100) / 1000.0 * getRandomDir()
-	min = math.random(5, 35) / 10.0 * -1
-	max = math.random(5, 35) / 10.0
-	hmcBarrage(0, c, min, max, true)
+	local c = math.random(50, 100) / 1000.0 * getRandomDir()
+	local minimum = math.random(5, 35) / 10.0 * -1
+	local maximum = math.random(5, 35) / 10.0
+	hmcBarrage(0, c, minimum, maximum, true)
 	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
 end
 
 function hmcDefAccelBarrageDouble()
 	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-	c = math.random(50, 100) / 1000.0 * getRandomDir()
-	min = math.random(5, 35) / 10.0 * -1
-	max = math.random(5, 35) / 10.0
-	hmcBarrage(0, c, min, max, true)
+	local c = math.random(50, 100) / 1000.0 * getRandomDir()
+	local minimum = math.random(5, 35) / 10.0 * -1
+	local maximum = math.random(5, 35) / 10.0
+	hmcBarrage(0, c, minimum, maximum, true)
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-	hmcBarrage(0, c, min, max, true)
+	hmcBarrage(0, c, minimum, maximum, true)
 	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
 end
 
 function hmcDefSpinnerSpiral()
 	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-	side = getRandomSide()
-	c = math.random(10, 20) / 10.0 * getRandomDir()
+	local side = getRandomSide()
+	local c = math.random(10, 20) / 10.0 * getRandomDir()
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 
@@ -282,18 +282,18 @@ end
 function hmcDefSpinnerSpiralAcc()
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
 	t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-	side = getRandomSide()
+	local side = getRandomSide()
 
-	acc = math.random(getRndMinDM(50), getRndMaxDM(100)) / 1000.0 * getRandomDir()
-	min = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0 * -1
-	max = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0
+	local acc = math.random(getRndMinDM(50), getRndMaxDM(100)) / 1000.0 * getRandomDir()
+	local minimum = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0 * -1
+	local maximum = math.random(getRndMinDM(12), getRndMaxDM(28)) / 10.0
 
 	
 
 	t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
 
 	for i = 0, math.random(4, 8) do
-		hmcSimpleSpinnerSAcc(side, 0, acc, min, max, true)
+		hmcSimpleSpinnerSAcc(side, 0, acc, minimum, maximum, true)
 		t_wait(getPerfectDelay(THICKNESS) * 0.8)
 	end
 

--- a/_RELEASE/Packs/hypercube/Scripts/nextpatterns.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/nextpatterns.lua
@@ -7,7 +7,7 @@ function wallSAdj(mSide, mAdj) w_wallAdj(mSide, THICKNESS, mAdj) end
 function wallSAcc(mSide, mAdj, mAcc, mMinSpd, mMaxSpd) w_wallAcc(mSide, THICKNESS, mAdj, mAcc * (u_getDifficultyMult()), mMinSpd, mMaxSpd) end
 
 function pTrapBarrage(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 		
 	cBarrage(mSide)
 	t_wait(delay * 3)
@@ -17,11 +17,11 @@ function pTrapBarrage(mSide)
 end
 
 function pTrapBarrageDouble(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	side2 = mSide + getHalfSides();
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local side2 = mSide + getHalfSides();
 	
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if((currentSide ~= mSide) and (currentSide ~= side2)) then cWall(currentSide) end
 	end
 
@@ -33,13 +33,13 @@ function pTrapBarrageDouble(mSide)
 end
 
 function pTrapBarrageInverse(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 	
 	cWall(mSide)	
 	t_wait(delay * 3)
 
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if(currentSide ~= mSide) then wallSAdj(currentSide, 1.9) end
 	end
 
@@ -47,17 +47,17 @@ function pTrapBarrageInverse(mSide)
 end
 
 function pTrapBarrageAlt(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if(currentSide % 2 ~= 0) then cWall(currentSide) end
 	end
 
 	t_wait(delay * 3)
 
 	for i = 0, l_getSides() - 1 do
-		currentSide = mSide + i
+		local currentSide = mSide + i
 		if(currentSide % 2 == 0) then wallSAdj(currentSide, 1.9) end
 	end
 
@@ -65,13 +65,13 @@ function pTrapBarrageAlt(mSide)
 end
 
 function pTrapSpiral(mSide)
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	loopDir = getRandomDir()		
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local loopDir = getRandomDir()		
 
 	if(l_getSides() < 6) then delay = delay + 4 end
 
 	for i = 0, l_getSides() + getHalfSides() do
-		currentSide = (mSide + i) * loopDir
+		local currentSide = (mSide + i) * loopDir
 		for j = 0, getHalfSides() do wallSAdj(currentSide + j, 1.2 + (i / 7.9)) end
 		t_wait((delay * 0.75) - (i * 0.45) + 3)
 	end
@@ -80,36 +80,39 @@ function pTrapSpiral(mSide)
 end
 
 function pRCBarrage()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+	
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
+		local currentSide = startSide + i
 		cWall(currentSide)
 	end
 	t_wait(delay * 2.5)
 end
 
 function pRCBarrageDouble()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
-		holeSide = startSide + i + (currentSides / 2)
+		local currentSide = startSide + i
+		local holeSide = startSide + i + (currentSides / 2)
 		if(i ~= holeSide) then cWall(currentSide) end
 	end
 	t_wait(delay * 2.5)
 end
 
 function pRCBarrageSpin()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
-	loopDir = getRandomDir()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+	local loopDir = getRandomDir()
+
 	for j = 0, 2 do
 		for i = 0, currentSides - 2 do
-			currentSide = startSide + i
+			local currentSide = startSide + i
 			cWall(currentSide + (j * loopDir))
 		end
 		t_wait(delay + 1)
@@ -118,23 +121,25 @@ function pRCBarrageSpin()
 end
 
 function pACBarrage()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
+		local currentSide = startSide + i
 		wallSAcc(currentSide, 9 + math.random(0, 1), -1.1, 1, 12)
 	end
 	t_wait(delay * 2.5)
 end
 
 function pACBarrageMulti()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 3.7
-	startSide = math.random(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
+
 	for i = 0, currentSides - 2 do
-		currentSide = startSide + i
-		wallSAcc(currentSide, 10, -1.09, 0.47, 10)
+		local currentSide = startSide + i
+		wallSAcc(currentSide, 10, -1.09, 0.31, 10)
 		wallSAcc(currentSide, 0, 0.05, 0, 4.0)
 		wallSAcc(currentSide, 0, 0.09, 0, 4.0)
 		wallSAcc(currentSide, 0, 0.12, 0, 4.0)
@@ -143,15 +148,16 @@ function pACBarrageMulti()
 end
 
 function pACBarrageMultiAltDir()
-	currentSides = l_getSides()
-	delay = getPerfectDelayDM(THICKNESS) * 4
-	mdiff = u_getDifficultyMult() / (u_getDifficultyMult()^1.3)
-	startSide = math.random(0, 10)
-	loopDir = getRandomDir()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 4
+	local mdiff = 1 + math.abs(1 - u_getDifficultyMult())
+	local startSide = math.random(0, 10)
+	local loopDir = getRandomDir()
+
 	for i = 0, currentSides + getHalfSides() do
-		currentSide = startSide + i * loopDir
+		local currentSide = startSide + i * loopDir
 		wallSAcc(currentSide, 10, -1.095, 0.40, 10)
-		t_wait((delay / 2.21) / mdiff)
+		t_wait((delay / 2.21) * (mdiff * 1.29))
 		wallSAcc(currentSide + (getHalfSides() * loopDir), 0, 0.128, 0, 1.4)
 	end
 	t_wait(delay * 8)


### PR DESCRIPTION
This was a bug that has been picked up by one of the community members last night, where he noticed that mirror spirals were not randomizing in their direction, but singular spirals did. It turns out that this was happening because "loopDir", the variable that is used to assign the direction of where the spiral goes, was constantly being overwritten by cWallEx, a function called in the spiral functions to create the walls. This pull request fixes this issue by renaming the loopDir variable in cWallEx to something else, so it doesn't overwrite the value of the loopDir in spiral patterns.

I also made it so pSpiral uses cWallEx now instead of just cWall and I also made a ton of variables in common patterns local, to ensure scope safety of a lot of the variables.