### PR TITLE
Bugfix/227 fix current time on steam not updating

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -59,7 +59,7 @@ public:
     CPlayer player;
     std::vector<CWall> walls;
     CCustomWallManager cwManager;
-    float timeUntilRichPresenceUpdate;
+    float timeUntilRichPresenceUpdate = 0.f;
 
 private:
     ssvs::Camera backgroundCamera{window,

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -59,6 +59,7 @@ public:
     CPlayer player;
     std::vector<CWall> walls;
     CCustomWallManager cwManager;
+    float timeUntilRichPresenceUpdate;
 
 private:
     ssvs::Camera backgroundCamera{window,

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -60,13 +60,12 @@ void HexagonGame::update(ssvu::FT mFT)
     if (timeUntilRichPresenceUpdate <= 0.f)
     {
         steamManager.set_rich_presence_in_game(nameStr, diffStr, timeStr);
-        steamManager.run_callbacks();
-
         discordManager.set_rich_presence_in_game(presenceStr);
-        discordManager.run_callbacks();
-
         timeUntilRichPresenceUpdate = DELAY_TO_UPDATE;
     }
+
+    steamManager.run_callbacks();
+    discordManager.run_callbacks();
 
     hg::Joystick::update();
 

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -51,15 +51,22 @@ void HexagonGame::update(ssvu::FT mFT)
     const std::string diffStr = diffFormat(difficultyMult);
     const std::string timeStr = timeFormat(status.getTimeSeconds());
 
+    constexpr float DELAY_TO_UPDATE = 5.f; // X seconds
+    timeUntilRichPresenceUpdate -= ssvu::getFTToSeconds(mFT);
+
     // Presence formatter
-    const std::string presenceStr =
-        nameStr + " [x" + diffStr + "] - " + timeStr + "s";
+    const std::string presenceStr = nameStr + " [x" + diffStr + "] - " + timeStr + "s";
 
-    steamManager.set_rich_presence_in_game(nameStr, diffStr, timeStr);
-    steamManager.run_callbacks();
+    if (timeUntilRichPresenceUpdate <= 0.f)
+    {
+        steamManager.set_rich_presence_in_game(nameStr, diffStr, timeStr);
+        steamManager.run_callbacks();
 
-    discordManager.set_rich_presence_in_game(presenceStr);
-    discordManager.run_callbacks();
+        discordManager.set_rich_presence_in_game(presenceStr);
+        discordManager.run_callbacks();
+
+        timeUntilRichPresenceUpdate = DELAY_TO_UPDATE;
+    }
 
     hg::Joystick::update();
 

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -243,6 +243,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
     // Set initial values for some status fields from Lua
     status.beatPulseDelay += levelStatus.beatPulseInitialDelay;
+    timeUntilRichPresenceUpdate = -1.f; // immediate update
 }
 
 void HexagonGame::death(bool mForce)


### PR DESCRIPTION
Closes #227.

This fixes the current time on Steam not updating by adding an X second timer between the next call to the Steam API, where the value of X can be changed in the code.

The reason for the timer not updating on Steam is because the game is sending requests to the Steam API every frame, which is way too quick.

~~**_This PR should only be merged when #221 gets merged and when I resolve merge conflicts here, but I still want to get an approval for the time being!_**~~