### PR TITLE
Add 3D Required as a toggleable requirement for score eligibility on 3D-reliant levels

### DIFF
--- a/_RELEASE/Packs/experimental/Levels/3D_required.json
+++ b/_RELEASE/Packs/experimental/Levels/3D_required.json
@@ -6,7 +6,7 @@
 	"menuPriority": 20,
 	"selectable": true,
 	"styleId": "cw",
-	"musicId": "theresnomusicsorry",
+	"musicId": "jackRussel",
 	"luaFile": "Scripts/Levels/3D_required.lua",
 	"difficultyMults": [1.6, 2.2, 2.8, 0.6, 0.4]
 }

--- a/_RELEASE/Packs/experimental/Levels/3D_required.json
+++ b/_RELEASE/Packs/experimental/Levels/3D_required.json
@@ -1,0 +1,12 @@
+{
+	"id": "ThreeDimensions-Required-test",
+	"name": "3D Required",
+	"description": "You have to play this level with 3D enabled\nfor your score to count",
+	"author": "Morxemplum",
+	"menuPriority": 20,
+	"selectable": true,
+	"styleId": "cw",
+	"musicId": "theresnomusicsorry",
+	"luaFile": "Scripts/Levels/3D_required.lua",
+	"difficultyMults": [1.6, 2.2, 2.8, 0.6, 0.4]
+}

--- a/_RELEASE/Packs/experimental/Scripts/Levels/3D_required.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/3D_required.lua
@@ -1,0 +1,91 @@
+-- include useful files
+u_execScript("utils.lua")
+u_execScript("common.lua")
+u_execScript("commonpatterns.lua")
+
+-- this function adds a pattern to the timeline based on a key
+function addPattern(mKey)
+		if mKey ==  0 then pAltBarrage(math.random(2, 4), 2)
+	elseif mKey ==  1 then pMirrorSpiral(math.random(3, 6), 0)
+	elseif mKey ==  2 then pBarrageSpiral(math.random(0, 3), 1, 1)
+	elseif mKey ==  3 then pBarrageSpiral(math.random(0, 2), 1.2, 2)
+	elseif mKey ==  4 then pBarrageSpiral(2, 0.7, 1)
+	elseif mKey ==  5 then pInverseBarrage(0)
+	elseif mKey ==  6 then pTunnel(math.random(1, 3))
+	elseif mKey ==  7 then pMirrorWallStrip(1, 0)
+	elseif mKey ==  8 then 
+		if l_getSides() > 5 then
+			pWallExVortex(0, 1, 1)
+		end
+	elseif mKey ==  9 then pDMBarrageSpiral(math.random(4, 7), 0.4, 1)
+	elseif mKey == 10 then pRandomBarrage(math.random(2, 4), 2.25)
+	end
+end
+
+-- shuffle the keys, and then call them to add all the patterns
+-- shuffling is better than randomizing - it guarantees all the patterns will be called
+keys = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 7, 7, 8, 9, 10, 10, 10 }
+keys = shuffle(keys)
+index = 0
+
+-- onInit is an hardcoded function that is called when the level is first loaded
+function onInit()
+	l_setSpeedMult(2.65)
+	l_setSpeedInc(0.1)
+	--l_setSpeedMax(3.4)
+	l_setRotationSpeed(0.2)
+	--l_setRotationSpeedMax(0.8)
+	l_setRotationSpeedInc(0.05)
+	l_setDelayMult(1.1)
+	l_setDelayInc(0.005)
+	--l_setDelayMin(1.05)
+	l_setFastSpin(70.0)
+	l_setSides(6)
+	l_setSidesMin(5)
+	l_setSidesMax(7)
+	l_setIncTime(15)
+
+	l_setPulseMin(70)
+	l_setPulseMax(90)
+	l_setPulseSpeed(1.0)
+	l_setPulseSpeedR(0.6)
+	l_setPulseDelayMax(0)
+
+	l_setBeatPulseMax(17)
+	l_setBeatPulseDelayMax(23.8)
+
+	l_set3dRequired(true)
+	enableSwapIfDMGreaterThan(1.4)
+	disableIncIfDMGreaterThan(1.4)
+end
+
+-- onLoad is an hardcoded function that is called when the level is started/restarted
+function onLoad()
+end
+
+-- onStep is an hardcoded function that is called when the level timeline is empty
+-- onStep should contain your pattern spawning logic
+function onStep()
+	addPattern(keys[index])
+	index = index + 1
+
+	if index - 1 == #keys then
+		index = 1
+		keys = shuffle(keys)
+	end
+end
+
+-- onIncrement is an hardcoded function that is called when the level difficulty is incremented
+function onIncrement()
+end
+
+-- onUnload is an hardcoded function that is called when the level is closed/restarted
+function onUnload()
+end
+
+local t = 0;
+-- onUpdate is an hardcoded function that is called every frame
+function onUpdate(mFrameTime)
+	t = l_getLevelTime();
+	s_set3dSkew(math.sin(t) * 2 + 2);
+end

