### PR TITLE
Add CI builds for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+# Trigger this workflow on push or pull request
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build (ubuntu-20.04)
+
+    runs-on: ubuntu-20.04
+
+    env:
+      CXXFLAGS: -I/usr/local/include/SFML -std=c++2a
+      LDFLAGS: -L/usr/local/lib
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build libsfml-dev libx11-dev libxrandr-dev libudev-dev libopenal-dev libvorbis-dev libflac-dev
+
+    - name: CMake configure
+      run: |
+        cd build
+        cmake -GNinja ..
+    - name: Build
+      run: ninja -C build
+
+    - name: Copy artifacts
+      run: cp build/SSVOpenHexagon build/OHWorkshopUploader _RELEASE
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: OpenHexagon-Linux
+        path: _RELEASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: CMake configure
       run: |
         cd build
-        cmake -GNinja ..
+        cmake -GNinja -DCMAKE_BUILD_TYPE=RELEASE ..
     - name: Build
       run: ninja -C build
 


### PR DESCRIPTION
This PR adds automatic CI builds for Linux. Every time a push or pull request is made, GitHub Actions will spin up an Ubuntu container that automatically checks out the repository, downloads dependencies, builds the game, and uploads the result. Anyone with a GitHub account can go to the Actions page, click the latest run, and download said build.

These CI builds serve two purposes: (1) to check that changes made to the codebase will compile correctly, and (2) to provide convenient builds so players don't have to clone and compile the game for themselves. (However, it's still a bit annoying, because you have to make a GitHub account and log in, but it's better than nothing.)

I would have liked to add CI builds for Windows and macOS, but every approach I tried for either of those two operating systems failed to work. I have spent countless hours attempting to get Windows builds working, but every attempt I just ran into annoying roadblocks that weren't easy to get around. The problem seems to be the fact that Open Hexagon uses so much new and exotic C++20 constructs, which requires GCC 9 or later, and which the corresponding MinGW 9 or later is hard to obtain. Not helping the case is that MSVC is simply not supported by Open Hexagon, so I can't go down that route either. And as for macOS, well, #150 has already been filed, and it seems to me that Open Hexagon depends on X11/XRandR stuff, which is hard to support on macOS.