### PR TITLE
Add Collision Test Level for Side Collision Testing

### DIFF
--- a/_RELEASE/Packs/experimental/Levels/collision_test.json
+++ b/_RELEASE/Packs/experimental/Levels/collision_test.json
@@ -1,0 +1,12 @@
+{
+	"id": "collisiontest",
+	"name": "Collision Test",
+	"description": "Side collision testing on ordinary walls",
+	"author": "Morxemplum",
+	"menuPriority": 12,
+	"selectable": true,
+	"styleId": "wall_ref",
+	"musicId": "jackRussel",
+	"luaFile": "Scripts/Levels/collision_test.lua",
+	"difficultyMults": [1.6, 2.2, 2.8, 0.6, 0.4]
+}

--- a/_RELEASE/Packs/experimental/Scripts/Levels/collision_test.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/collision_test.lua
@@ -1,0 +1,63 @@
+-- include useful files
+u_execScript("utils.lua")
+u_execScript("common.lua")
+u_execScript("commonpatterns.lua")
+u_execScript("nextpatterns.lua")
+u_execScript("evolutionpatterns.lua")
+
+-- onInit is an hardcoded function that is called when the level is first loaded
+function onInit()
+	l_setSpeedMult(5.0)
+	l_setSpeedInc(0.0)
+	l_setRotationSpeed(0.0)
+	l_setRotationSpeedMax(0.0)
+	l_setRotationSpeedInc(0.0)
+	l_setDelayMult(1.35)
+	l_setDelayInc(0.0)
+	l_setFastSpin(71.0)
+	l_setSides(6)
+	l_setSidesMin(6)
+	l_setSidesMax(6)
+	l_setIncTime(10)
+
+	l_setPulseMin(75)
+	l_setPulseMax(75)
+	l_setPulseSpeed(0)
+	l_setPulseSpeedR(0)
+	l_setPulseDelayMax(6.8)
+
+	l_setBeatPulseMax(20)
+	l_setBeatPulseDelayMax(26.1)
+	
+	l_addTracked("thickness", "Wall Thickness");
+
+	l_setSwapEnabled(true)
+end
+
+-- onLoad is an hardcoded function that is called when the level is started/restarted
+function onLoad()
+end
+
+thickness = 40;
+-- onStep is an hardcoded function that is called when the level timeline is empty
+-- onStep should contain your pattern spawning logic
+function onStep()
+	w_wall(0, thickness)
+	w_wall(3, 80)
+	t_wait(getPerfectDelay(THICKNESS));
+	thickness = thickness + 1
+	thickness = clamp(thickness, 40, 75);
+end
+
+
+-- onIncrement is an hardcoded function that is called when the level difficulty is incremented
+function onIncrement()
+end
+
+-- onUnload is an hardcoded function that is called when the level is closed/restarted
+function onUnload()
+end
+
+-- onUpdate is an hardcoded function that is called every frame
+function onUpdate(mFrameTime)
+end

--- a/_RELEASE/Packs/experimental/Styles/wall_ref.json
+++ b/_RELEASE/Packs/experimental/Styles/wall_ref.json
@@ -1,0 +1,33 @@
+{
+	// Style data id
+	"id": "wall_ref",
+
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": true,
+	"hue_increment": 1.0,
+
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 0.5,
+	"pulse_increment": 0.025,
+
+	// 3D options
+	"3D_depth": 0,
+	"3D_skew": 0.0,
+	"3D_spacing": 1.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 0.5,
+	"3D_alpha_falloff": 19.0,
+
+	// Main color
+	"main": { "main": true, "dynamic": false, "value": [255, 255, 255, 100], "pulse": [0, 0, 0, 0] },
+	"cap_color": "main_darkened",
+
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [0, 0, 0, 255], "pulse": [0, 0, 0, 0]}
+	]
+}


### PR DESCRIPTION
Am doing this at the request of @SuperV1234. This just adds a level where it specializes in testing the collision system for ordinary walls (side collisions), to make sure that they work properly. (Currently the no overlap is having problems).