--- a/include/SSVOpenHexagon/Core/HGStatus.hpp
+++ b/include/SSVOpenHexagon/Core/HGStatus.hpp
@@ -49,6 +49,7 @@ public:
     float fastSpin{0};
     bool hasDied{false}, mustRestart{false};
     bool scoreInvalid{false};
+    std::string invalidReason{""};
     bool started{false};
     sf::Color overrideColor{sf::Color::Transparent};
     ssvu::ObfuscatedValue<float> lostFrames{0};

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -241,7 +241,7 @@ private:
     void changeLevel(
         const std::string& mPackId, const std::string& mId, bool mFirstTime);
 
-    void invalidateScore();
+    void invalidateScore(std::string mReason);
 
 
     template <typename F>

--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -92,9 +92,11 @@ struct LevelStatus
 
     bool swapEnabled{false};
     bool tutorialMode{false};
+    bool 3DRequired{false};
     bool incEnabled{true};
     bool rndSideChangesEnabled{true};
     bool darkenUnevenBackgroundChunk{true};
+    
 
     std::size_t currentIncrements{0u};
 

--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -92,7 +92,7 @@ struct LevelStatus
 
     bool swapEnabled{false};
     bool tutorialMode{false};
-    bool 3DRequired{false};
+    bool _3DRequired{false};
     bool incEnabled{true};
     bool rndSideChangesEnabled{true};
     bool darkenUnevenBackgroundChunk{true};

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -199,7 +199,9 @@ void HexagonGame::updateText()
 
         if(status.scoreInvalid)
         {
-            os << "SCORE INVALIDATED (PERFORMANCE ISSUES)\n";
+            os << "SCORE INVALIDATED ("
+               << status.invalidReason
+               << ")\n";
         }
 
         if(status.hasDied)

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -337,6 +337,7 @@ void HexagonGame::initLua_LevelControl()
     lsVar("WallSkewRight", &LevelStatus::wallSkewRight);
     lsVar("WallAngleLeft", &LevelStatus::wallAngleLeft);
     lsVar("WallAngleRight", &LevelStatus::wallAngleRight);
+    lsVar("3dRequired", &LevelStatus::_3DRequired);
     lsVar("3dEffectMultiplier", &LevelStatus::_3dEffectMultiplier);
     lsVar("CameraShake", &LevelStatus::cameraShake);
     lsVar("Sides", &LevelStatus::sides);

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -219,9 +219,10 @@ void HexagonGame::update(ssvu::FT mFT)
         if(!status.scoreInvalid && Config::getOfficial() &&
             fpsWatcher.isLimitReached())
         {
-            invalidateScore();
+            invalidateScore("PERFORMANCE ISSUES");
+        } else if (!status.scoreInvalid && !Config::get3D() && levelStatus._3DRequired) {
+            invalidateScore("3D REQUIRED");
         }
-
         fpsWatcher.update();
     }
 }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -256,6 +256,11 @@ void HexagonGame::checkAndSaveScore()
                 << "Not sending score - less than 8 seconds\n";
             return;
         }
+        if (levelStatus.3DRequired && !Config::get3D())
+        {
+            ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
+                << "Not saving score - 3D not enabled on a 3D Required level\n";
+        }
         Online::trySendScore(levelData->id, difficultyMult, time);
     }
 }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -224,11 +224,19 @@ void HexagonGame::checkAndSaveScore()
 {
     const float time = status.getTimeSeconds();
 
-    if(Config::getInvincible())
+    // These are requirements that need to be met for a score to be valid
+    if(status.scoreInvalid || !Config::isEligibleForScore())
     {
         ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
-            << "Not saving score - invincibility on\n";
+            << "Not sending/saving score - not eligible\n"
+            << Config::getUneligibilityReason() << "\n";
         return;
+    }
+
+    if (levelStatus.3DRequired && !Config::get3D())
+    {
+        ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
+            << "Not saving score - 3D not enabled on a 3D Required level\n";
     }
 
     if(assets.pIsLocal())
@@ -243,23 +251,12 @@ void HexagonGame::checkAndSaveScore()
     }
     else
     {
-        if(status.scoreInvalid || !Config::isEligibleForScore())
-        {
-            ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
-                << "Not sending/saving score - not eligible\n"
-                << Config::getUneligibilityReason() << "\n";
-            return;
-        }
+        // These are requirements that need to be met for a score to be sent online
         if(time < 8)
         {
             ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
                 << "Not sending score - less than 8 seconds\n";
             return;
-        }
-        if (levelStatus.3DRequired && !Config::get3D())
-        {
-            ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
-                << "Not saving score - 3D not enabled on a 3D Required level\n";
         }
         Online::trySendScore(levelData->id, difficultyMult, time);
     }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -228,7 +228,7 @@ void HexagonGame::checkAndSaveScore()
     if(status.scoreInvalid || !Config::isEligibleForScore())
     {
         ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
-            << "Not sending/saving score - not eligible\n"
+            << "Not saving score - not eligible - "
             << Config::getUneligibilityReason() << "\n";
         return;
     }
