### PR TITLE
Improve Styles by Patching Hue Clamping and Adding Player Color and Text Color Overrides

### DIFF
--- a/_RELEASE/Packs/experimental/Styles/negative_pulse.json
+++ b/_RELEASE/Packs/experimental/Styles/negative_pulse.json
@@ -24,6 +24,8 @@
 	// Main color
 	"main": { "main": true, "dynamic": false, "value": [0, 0, 255, 255], "pulse": [25, 25, 0, 0] },
 	"cap_color": "main_darkened",
+	"player_color": {"dynamic": false, "value": [255, 0, 0, 255], "pulse": [0, 80, 0, 0] },
+	"text_color": {"dynamic": false, "value": [255, 255, 0, 255], "pulse": [0, -100, 0, 0] },
 
 	// Background colors
 	"colors":

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -436,6 +436,8 @@ public:
     }
 
     [[nodiscard]] sf::Color getColorMain() const;
+    [[nodiscard]] sf::Color getColorPlayer() const;
+    [[nodiscard]] sf::Color getColorText() const;
 
     [[nodiscard]] float getMusicDMSyncFactor() const
     {

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -174,7 +174,7 @@ private:
     {
         return (state != States::SMain || Config::getBlackAndWhite())
                    ? sf::Color::White
-                   : styleData.getMainColor();
+                   : styleData.getTextColor();
     }
 
     sf::Text& renderText(

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -21,7 +21,8 @@ class StyleData
 private:
     float currentHue, currentSwapTime{0}, pulseFactor{0};
     ssvufs::Path rootPath;
-    sf::Color currentMainColor, current3DOverrideColor;
+    sf::Color currentMainColor, currentPlayerColor, currentTextColor,
+        current3DOverrideColor;
     std::vector<sf::Color> currentColors;
 
     sf::Color calculateColor(const ColorData& mColorData) const;
@@ -31,11 +32,13 @@ public:
     float hueMin;
     float hueMax;
     float hueIncrement;
+    bool huePingPong;
+
     float pulseMin;
     float pulseMax;
     float pulseIncrement;
-    bool huePingPong;
     float maxSwapTime;
+
     float _3dDepth;
     float _3dSkew;
     float _3dSpacing;
@@ -46,12 +49,16 @@ public:
     float _3dPulseMin;
     float _3dPulseSpeed;
     float _3dPerspectiveMult;
+
     float bgTileRadius{10000.f};
     unsigned int BGColorOffset{0};
     float BGRotOff{0}; // In degrees
 
     sf::Color _3dOverrideColor;
     ColorData mainColorData;
+    ColorData playerColor;
+    ColorData textColor;
+
     CapColor capColor;
 
     std::vector<ColorData> colorDatas;
@@ -63,11 +70,13 @@ public:
           hueMin{ssvuj::getExtr<float>(mRoot, "hue_min", 0.f)},
           hueMax{ssvuj::getExtr<float>(mRoot, "hue_max", 360.f)},
           hueIncrement{ssvuj::getExtr<float>(mRoot, "hue_increment", 0.f)},
+          huePingPong{ssvuj::getExtr<bool>(mRoot, "hue_ping_pong", false)},
+
           pulseMin{ssvuj::getExtr<float>(mRoot, "pulse_min", 0.f)},
           pulseMax{ssvuj::getExtr<float>(mRoot, "pulse_max", 0.f)},
           pulseIncrement{ssvuj::getExtr<float>(mRoot, "pulse_increment", 0.f)},
-          huePingPong{ssvuj::getExtr<bool>(mRoot, "hue_ping_pong", false)},
           maxSwapTime{ssvuj::getExtr<float>(mRoot, "max_swap_time", 100.f)},
+
           _3dDepth{ssvuj::getExtr<float>(mRoot, "3D_depth", 15.f)},
           _3dSkew{ssvuj::getExtr<float>(mRoot, "3D_skew", 0.18f)},
           _3dSpacing{ssvuj::getExtr<float>(mRoot, "3D_spacing", 1.f)},
@@ -84,10 +93,33 @@ public:
               ssvuj::getExtr<float>(mRoot, "3D_perspective_multiplier", 1.f)},
           _3dOverrideColor{ssvuj::getExtr<sf::Color>(
               mRoot, "3D_override_color", sf::Color::Transparent)},
+
           mainColorData{ssvuj::getObj(mRoot, "main")}, //
           capColor{parseCapColor(ssvuj::getObj(mRoot, "cap_color"))}
     {
         currentHue = hueMin;
+
+        // Player color is defined with an override property, otherwise it
+        // defaults to the main color
+        if(ssvuj::hasObj(mRoot, "player_color"))
+        {
+            playerColor = ssvuj::getObj(mRoot, "player_color");
+        }
+        else
+        {
+            playerColor = mainColorData;
+        }
+        
+        // Text color is defined with an override property, otherwise it
+        // defaults to the main color
+        if(ssvuj::hasObj(mRoot, "text_color"))
+        {
+            textColor = ssvuj::getObj(mRoot, "text_color");
+        }
+        else
+        {
+            textColor = mainColorData;
+        }
 
         const auto& objColors(ssvuj::getObj(mRoot, "colors"));
         const auto& colorCount(ssvuj::getObjSize(objColors));
@@ -116,6 +148,16 @@ public:
     const sf::Color& getMainColor() const noexcept
     {
         return currentMainColor;
+    }
+
+    const sf::Color& getPlayerColor() const noexcept
+    {
+        return currentPlayerColor;
+    }
+
+    const sf::Color& getTextColor() const noexcept
+    {
+        return currentTextColor;
     }
 
     const std::vector<sf::Color>& getColors() const noexcept

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -52,7 +52,7 @@ void CPlayer::draw(HexagonGame& mHexagonGame, const sf::Color& mCapColor)
         drawDeathEffect(mHexagonGame);
     }
 
-    sf::Color colorMain{!dead ? mHexagonGame.getColorMain()
+    sf::Color colorMain{!dead ? mHexagonGame.getColorPlayer()
                               : ssvs::getColorFromHSV(hue / 360.f, 1.f, 1.f)};
 
     const float triangleWidth = mHexagonGame.getInputFocused() ? -1.5f : 3.f;

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -128,6 +128,15 @@ void HexagonGame::draw()
                 wallQuads3D[k].color = status.overrideColor;
             }
 
+            // Apply player color if no 3D override is present.
+			if (styleData.get3DOverrideColor() == styleData.getMainColor())
+			{
+				status.overrideColor = getColorDarkened(
+                styleData.getPlayerColor(), styleData._3dDarkenMult);
+				status.overrideColor.a /= styleData._3dAlphaMult;
+				status.overrideColor.a -= i * styleData._3dAlphaFalloff;
+			}
+
             for(std::size_t k = j * numPlayerTris; k < (j + 1) * numPlayerTris;
                 ++k)
             {

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -182,7 +182,7 @@ void HexagonGame::drawKeyIcons()
     constexpr sf::Uint8 offOpacity = 90;
     constexpr sf::Uint8 onOpacity = 255;
 
-    const sf::Color c = getColorMain();
+    const sf::Color c = getColorText();
 
     const sf::Color offColor{c.r, c.g, c.b, offOpacity};
     const sf::Color onColor{c.r, c.g, c.b, onOpacity};
@@ -364,18 +364,18 @@ void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor)
     const float padding = Config::getTextPadding() * Config::getTextScaling();
     const float offsetRatio = Config::getHeight() / 720.f;
 
-    timeText.setFillColor(getColorMain());
+    timeText.setFillColor(getColorText());
     timeText.setPosition(
         sf::Vector2f{padding, -22.f * offsetRatio * Config::getTextScaling()});
     render(timeText);
 
-    text.setFillColor(getColorMain());
+    text.setFillColor(getColorText());
     text.setPosition(sf::Vector2f{padding, ssvs::getGlobalBottom(timeText)});
     render(text);
 
     if(Config::getShowFPS())
     {
-        fpsText.setFillColor(getColorMain());
+        fpsText.setFillColor(getColorText());
         fpsText.setOrigin(0, ssvs::getGlobalHeight(fpsText));
         fpsText.setPosition(sf::Vector2f{
             padding, Config::getHeight() - ((8.f * (2.f * offsetRatio))) *
@@ -389,7 +389,7 @@ void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor)
             Config::getKeyIconsScale() / Config::getZoomFactor();
         const float replayPadding = 8.f * scaling;
 
-        replayText.setFillColor(getColorMain());
+        replayText.setFillColor(getColorText());
         replayText.setOrigin(ssvs::getLocalCenterE(replayText));
         replayText.setPosition(ssvs::getGlobalCenterW(replayIcon) -
                                sf::Vector2f{replayPadding, 0});
@@ -416,7 +416,7 @@ void HexagonGame::drawText_Message(const sf::Color& offsetColor)
 
     messageText.setPosition(
         sf::Vector2f{Config::getWidth() / 2.f, Config::getHeight() / 6.f});
-    messageText.setFillColor(getColorMain());
+    messageText.setFillColor(getColorText());
     render(messageText);
 }
 

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -558,6 +558,28 @@ auto HexagonGame::getColorMain() const -> sf::Color
     }
 }
 
