### PR TITLE
Add new optional Lua function onDeath

### DIFF
--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -162,6 +162,7 @@ void HexagonGame::death(bool mForce)
         return;
     }
     assets.playSound("gameOver.ogg", ssvs::SoundPlayer::Mode::Abort);
+    runLuaFunctionIfExists<void>("onDeath");
 
     if(!assets.pIsLocal() && Config::isEligibleForScore())
     {


### PR DESCRIPTION
Since optional functions exist, I thought that it would be a great idea if I decide to add one of my own. I call this one onDeath(), which is run when the player dies. They have to ACTUALLY die to get this to run, so if they turn on invincibility mode this function will not run.

It's a simple addition, but oh the many possibilities that can open up with just this one function.