@@ -236,7 +236,7 @@ void HexagonGame::checkAndSaveScore()
     if (levelStatus._3DRequired && !Config::get3D())
     {
         ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
-            << "Not saving score - 3D not enabled on a 3D Required level\n";
+            << "Not saving score - 3D disabled on 3D Required level\n";
     }
 
     if(assets.pIsLocal())
@@ -258,6 +258,18 @@ void HexagonGame::checkAndSaveScore()
                 << "Not sending score - less than 8 seconds\n";
             return;
         }
+		if(Online::getServerVersion() == -1)
+		{
+			ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
+                << "Not sending score - connection error\n";
+			return;
+		}
+		if(Online::getServerVersion() > Config::getVersion())
+		{
+			ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
+                << "Not sending score - version mismatch\n";
+			return;
+		}
         Online::trySendScore(levelData->id, difficultyMult, time);
     }
 }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -233,7 +233,7 @@ void HexagonGame::checkAndSaveScore()
         return;
     }
 
-    if (levelStatus.3DRequired && !Config::get3D())
+    if (levelStatus._3DRequired && !Config::get3D())
     {
         ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
             << "Not saving score - 3D not enabled on a 3D Required level\n";

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -225,7 +225,7 @@ void HexagonGame::checkAndSaveScore()
     const float time = status.getTimeSeconds();
 
     // These are requirements that need to be met for a score to be valid
-    if(status.scoreInvalid || !Config::isEligibleForScore())
+    if(!Config::isEligibleForScore())
     {
         ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
             << "Not saving score - not eligible - "
@@ -233,10 +233,10 @@ void HexagonGame::checkAndSaveScore()
         return;
     }
 
-    if (levelStatus._3DRequired && !Config::get3D())
+    if (status.scoreInvalid)
     {
         ssvu::lo("hg::HexagonGame::checkAndSaveScore()")
-            << "Not saving score - 3D disabled on 3D Required level\n";
+            << "Not saving score - score invalidated\n";
     }
 
     if(assets.pIsLocal())
@@ -359,11 +359,14 @@ void HexagonGame::stopLevelMusic()
     }
 }
 
-void HexagonGame::invalidateScore()
+void HexagonGame::invalidateScore(std::string mReason)
 {
     status.scoreInvalid = true;
+    status.invalidReason = mReason;
     ssvu::lo("HexagonGame::invalidateScore")
-        << "Too much slowdown, invalidating official game\n";
+        << "Invalidating official game ("
+        << mReason
+        << ")\n";
 }
 
 auto HexagonGame::getColorMain() const -> sf::Color

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -631,6 +631,8 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
 
     mLua.writeVariable("l_getSides", [this] { return levelStatus.sides; });
 
+    mLua.writeVariable("l_set3dRequired", [this](bool mValue) { levelStatus._3DRequired = mValue; });
+
     mLua.writeVariable("s_setPulseInc",
         [this](float mValue) { styleData.pulseIncrement = mValue; });
 
@@ -650,7 +652,7 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "l_setBeatPulseDelayMax", "l_setWallSkewLeft", "l_setWallSkewRight",
             "l_setWallAngleLeft", "l_setWallAngleRight", "l_setRadiusMin",
             "l_setSwapEnabled", "l_setTutorialMode", "l_setIncEnabled",
-            "l_enableRndSideChanges", "l_darkenUnevenBackgroundChunk",
+            "l_get3dRequired", "l_enableRndSideChanges", "l_darkenUnevenBackgroundChunk",
             "l_getSpeedMult", "l_getDelayMult", "l_addTracked", "u_playSound",
             "u_isKeyPressed", "u_isMouseButtonPressed", "u_isFastSpinning",
             "u_setPlayerAngle", "u_forceIncrement", "u_kill", "u_eventKill",

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -224,18 +224,6 @@ bool isEligibleForScore()
         return false;
     }
 
-    if(Online::getServerVersion() == -1)
-    {
-        uneligibilityReason = "connection error";
-        return false;
-    }
-
-    if(Online::getServerVersion() > getVersion())
-    {
-        uneligibilityReason = "version mismatch";
-        return false;
-    }
-
     return true;
 }
 


### PR DESCRIPTION
Fixes #200 

Does pretty much it asks. Use l_set3dRequired(boolean) and l_get3dRequired. 
I also:
- Made the "Score Invalidated" display parameterized, which means that you can now add many more reasons to invalidate a score. 
- Fixed a major oversight in the game design and I heavily increased the standards for local scores to have the same standards online scores have. I have no idea why it was the case that the standards were so low for local scores, but now you can't just turn off official mode and get away with it.
- Added an experimental level to try out the 3D required yourself.