### PR TITLE
Make slight updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@
     *(or clone [SSVOpenHexagonAssets](https://github.com/SuperV1234/SSVOpenHexagonAssets))*
 
 
-## How to build on Debian distros
+## How to build on Debian Distributions
+(Tested on Ubuntu 20.04 LTS and Linux Mint 20 Cinnamon)
 
 0. Install dependencies
 
@@ -118,6 +119,8 @@
     ```
 
     Ensure you have the latest versions on all dependencies.
+    
+    **Tip:** If your distribution is not able to find ``libopengl-dev``, you can install two packages: ``libglm-dev`` and ``libglew-dev``. Install both of these and it should substitute for OpenGL.
     
 1. Clone this repository with submodules:
 


### PR DESCRIPTION
This PR makes slight updates to the README, as this was recently built on Linux Mint 20 successfully thanks to Alpha's new instructions. 

One of these changes adds a tip of how to substitute OpenGL, in case the distribution can't find the OpenGL library. Also, I added which Linux distributions were tested for additional information.