### PR TITLE
onLoad runs when the level starts instead of level initialization

### DIFF
--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -319,6 +319,8 @@ void HexagonGame::start()
     {
         fpsWatcher.enable();
     }
+
+    runLuaFunction<void>("onLoad");
 }
 
 void HexagonGame::updateInput()

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -291,7 +291,6 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
     runLuaFile(levelData->luaScriptPath);
     runLuaFunction<void>("onInit");
-    runLuaFunction<void>("onLoad");
     restartId = mId;
     restartFirstTime = false;
     setSides(levelStatus.sides);


### PR DESCRIPTION
I find it quite funny that onLoad runs at level initialization, the same time as when onInit runs, which kind of makes it silly that onInit and onLoad are separate functions when they do the exact same thing.

However, this makes onLoad run when the level is finished loading and the level starts, which I think is what onLoad was intended to do. 

Also by doing this we also fix a few bugs with Lua functions. Setting music by segments and seconds previously didn't work properly with onLoad because the music player is paused while the onLoad function is called; it was because of this that the music would always play at the beginning, no matter what segment or timestamp was given. With this new placement the music starts playing before onLoad is ran, making those functions run properly.