### PR TITLE
Allow styles to support negative values for the `"Pulse" field

### DIFF
--- a/_RELEASE/Packs/experimental/Levels/negative_pulse.json
+++ b/_RELEASE/Packs/experimental/Levels/negative_pulse.json
@@ -1,0 +1,12 @@
+{
+	"id": "negative_pulse",
+	"name": "Negative Pulse",
+	"description": "Another test for negative pulses on styles",
+	"author": "Morxemplum",
+	"menuPriority": 30,
+	"selectable": true,
+	"styleId": "negative_pulse_style",
+	"musicId": "jackRussel",
+	"luaFile": "Scripts/Levels/negative_pulse.lua",
+	"difficultyMults": []
+}

--- a/_RELEASE/Packs/experimental/Scripts/Levels/negative_pulse.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/negative_pulse.lua
@@ -1,0 +1,88 @@
+-- include useful files
+u_execScript("utils.lua")
+u_execScript("common.lua")
+u_execScript("commonpatterns.lua")
+
+-- this function adds a pattern to the timeline based on a key
+function addPattern(mKey)
+		if mKey ==  0 then pAltBarrage(math.random(2, 4), 2)
+	elseif mKey ==  1 then pMirrorSpiral(math.random(3, 6), 0)
+	elseif mKey ==  2 then pBarrageSpiral(math.random(0, 3), 1, 1)
+	elseif mKey ==  3 then pBarrageSpiral(math.random(0, 2), 1.2, 2)
+	elseif mKey ==  4 then pBarrageSpiral(2, 0.7, 1)
+	elseif mKey ==  5 then pInverseBarrage(0)
+	elseif mKey ==  6 then pTunnel(math.random(1, 3))
+	elseif mKey ==  7 then pMirrorWallStrip(1, 0)
+	elseif mKey ==  8 then 
+		if l_getSides() > 5 then
+			pWallExVortex(0, 1, 1)
+		end
+	elseif mKey ==  9 then pDMBarrageSpiral(math.random(4, 7), 0.4, 1)
+	elseif mKey == 10 then pRandomBarrage(math.random(2, 4), 2.25)
+	end
+end
+
+-- shuffle the keys, and then call them to add all the patterns
+-- shuffling is better than randomizing - it guarantees all the patterns will be called
+keys = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 7, 7, 8, 9, 10, 10, 10 }
+keys = shuffle(keys)
+index = 0
+
+-- onInit is an hardcoded function that is called when the level is first loaded
+function onInit()
+	l_setSpeedMult(2.65)
+	l_setSpeedInc(0.1)
+	--l_setSpeedMax(3.4)
+	l_setRotationSpeed(0.2)
+	l_setRotationSpeedMax(1)
+	l_setRotationSpeedInc(0.05)
+	l_setDelayMult(1.1)
+	l_setDelayInc(0.005)
+	--l_setDelayMin(1.05)
+	l_setFastSpin(70.0)
+	l_setSides(6)
+	l_setSidesMin(5)
+	l_setSidesMax(7)
+	l_setIncTime(15)
+
+	l_setPulseMin(70)
+	l_setPulseMax(90)
+	l_setPulseSpeed(1.0)
+	l_setPulseSpeedR(0.6)
+	l_setPulseDelayMax(0)
+
+	l_setBeatPulseMax(17)
+	l_setBeatPulseDelayMax(23.8)
+	l_setDarkenUnevenBackgroundChunk(false);
+
+	enableSwapIfDMGreaterThan(1.4)
+	disableIncIfDMGreaterThan(1.4)
+end
+
+-- onLoad is an hardcoded function that is called when the level is started/restarted
+function onLoad()
+end
+
+-- onStep is an hardcoded function that is called when the level timeline is empty
+-- onStep should contain your pattern spawning logic
+function onStep()
+	addPattern(keys[index])
+	index = index + 1
+
+	if index - 1 == #keys then
+		index = 1
+		keys = shuffle(keys)
+	end
+end
+
+-- onIncrement is an hardcoded function that is called when the level difficulty is incremented
+function onIncrement()
+end
+
+-- onUnload is an hardcoded function that is called when the level is closed/restarted
+function onUnload()
+end
+
+-- onUpdate is an hardcoded function that is called every frame
+function onUpdate(mFrameTime)
+end

--- a/_RELEASE/Packs/experimental/Styles/negative_pulse.json
+++ b/_RELEASE/Packs/experimental/Styles/negative_pulse.json
@@ -1,0 +1,34 @@
+{
+	// Style data id
+	"id": "negative_pulse_style",
+
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": true,
+	"hue_increment": 1.0,
+
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1,
+	"pulse_increment": 0.025,
+
+	// 3D options
+	"3D_depth": 7,
+	"3D_skew": 0.15,
+	"3D_spacing": 1.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 0.5,
+	"3D_alpha_falloff": 19.0,
+
+	// Main color
+	"main": { "main": true, "dynamic": false, "value": [0, 0, 255, 255], "pulse": [25, 25, 0, 0] },
+	"cap_color": "main_darkened",
+
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [0, 255, 0, 255], "pulse": [255, -255, 255, 0]},
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [0, 255, 0, 255], "pulse": [255, -255, 255, 0]}
+	]
+}

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -15,11 +15,6 @@ struct PulseColor {
     int g;
     int b;
     int a;
-
-    PulseColor() = default;
-
-    PulseColor(const int red, const int green, const int blue, const int alpha)
-        : r{red}, g{green}, b{blue}, a{alpha} {};
 };
 
 namespace hg 

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -44,7 +44,7 @@ struct ColorData
 
     ColorData(const bool mMain, const bool mDynamic, const bool mDynamicOffset,
         const float mDynamicDarkness, const float mHueShift,
-        const float mOffset, sf::Color mColor, PulseColor mPulse)
+        const float mOffset, sf::Color mColor, const PulseColor& mPulse)
         : main{mMain}, dynamic{mDynamic}, dynamicOffset{mDynamicOffset},
           dynamicDarkness{mDynamicDarkness}, hueShift{mHueShift},
           offset{mOffset}, color{mColor}, pulse{mPulse}

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -9,11 +9,30 @@
 
 #include <SFML/Graphics/Color.hpp>
 
+
+struct PulseColor {
+    int r;
+    int g;
+    int b;
+    int a;
+
+    PulseColor() = default;
+
+    PulseColor(const int red, const int green, const int blue, const int alpha)
+        : r{red}, g{green}, b{blue}, a{alpha} {};
+};
+
+namespace hg 
+{
+	[[nodiscard]] PulseColor pulse_from_json(const ssvuj::Obj& root) noexcept;
+}
+
 struct ColorData
 {
     bool main, dynamic, dynamicOffset;
     float dynamicDarkness, hueShift, offset;
-    sf::Color color, pulse;
+    sf::Color color; 
+    PulseColor pulse;
 
     ColorData() = default;
 
@@ -26,11 +45,11 @@ struct ColorData
           hueShift{ssvuj::getExtr<float>(mRoot, "hue_shift", 0.f)},
           offset{ssvuj::getExtr<float>(mRoot, "offset", 0.f)},
           color{ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::White)},
-          pulse{ssvuj::getExtr<sf::Color>(mRoot, "pulse", sf::Color::White)} {};
+          pulse{hg::pulse_from_json(mRoot)} {};
 
     ColorData(const bool mMain, const bool mDynamic, const bool mDynamicOffset,
         const float mDynamicDarkness, const float mHueShift,
-        const float mOffset, sf::Color mColor, sf::Color mPulse)
+        const float mOffset, sf::Color mColor, PulseColor mPulse)
         : main{mMain}, dynamic{mDynamic}, dynamicOffset{mDynamicOffset},
           dynamicDarkness{mDynamicDarkness}, hueShift{mHueShift},
           offset{mOffset}, color{mColor}, pulse{mPulse}

--- a/src/SSVOpenHexagon/Data/CapColor.cpp
+++ b/src/SSVOpenHexagon/Data/CapColor.cpp
@@ -3,6 +3,7 @@
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
 #include "SSVOpenHexagon/Data/CapColor.hpp"
+#include "SSVOpenHexagon/Data/ColorData.hpp"
 
 #include "SSVOpenHexagon/SSVUtilsJson/SSVUtilsJson.hpp"
 
@@ -44,7 +45,7 @@ namespace hg
                 ssvuj::getExtr<float>(obj, "hue_shift", 0.f),
                 ssvuj::getExtr<float>(obj, "offset", 0.f),
                 ssvuj::getExtr<sf::Color>(obj, "value", sf::Color::White),
-                ssvuj::getExtr<sf::Color>(obj, "pulse", sf::Color::White)};
+                hg::pulse_from_json(obj)};
         }
     }
 

--- a/src/SSVOpenHexagon/Data/ColorData.cpp
+++ b/src/SSVOpenHexagon/Data/ColorData.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2013-2020 Vittorio Romeo
+// License: Academic Free License ("AFL") v. 3.0
+// AFL License page: http://opensource.org/licenses/AFL-3.0
+
+#include "SSVOpenHexagon/Data/ColorData.hpp"
+
+#include "SSVOpenHexagon/SSVUtilsJson/SSVUtilsJson.hpp"
+
+#include <string>
+
+namespace hg 
+{
+	[[nodiscard]] PulseColor pulse_from_json(const ssvuj::Obj& root) noexcept
+	{
+		std::vector<int> rawPulseData = ssvuj::getExtr<std::vector<int>>(root, "pulse", {0, 0, 0, 255});
+		if (rawPulseData.size() == 4)
+		{
+			return {rawPulseData[0], rawPulseData[1], rawPulseData[2], rawPulseData[3]};
+		}
+		return {0, 0, 0, 255};
+	}
+}

--- a/src/SSVOpenHexagon/Data/ColorData.cpp
+++ b/src/SSVOpenHexagon/Data/ColorData.cpp
@@ -12,11 +12,18 @@ namespace hg
 {
 	[[nodiscard]] PulseColor pulse_from_json(const ssvuj::Obj& root) noexcept
 	{
-		std::vector<int> rawPulseData = ssvuj::getExtr<std::vector<int>>(root, "pulse", {0, 0, 0, 255});
-		if (rawPulseData.size() == 4)
-		{
-			return {rawPulseData[0], rawPulseData[1], rawPulseData[2], rawPulseData[3]};
-		}
-		return {0, 0, 0, 255};
+        if(!ssvuj::hasObj(root, "pulse"))
+        {
+             return {0, 0, 0, 255};
+        }
+        
+        const auto& pulseObj = ssvuj::getObj(root, "pulse");
+
+        return {
+            ssvuj::getExtr<int>(pulseObj, 0),
+            ssvuj::getExtr<int>(pulseObj, 1),
+            ssvuj::getExtr<int>(pulseObj, 2),
+            ssvuj::getExtr<int>(pulseObj, 3)
+        };
 	}
 }


### PR DESCRIPTION
Closes #241.

Had to make my own struct and all that to accomplish this. I wouldn't have been able to do this without a bit of help from @SuperV1234  and @MultHub, because I was struggling to figure out how the JSON Parser worked when parsing arrays. 

Hopefully people can now make all new types of styles with this restriction removed.