+auto HexagonGame::getColorPlayer() const -> sf::Color
+{
+    if(Config::getBlackAndWhite())
+    {
+        return sf::Color(255, 255, 255, styleData.getPlayerColor().a);
+    }
+    {
+        return styleData.getPlayerColor();
+    }
+}
+
+auto HexagonGame::getColorText() const -> sf::Color
+{
+    if(Config::getBlackAndWhite())
+    {
+        return sf::Color(255, 255, 255, styleData.getTextColor().a);
+    }
+    {
+        return styleData.getTextColor();
+    }
+}
+
 void HexagonGame::setSides(unsigned int mSides)
 {
     assets.playSound("beep.ogg");

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1346,7 +1346,7 @@ void MenuGame::drawLevelSelection()
     txtPacks.setString(packNames);
     txtPacks.setOrigin(getGlobalWidth(txtPacks), getGlobalHeight(txtPacks));
     txtPacks.setPosition({w - 20.f, getGlobalTop(bottomBar) - 15.f});
-    txtPacks.setFillColor(styleData.getMainColor());
+    txtPacks.setFillColor(styleData.getTextColor());
     render(txtPacks);
 }
 void MenuGame::drawEnteringText()

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -115,6 +115,8 @@ void StyleData::update(ssvu::FT mFT, float mMult)
 void StyleData::computeColors(const LevelStatus& levelStatus)
 {
     currentMainColor = calculateColor(mainColorData);
+    currentPlayerColor = calculateColor(playerColor);
+    currentTextColor = calculateColor(textColor);
 
     current3DOverrideColor =
         _3dOverrideColor.a != 0 ? _3dOverrideColor : getMainColor();

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -23,7 +23,7 @@ sf::Color StyleData::calculateColor(const ColorData& mColorData) const
 
     if(mColorData.dynamic)
     {
-        const auto hue = (currentHue + mColorData.hueShift) / 360.f;
+        const auto hue = std::fmod(currentHue + mColorData.hueShift, 360.f) / 360.f;
 
         const auto& dynamicColor(
             ssvs::getColorFromHSV(ssvu::getClamped(hue, 0.f, 1.f), 1.f, 1.f));


### PR DESCRIPTION
Fixes #259 and partially solves #260. The only thing about 260 that isn't solved is the swap color. I took a look at how color works for swapping and the logic works much differently than your traditional color logic. It will take some time for me to think of how I'll be able to get swap color to be customizable (while at the same time, making sure that players can identify that a swap color means that they can swap, so pack devs can't just be dicks). 

In the meantime, I've decided to make the improvements to the styles so dynamic colors should no longer get stuck on pink/magenta when they surpass 360, along with being able to customize player and text by giving them their own color properties. They can now function as their own ColorDatas that pack developers can tweak and modify. However, if these two overrides are not defined, then they will resort to the main color field to keep compatibility. 

You can test this all out by going to the "Negative Pulse" level in the experimental pack, which has been updated to demonstrate both of these overrides.