### PR TITLE
Add Lua function that grabs the current version of Open Hexagon

### DIFF
--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -223,6 +223,12 @@ void HexagonGame::initLua_Utils()
         .doc(
             "Force-swaps (180 degrees) the player when invoked. If `$0` is "
             "`true`, the swap sound will be played.");
+    
+    addLuaFn("u_getVersion", //
+        [this] { return Config::getVersion(); })
+        .doc(
+            "Gets the current version of the game. Useful for executing code "
+            "that would only work in a beta branch.");
 }
 
 void HexagonGame::initLua_Messages()

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -712,7 +712,7 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "u_isFastSpinning", "u_setPlayerAngle", "u_forceIncrement",
             "u_kill", "u_eventKill", "u_haltTime", "u_timelineWait",
             "u_clearWalls", "u_setMusic", "u_setMusicSegment",
-            "u_setMusicSeconds",
+            "u_setMusicSeconds", "u_getVersion",
 
             "m_messageAdd", "m_messageAddImportant",
             "m_messageAddImportantSilent", "m_clearMessages",


### PR DESCRIPTION
Another small, yet useful addition to the game. This pull request adds a Lua function that just simply grabs the Open Hexagon version. It's small, but it's useful for developers who are developing code on a beta branch and their pack wouldn't run on the normal release.