### PR TITLE
Add e_eval to Lua, the closest we'll get to 1.92 events.

### DIFF
--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -311,6 +311,15 @@ void HexagonGame::initLua_MainTimeline()
 
 void HexagonGame::initLua_EventTimeline()
 {
+    addLuaFn("e_eval",
+        [this](const std::string& mCode) {
+            eventTimeline.append_do([=, this] { lua.executeCode(mCode); });
+        })
+        .arg("code")
+        .doc(
+            "*Add to the event timeline*: evaluate the Lua code specified in "
+            "`$0`. (This is the closest you'll get to 1.92 events)");
+
     addLuaFn("e_eventStopTime", //
         [this](double mDuration) {
             eventTimeline.append_do([=, this] {

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -717,10 +717,9 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "m_messageAdd", "m_messageAddImportant",
             "m_messageAddImportantSilent", "m_clearMessages",
 
-            "t_wait", "t_waitS", "t_waitUntilS",
+            "t_eval", "t_wait", "t_waitS", "t_waitUntilS",
 
-            "e_eventStopTime", "e_eventStopTimeS", "e_eventWait",
-
+            "e_eval", "e_eventStopTime", "e_eventStopTimeS", "e_eventWait",
             "e_eventWaitS", "e_eventWaitUntilS",
 
             "w_wall", "w_wallAdj", "w_wallAcc", "w_wallHModSpeedData",


### PR DESCRIPTION
I took a look at ``t_eval``, which is one of the more recent functions that have been added, and it's surprised me that you can run Lua code using a function. So what I decided to do was to create the _event timeline_ equivalent of ``t_eval``. And I've remade my Fusion level to work off the ``e_eval`` function, and it works. I don't have to use ``onUpdate`` anymore to rely on carrying out events, as I can now define them all in ``onLoad``. 

**A lot of people** want 1.92 events to be in 2.0, and I think this is the closest that we'll ever get to having Events in 2.0 Open Hexagon. After this, I would say we've brought back events to 2.0. I don't care for the super bitter people who want JSON events back, but those aren't coming back. This is the best you're going to get when it comes to running events in 2.0.