### PR TITLE
Boot OH into a level with command line argument

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -241,7 +241,8 @@ public:
         Discord::discord_manager& mDiscordManager, HGAssets& mAssets,
         HexagonGame& mHexagonGame, ssvs::GameWindow& mGameWindow);
 
-    void init(bool mErrored);
+    void init(bool mErrored, const std::string& level = "");
+    void loadCommandLineLevel(const std::string& level);
 
     ssvs::GameState& getGame() noexcept
     {

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -241,8 +241,9 @@ public:
         Discord::discord_manager& mDiscordManager, HGAssets& mAssets,
         HexagonGame& mHexagonGame, ssvs::GameWindow& mGameWindow);
 
-    void init(bool mErrored, const std::string& level = "");
-    void loadCommandLineLevel(const std::string& level);
+    void init(bool mErrored);
+    void init(bool mErrored, const std::string& pack, const std::string& level);
+    void loadCommandLineLevel(const std::string& pack, const std::string& level);
 
     ssvs::GameState& getGame() noexcept
     {

--- a/include/SSVOpenHexagon/Global/Assets.hpp
+++ b/include/SSVOpenHexagon/Global/Assets.hpp
@@ -120,6 +120,11 @@ public:
         return levelDataIdsByPack.at(mPackId);
     }
 
+    const std::unordered_map<std::string, PackData>& getPacksData()
+    {
+        return packDatas;
+    }
+
     const PackData& getPackData(const std::string& mPackId)
     {
         SSVU_ASSERT(packDatas.count(mPackId) > 0);

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -3,25 +3,12 @@
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
 #include "SSVOpenHexagon/Global/Assets.hpp"
-#include "SSVOpenHexagon/Global/Common.hpp"
 #include "SSVOpenHexagon/Core/HexagonGame.hpp"
 #include "SSVOpenHexagon/Core/MenuGame.hpp"
 #include "SSVOpenHexagon/Core/Joystick.hpp"
-#include "SSVOpenHexagon/Core/Steam.hpp"
-#include "SSVOpenHexagon/Core/Discord.hpp"
-#include "SSVOpenHexagon/Online/Online.hpp"
-#include "SSVOpenHexagon/Utils/Utils.hpp"
-#include "SSVOpenHexagon/Utils/LuaWrapper.hpp"
-
-#include <SSVStart/Utils/Vector2.hpp>
-#include <SSVStart/SoundPlayer/SoundPlayer.hpp>
-
-#include <SSVUtils/Core/Common/Frametime.hpp>
-
 #include <cassert>
 
 using namespace hg::Utils;
-
 
 namespace hg
 {

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -3,9 +3,20 @@
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
 #include "SSVOpenHexagon/Global/Assets.hpp"
+#include "SSVOpenHexagon/Global/Common.hpp"
 #include "SSVOpenHexagon/Core/HexagonGame.hpp"
 #include "SSVOpenHexagon/Core/MenuGame.hpp"
 #include "SSVOpenHexagon/Core/Joystick.hpp"
+#include "SSVOpenHexagon/Core/Steam.hpp"
+#include "SSVOpenHexagon/Core/Discord.hpp"
+#include "SSVOpenHexagon/Online/Online.hpp"
+#include "SSVOpenHexagon/Utils/Utils.hpp"
+#include "SSVOpenHexagon/Utils/LuaWrapper.hpp"
+
+#include <SSVStart/Utils/Vector2.hpp>
+#include <SSVStart/SoundPlayer/SoundPlayer.hpp>
+
+#include <SSVUtils/Core/Common/Frametime.hpp>
 #include <cassert>
 
 using namespace hg::Utils;

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -193,10 +193,7 @@ void MenuGame::init(bool error, const std::string& pack, const std::string& leve
 
     Online::setForceLeaderboardRefresh(true);
 
-    if(!pack.empty() && !level.empty())
-    {
-        loadCommandLineLevel(pack, level);
-    }
+    loadCommandLineLevel(pack, level);
 }
 
 void MenuGame::initAssets()

--- a/src/SSVOpenHexagon/Core/main.cpp
+++ b/src/SSVOpenHexagon/Core/main.cpp
@@ -8,12 +8,6 @@
 #include "SSVOpenHexagon/Online/OHServer.hpp"
 #include "SSVOpenHexagon/Core/HexagonGame.hpp"
 #include "SSVOpenHexagon/Core/MenuGame.hpp"
-#include "SSVOpenHexagon/Core/Steam.hpp"
-#include "SSVOpenHexagon/Core/Discord.hpp"
-#include "SSVOpenHexagon/Global/Assets.hpp"
-#include "SSVOpenHexagon/Global/Config.hpp"
-
-#include <SSVStart/GameSystem/GameWindow.hpp>
 
 static void createProfilesFolder()
 {
@@ -42,11 +36,15 @@ int main(int argc, char* argv[])
     hg::Online::setCurrentGtm(
         std::make_unique<hg::Online::GlobalThreadManager>());
 
-    const auto overrideIds = [&] {
+    const auto overrideIds = [&]
+    {
         std::vector<std::string> result;
         for(int i{0}; i < argc; ++i)
         {
-            result.emplace_back(argv[i]);
+            if(!strcmp(argv[i], "-l")) // need this later
+                i += 2;
+            else
+                result.emplace_back(argv[i]);
         }
         return result;
     }();
@@ -104,7 +102,22 @@ int main(int argc, char* argv[])
 
     assets->refreshVolumes();
     window.setGameState(mg->getGame());
-    mg->init(false /* mError */);
+
+    const std::string levelName = [&]
+    {
+      std::string levelResult;
+      for(int i{0}; i < argc; ++i)
+      {
+          if(!strcmp(argv[i], "-l"))
+          {
+              levelResult = argv[++i];
+              break;
+          }
+      }
+      return levelResult;
+    }();
+
+    mg->init(false /* mError */, levelName);
 
     window.run();
 

--- a/src/SSVOpenHexagon/Core/main.cpp
+++ b/src/SSVOpenHexagon/Core/main.cpp
@@ -41,10 +41,14 @@ int main(int argc, char* argv[])
         std::vector<std::string> result;
         for(int i{0}; i < argc; ++i)
         {
-            if(!strcmp(argv[i], "-l")) // need this later
-                i += 2;
+            if(!strcmp(argv[i], "-p") || !strcmp(argv[i], "-l")) // need these later
+            {
+                i++;
+            }
             else
+            {
                 result.emplace_back(argv[i]);
+            }
         }
         return result;
     }();
@@ -103,21 +107,26 @@ int main(int argc, char* argv[])
     assets->refreshVolumes();
     window.setGameState(mg->getGame());
 
-    const std::string levelName = [&]
+    // this occurs separately because the strings get corrupted
+    // somewhere during the execution of the functions above
+    const auto [packName, levelName] = [&]
     {
-      std::string levelResult;
-      for(int i{0}; i < argc; ++i)
-      {
-          if(!strcmp(argv[i], "-l"))
-          {
-              levelResult = argv[++i];
-              break;
-          }
-      }
-      return levelResult;
+        std::string packResult = "", levelResult = "";
+        for(int i{0}; i < argc; ++i)
+        {
+            if(!strcmp(argv[i], "-p"))
+            {
+                packResult = argv[++i];
+            }
+            else if(!strcmp(argv[i], "-l"))
+            {
+                levelResult = argv[++i];
+            }
+        }
+        return std::make_pair(packResult, levelResult);
     }();
 
-    mg->init(false /* mError */, levelName);
+    mg->init(false /* mError */, packName, levelName);
 
     window.run();
 

--- a/src/SSVOpenHexagon/Core/main.cpp
+++ b/src/SSVOpenHexagon/Core/main.cpp
@@ -123,10 +123,18 @@ int main(int argc, char* argv[])
                 levelResult = argv[++i];
             }
         }
+
         return std::make_pair(packResult, levelResult);
     }();
 
