### PR TITLE
Get Camera Shake to accept float values

### DIFF
--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -92,7 +92,7 @@ struct LevelStatus
     float wallAngleRight{0.f};
     float _3dEffectMultiplier{1.f};
 
-    int cameraShake{0};
+    float cameraShake{0};
 
     unsigned int sides{6};
     unsigned int sidesMax{6};

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -31,11 +31,11 @@ void HexagonGame::draw()
 
     if(!status.hasDied)
     {
-        if(levelStatus.cameraShake > 0)
+        if(levelStatus.cameraShake > 0.f)
         {
             const sf::Vector2f shake(
-                getRndI(-levelStatus.cameraShake, levelStatus.cameraShake),
-                getRndI(-levelStatus.cameraShake, levelStatus.cameraShake));
+                getRndR(-levelStatus.cameraShake, levelStatus.cameraShake),
+                getRndR(-levelStatus.cameraShake, levelStatus.cameraShake));
 
             backgroundCamera.setCenter(shake);
             overlayCamera.setCenter(


### PR DESCRIPTION
I consider this more of a bug fix than a feature. Previously setting camera shake wouldn't accept float values. Now it can. Pretty simple fix.