### PR TITLE
Add u_playPackSound to simplify playing sounds

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -448,7 +448,12 @@ public:
         return cwManager.anyCustomWall(std::forward<F>(f));
     }
 
+    // Pack information
     [[nodiscard]] const std::string& getPackId() const;
+    [[nodiscard]] std::string getPackDisambiguator() const;
+    [[nodiscard]] std::string getPackAuthor() const;
+    [[nodiscard]] std::string getPackName() const;
+    [[nodiscard]] int getPackVersion() const;
 
     [[nodiscard]] bool mustReplayInput() const noexcept;
     [[nodiscard]] bool mustShowReplayUI() const noexcept;

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -70,6 +70,15 @@ void HexagonGame::initLua_Utils()
             "Play the sound with id `$0`. The id must be registered in "
             "`assets.json`, under `\"soundBuffers\"`.");
 
+    addLuaFn("u_playPackSound", //
+        [this](std::string fileName) {
+            assets.playPackSound(getPackId(), fileName);
+        })
+        .arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "plays the specified file `$0`.");
+
     addLuaFn("u_setMusic", //
         [this](std::string mId) {
             musicData = assets.getMusicData(levelData->packId, mId);

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -489,6 +489,26 @@ void HexagonGame::setLevelData(
     return levelData->packId;
 }
 
+[[nodiscard]] std::string HexagonGame::getPackDisambiguator() const
+{
+    return assets.getPackData(getPackId()).disambiguator;
+}
+
+[[nodiscard]] std::string HexagonGame::getPackAuthor() const
+{
+    return assets.getPackData(getPackId()).author;
+}
+
+[[nodiscard]] std::string HexagonGame::getPackName() const
+{
+    return assets.getPackData(getPackId()).name;
+}
+
+[[nodiscard]] int HexagonGame::getPackVersion() const
+{
+    return assets.getPackData(getPackId()).version;
+}
+
 void HexagonGame::playLevelMusic()
 {
     if(!Config::getNoMusic())


### PR DESCRIPTION
Closes #245.

Instead of making improvements on u_playSound I decided to make a separate function called u_playPackSound in case people want to still be able to play programmer assets.