### PR TITLE
Point Workshop Tutorial on website to GitHub Wiki

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -11335,10 +11335,10 @@
                     </a>
 
                     <a style="width:310px; margin-left:9px" class="btn btn-light btn-xl js-scroll-trigger" target="_blank"
-                        href="https://github.com/SuperV1234/SSVOpenHexagon/wiki/Workshop-Tutorial">
+                        href="https://github.com/SuperV1234/SSVOpenHexagon/wiki">
                         <i class="fas fa-book fa-4x mb-3"></i>
 
-                        <div style="font-size: large">Workshop Tutorial</div>
+                        <div style="font-size: large">GitHub Wiki</div>
                     </a>
                 </div>
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -11335,7 +11335,7 @@
                     </a>
 
                     <a style="width:310px; margin-left:9px" class="btn btn-light btn-xl js-scroll-trigger" target="_blank"
-                        href="https://openhexagon.org/workshop">
+                        href="https://github.com/SuperV1234/SSVOpenHexagon/wiki/Workshop-Tutorial">
                         <i class="fas fa-book fa-4x mb-3"></i>
 
                         <div style="font-size: large">Workshop Tutorial</div>


### PR DESCRIPTION
This should complete the Workshop Tutorials move to GitHub Wiki. The old tutorial itself should be removed as well but I didn't include that here.

Closes #257 