### PR TITLE
Update build instructions on Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 1. Clone this repository with submodules:
 
     ```bash
-    git clone --recurse-submodules git://github.com/SuperV1234/SSVOpenHexagon.git
+    git clone --recurse-submodules --remote-submodules git://github.com/SuperV1234/SSVOpenHexagon.git
     cd SSVOpenHexagon
     ```
 
@@ -125,7 +125,7 @@
 1. Clone this repository with submodules:
 
     ```bash
-    git clone --recurse-submodules git://github.com/SuperV1234/SSVOpenHexagon.git
+    git clone --recurse-submodules --remote-submodules git://github.com/SuperV1234/SSVOpenHexagon.git
     cd SSVOpenHexagon
     ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@
 6. (Optional) Download assets:
 
     ```bash
-    # (from repository root)
     ./wget-assets.sh ./_RELEASE/
     ```
 
@@ -65,51 +64,39 @@
     **Note:** If this file is producing errors, make sure the file is using UNIX line endings and not Windows Line Endings. Bash recognizes files primarily with UNIX Line Endings.
 
 ## How to build on Arch Linux
+(Tested on Manjaro 20.0.3)
 
 0. Install dependencies
 
     ```bash
     sudo pacman -S git make cmake gcc sfml
     ```
-
+    
 1. Clone this repository with submodules:
 
     ```bash
-    git clone --recurse-submodules --remote-submodules git://github.com/SuperV1234/SSVOpenHexagon.git
+    git clone --recurse-submodules git://github.com/SuperV1234/SSVOpenHexagon.git
     cd SSVOpenHexagon
     ```
 
-2. Create a build directory and `cd` into it:
+2. Execute the build script:
 
     ```bash
-    mkdir build
-    cd build
+    ./build.sh
     ```
 
-3. Run CMake and build:
+    List of arguments:
+    - ```-r, --run```: Run the game after build completion.
+    - ```-d, --debug```: Runs and debugs the game after build completion.
+    - ```-v, --valgrind```: Valgrinds the game after build completion.
+    - ```-g, --regenerate-cmake```: Regenerates CMake files in build folder to match current OS. This is automatic, but can be done manually if needed.
+    - ```-jN```: Executes the `make` command using N threads. Default is 4.
+    - ```-h, --help```: Displays this help.
+
+
+3. (Optional) Download assets:
 
     ```bash
-    cmake ..
-    make -j
-    ```
-
-4. Install to `_RELEASE` folder and copy dependencies:
-
-    ```bash
-    sudo make install
-    ```
-
-5. Run the game:
-
-    ```bash
-    cd ../_RELEASE
-    ./SSVOpenHexagon
-    ```
-
-6. (Optional) Download assets:
-
-    ```bash
-    # (from repository root)
     ./wget-assets.sh ./_RELEASE/
     ```
 
@@ -160,7 +147,6 @@
 3. (Optional) Download assets:
 
     ```bash
-    # (from repository root)
     ./wget-assets.sh ./_RELEASE/
     ```
 


### PR DESCRIPTION
I have not been following this project for a while, and hot damn! So many changes have been made! I saw that there's now a build script and the Arch build instructions didn't reflect that, so I rewrote that part. Tested it on my machine and builds flawlessly on Manjaro 20.0.3.

Also, congrats on the Steam launch! I might buy it when I can to support this project.