### PR TITLE
Feature/221 show difficulty multiplier on steam and discord

### DIFF
--- a/include/SSVOpenHexagon/Core/Discord.hpp
+++ b/include/SSVOpenHexagon/Core/Discord.hpp
@@ -32,7 +32,7 @@ public:
     bool run_callbacks();
 
     bool set_rich_presence_in_menu();
-    bool set_rich_presence_in_game(std::string str_status);
+    bool set_rich_presence_in_game(const std::string& str_status);
 };
 
 } // namespace hg::Discord

--- a/include/SSVOpenHexagon/Core/Discord.hpp
+++ b/include/SSVOpenHexagon/Core/Discord.hpp
@@ -32,7 +32,7 @@ public:
     bool run_callbacks();
 
     bool set_rich_presence_in_menu();
-    bool set_rich_presence_in_game(std::string_view level_name, float time);
+    bool set_rich_presence_in_game(std::string str_status);
 };
 
 } // namespace hg::Discord

--- a/include/SSVOpenHexagon/Core/Steam.hpp
+++ b/include/SSVOpenHexagon/Core/Steam.hpp
@@ -52,7 +52,8 @@ public:
     bool unlock_achievement(std::string_view name);
 
     bool set_rich_presence_in_menu();
-    bool set_rich_presence_in_game(std::string_view level_name, float time);
+    bool set_rich_presence_in_game(
+        std::string level_name_format, std::string difficulty_mult_format, std::string time_format);
 
     bool set_and_store_stat(std::string_view name, int data);
     [[nodiscard]] bool get_achievement(bool* out, std::string_view name);

--- a/include/SSVOpenHexagon/Core/Steam.hpp
+++ b/include/SSVOpenHexagon/Core/Steam.hpp
@@ -53,7 +53,7 @@ public:
 
     bool set_rich_presence_in_menu();
     bool set_rich_presence_in_game(
-        std::string level_name_format, std::string difficulty_mult_format, std::string time_format);
+        std::string_view level_name_format, std::string_view difficulty_mult_format, std::string_view time_format);
 
     bool set_and_store_stat(std::string_view name, int data);
     [[nodiscard]] bool get_achievement(bool* out, std::string_view name);

--- a/misc/richpresence.txt
+++ b/misc/richpresence.txt
@@ -4,7 +4,7 @@
     {
 	    "tokens"
 	    {
-	    	"#InGame"	"%levelname%: %time%s"
+	    	"#InGame"	"%levelname% [x%difficultymult%] - %time%s"
 	    	"#InMenu"	"In menu"
 	    }
     }

--- a/src/SSVOpenHexagon/Core/Discord.cpp
+++ b/src/SSVOpenHexagon/Core/Discord.cpp
@@ -101,17 +101,16 @@ bool discord_manager::set_rich_presence_in_menu()
     return true;
 }
 
