### PR TITLE
Add silent message function to menu Lua

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -714,7 +714,8 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "u_clearWalls", "u_setMusic", "u_setMusicSegment",
             "u_setMusicSeconds",
 
-            "m_messageAdd", "m_messageAddImportant", "m_clearMessages",
+            "m_messageAdd", "m_messageAddImportant", "m_messageAddImportantSilent",
+            "m_clearMessages",
 
             "t_wait", "t_waitS", "t_waitUntilS",
 


### PR DESCRIPTION
Turns out that adding silent messages was not added to the menu Lua, which means that the menu would error whenever the function was present. This is just a very simple addition that fixes this bug.