### PR TITLE
Add unit tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build (ubuntu-20.04)
+    name: Build and test (ubuntu-20.04)
 
     runs-on: ubuntu-20.04
 
@@ -45,3 +45,6 @@ jobs:
       with:
         name: OpenHexagon-Linux
         path: _RELEASE
+
+    - name: Run tests
+      run: ninja -C build check


### PR DESCRIPTION
Now, every time the CI builds the game, tests will be run afterwards. I put the tests last so the tests failing won't mean artifacts won't be uploaded.

Closes #202.