-bool discord_manager::set_rich_presence_in_game(std::string str_status)
+bool discord_manager::set_rich_presence_in_game(const std::string &str_status)
 {
     if(!_initialized)
     {
         return false;
     }
 
-
     discord::Activity activity{};
     activity.SetState("In game");
-    activity.SetDetails(buf.data());
+    activity.SetDetails(str_status.data());
     _core->ActivityManager().UpdateActivity(activity, [](discord::Result r) {
         if(r != discord::Result::Ok)
         {

--- a/src/SSVOpenHexagon/Core/Discord.cpp
+++ b/src/SSVOpenHexagon/Core/Discord.cpp
@@ -6,6 +6,8 @@
 
 #include <SSVUtils/Core/Log/Log.hpp>
 
+#include <math.h>
+
 #include "discord/discord.h"
 
 namespace hg::Discord
@@ -99,8 +101,7 @@ bool discord_manager::set_rich_presence_in_menu()
     return true;
 }
 
-bool discord_manager::set_rich_presence_in_game(
-    std::string_view level_name, float time)
+bool discord_manager::set_rich_presence_in_game(std::string str_status)
 {
     if(!_initialized)
     {
@@ -109,7 +110,7 @@ bool discord_manager::set_rich_presence_in_game(
 
     static std::string buf;
     buf.clear();
-    buf = std::string(level_name) + " - " + std::to_string(time) + "s";
+    buf = str_status;
 
     discord::Activity activity{};
     activity.SetState("In game");

--- a/src/SSVOpenHexagon/Core/Discord.cpp
+++ b/src/SSVOpenHexagon/Core/Discord.cpp
@@ -108,9 +108,6 @@ bool discord_manager::set_rich_presence_in_game(std::string str_status)
         return false;
     }
 
-    static std::string buf;
-    buf.clear();
-    buf = str_status;
 
     discord::Activity activity{};
     activity.SetState("In game");

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -48,8 +48,8 @@ void HexagonGame::update(ssvu::FT mFT)
 
     std::string nameStr = levelData->name;
     nameFormat(nameStr);
-    std::string diffStr = diffFormat(difficultyMult);
-    std::string timeStr = timeFormat(status.getTimeSeconds());
+    const std::string diffStr = diffFormat(difficultyMult);
+    const std::string timeStr = timeFormat(status.getTimeSeconds());
 
     // Presence formatter
     std::string presenceStr = nameStr + " [x" + diffStr + "] - " + timeStr + "s";

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -25,14 +25,28 @@ void HexagonGame::update(ssvu::FT mFT)
 {
     mFT *= Config::getTimescale();
 
-    // TODO: refactor to avoid repetition, and truncate floating point number
-    // TODO: also show best record (here) and last run + best record (in menu)
-    steamManager.set_rich_presence_in_game(
-        levelData->name, status.getTimeSeconds());
+    // TODO: show best record (here) and last run + best record (in menu)
+
+    // Name formatter
+    std::string nameStr = std::string(levelData->name);
+    nameStr[0] = std::toupper(nameStr[0]);
+
+    // Difficulty multipler formatter
+    std::string diffStr = std::to_string(HexagonGame::difficultyMult);
+    size_t endPos = diffStr.find_last_not_of('0');
+    diffStr.erase(endPos + 1 + (int)(diffStr[endPos] == '.'), std::string::npos); // at least 1 dp
+
+    // Time formatter
+    std::string timeStr = std::to_string(floorf(status.getTimeSeconds() * 1000) / 1000); // 3 dp
+    timeStr.erase(timeStr.find_first_of('.') + 4, std::string::npos);
+
+    // Presence formatter
+    std::string presenceStr = nameStr + " [x" + diffStr + "] - " + timeStr + "s";
+
+    steamManager.set_rich_presence_in_game(nameStr, diffStr, timeStr);
     steamManager.run_callbacks();
 
-    discordManager.set_rich_presence_in_game(
-        levelData->name, status.getTimeSeconds());
+    discordManager.set_rich_presence_in_game(presenceStr);
     discordManager.run_callbacks();
 
     hg::Joystick::update();

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -32,7 +32,7 @@ void HexagonGame::update(ssvu::FT mFT)
     nameStr[0] = std::toupper(nameStr[0]);
 
     // Difficulty multipler formatter
-    std::string diffStr = std::to_string(HexagonGame::difficultyMult);
+    std::string diffStr = std::to_string(difficultyMult);
     size_t endPos = diffStr.find_last_not_of('0');
     diffStr.erase(endPos + 1 + (int)(diffStr[endPos] == '.'), std::string::npos); // at least 1 dp
 

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -21,19 +21,19 @@ using namespace hg::Utils;
 namespace hg
 {
 
-void nameFormat(std::string& name)
+static void nameFormat(std::string& name)
 {
     name[0] = std::toupper(name[0]);
 }
 
-[[nodiscard]] std::string diffFormat(float diff)
+[[nodiscard]] static std::string diffFormat(float diff)
 {
     char buf[255];
     std::snprintf(buf, sizeof(buf), "%g", diff);
     return buf;
 }
 
-[[nodiscard]] std::string timeFormat(float time)
+[[nodiscard]] static std::string timeFormat(float time)
 {
     char buf[255];
     std::snprintf(buf, sizeof(buf), "%.3f", time);

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -28,7 +28,7 @@ void HexagonGame::update(ssvu::FT mFT)
     // TODO: show best record (here) and last run + best record (in menu)
 
     // Name formatter
-    std::string nameStr = std::string(levelData->name);
+    std::string nameStr = levelData->name;
     nameStr[0] = std::toupper(nameStr[0]);
 
     // Difficulty multipler formatter

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -21,24 +21,35 @@ using namespace hg::Utils;
 namespace hg
 {
 
+void nameFormat(std::string& name)
+{
+    name[0] = std::toupper(name[0]);
+}
+
+[[nodiscard]] std::string diffFormat(float diff)
+{
+    char buf[255];
+    std::snprintf(buf, sizeof(buf), "%g", diff);
+    return buf;
+}
+
+[[nodiscard]] std::string timeFormat(float time)
+{
+    char buf[255];
+    std::snprintf(buf, sizeof(buf), "%.3f", time);
+    return buf;
+}
+
 void HexagonGame::update(ssvu::FT mFT)
 {
     mFT *= Config::getTimescale();
 
     // TODO: show best record (here) and last run + best record (in menu)
 
-    // Name formatter
     std::string nameStr = levelData->name;
-    nameStr[0] = std::toupper(nameStr[0]);
-
-    // Difficulty multipler formatter
-    std::string diffStr = std::to_string(difficultyMult);
-    size_t endPos = diffStr.find_last_not_of('0');
-    diffStr.erase(endPos + 1 + (int)(diffStr[endPos] == '.'), std::string::npos); // at least 1 dp
-
-    // Time formatter
-    std::string timeStr = std::to_string(std::floor(status.getTimeSeconds() * 1000) / 1000); // 3 dp
-    timeStr.erase(timeStr.find_first_of('.') + 4, std::string::npos);
+    nameFormat(nameStr);
+    std::string diffStr = diffFormat(difficultyMult);
+    std::string timeStr = timeFormat(status.getTimeSeconds());
 
     // Presence formatter
     std::string presenceStr = nameStr + " [x" + diffStr + "] - " + timeStr + "s";

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -37,7 +37,7 @@ void HexagonGame::update(ssvu::FT mFT)
     diffStr.erase(endPos + 1 + (int)(diffStr[endPos] == '.'), std::string::npos); // at least 1 dp
 
     // Time formatter
-    std::string timeStr = std::to_string(floorf(status.getTimeSeconds() * 1000) / 1000); // 3 dp
+    std::string timeStr = std::to_string(std::floor(status.getTimeSeconds() * 1000) / 1000); // 3 dp
     timeStr.erase(timeStr.find_first_of('.') + 4, std::string::npos);
 
     // Presence formatter

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -52,7 +52,7 @@ void HexagonGame::update(ssvu::FT mFT)
     const std::string timeStr = timeFormat(status.getTimeSeconds());
 
     // Presence formatter
-    std::string presenceStr = nameStr + " [x" + diffStr + "] - " + timeStr + "s";
+    const std::string presenceStr = nameStr + " [x" + diffStr + "] - " + timeStr + "s";
 
     steamManager.set_rich_presence_in_game(nameStr, diffStr, timeStr);
     steamManager.run_callbacks();

--- a/src/SSVOpenHexagon/Core/Steam.cpp
+++ b/src/SSVOpenHexagon/Core/Steam.cpp
@@ -196,16 +196,16 @@ bool steam_manager::set_rich_presence_in_menu()
 }
 
 bool steam_manager::set_rich_presence_in_game(
-    std::string_view level_name, float time)
+    std::string level_name_format, std::string difficulty_mult_format, std::string time_format)
 {
     if(!_initialized)
     {
         return false;
     }
 
-    return SteamFriends()->SetRichPresence("levelname", level_name.data()) &&
-           SteamFriends()->SetRichPresence(
-               "time", std::to_string(time).data()) &&
+    return SteamFriends()->SetRichPresence("levelname", level_name_format.data()) &&
+           SteamFriends()->SetRichPresence("difficulty", difficulty_mult_format.data()) &&
+           SteamFriends()->SetRichPresence("time", time_format.data()) &&
            SteamFriends()->SetRichPresence("steam_display", "#InGame");
 }
 

--- a/src/SSVOpenHexagon/Core/Steam.cpp
+++ b/src/SSVOpenHexagon/Core/Steam.cpp
@@ -196,7 +196,7 @@ bool steam_manager::set_rich_presence_in_menu()
 }
 
 bool steam_manager::set_rich_presence_in_game(
-    std::string level_name_format, std::string difficulty_mult_format, std::string time_format)
+    std::string_view level_name_format, std::string_view difficulty_mult_format, std::string_view time_format)
 {
     if(!_initialized)
     {

--- a/src/SSVOpenHexagon/Core/Steam.cpp
+++ b/src/SSVOpenHexagon/Core/Steam.cpp
@@ -204,7 +204,7 @@ bool steam_manager::set_rich_presence_in_game(
     }
 
     return SteamFriends()->SetRichPresence("levelname", level_name_format.data()) &&
-           SteamFriends()->SetRichPresence("difficulty", difficulty_mult_format.data()) &&
+           SteamFriends()->SetRichPresence("difficultymult", difficulty_mult_format.data()) &&
            SteamFriends()->SetRichPresence("time", time_format.data()) &&
            SteamFriends()->SetRichPresence("steam_display", "#InGame");
 }


### PR DESCRIPTION
Closes #221.

This enables the ability to show the current difficulty multiplier selected on Steam and Discord as so:
![image](https://user-images.githubusercontent.com/25865659/87861244-0e835280-c977-11ea-834b-f634853c66de.png)

Levels that do not have selectable difficulty multipliers will just display as [x1.0].

It doesn't update for Steam at the moment, but I think that is because it's using the `richpresence.txt` released on Steam, however the level name and time formatting is updated. **If this is meant to update locally as well then do let me know how this should be fixed!**