-    mg->init(false /* mError */, packName, levelName);
+    if(!packName.empty() && !levelName.empty())
+    {
+        mg->init(false /* mError */, packName, levelName);
+    }
+    else
+    {
+        mg->init(false /* mError */);
+    }
 
     window.run();
 

--- a/src/SSVOpenHexagon/Core/main.cpp
+++ b/src/SSVOpenHexagon/Core/main.cpp
@@ -8,6 +8,12 @@
 #include "SSVOpenHexagon/Online/OHServer.hpp"
 #include "SSVOpenHexagon/Core/HexagonGame.hpp"
 #include "SSVOpenHexagon/Core/MenuGame.hpp"
+#include "SSVOpenHexagon/Core/Steam.hpp"
+#include "SSVOpenHexagon/Core/Discord.hpp"
+#include "SSVOpenHexagon/Global/Assets.hpp"
+#include "SSVOpenHexagon/Global/Config.hpp"
+
+#include <SSVStart/GameSystem/GameWindow.hpp>
 
 static void createProfilesFolder()
 {


### PR DESCRIPTION
Brief: add command line parameter -l and a level name to make OH load a level on boot. Mostly meant for level makers who might take advantage of not scrolling trough the menus to start the level they are working on.
https://youtu.be/9iyT4n7QacA

Details:
- add -l followed by the level name to load straight into the level (arguments used in the video are -l seconddimension);
- the level name is sent to the Menu class when MenuGame::Init() is called for the first time and here it is processed to see if there is a loaded level with matching name. In case no level is found an error message is printed to console and the load process is aborted;
- the level load will also abort if there is no local profile created, and the process will stop at the profile creation screen.

Notes:
- I store the level argument later compared to "overrideIds" in main.cpp because the string corrupts during the load process until it becomes an empty string;
- also removed a few redundant #includes.