### PR TITLE
Reload assets of level selected in the main menu

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -236,6 +236,8 @@ private:
         return getCurrentMenu() != nullptr;
     }
 
+    void reloadLevelAssets();
+
 public:
     MenuGame(Steam::steam_manager& mSteamManager,
         Discord::discord_manager& mDiscordManager, HGAssets& mAssets,

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -101,7 +101,8 @@ private:
     sf::Text txtVersion{"", imagine, 40}, txtProf{"", imagine, 21},
         txtLName{"", imagine, 65}, txtLDesc{"", imagine, 32},
         txtLAuth{"", imagine, 20}, txtLMus{"", imagine, 20},
-        txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14};
+        txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14},
+        txtReload{"", imagine, 32};
 
     void playLocally();
 
@@ -237,6 +238,7 @@ private:
     }
 
     void reloadLevelAssets();
+    float reloadMessageTimer{0.f};
 
 public:
     MenuGame(Steam::steam_manager& mSteamManager,

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -104,9 +104,12 @@ private:
         txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14};
 
     // dialog box
+    void drawDialogBox();
+    Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogBackdrop;
+    Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
+    std::vector<std::string> dialogText;
     sf::Text txtDialog{"", imagine, 0};
-    std::string dialogText;
-    float dialogHeight{0.f};
+    float dialogHeight{0.f}, dialogWidth{0.f}, frameOffset{0.f}, lineHeight{0.f};
     int noActions{0};
 
     void playLocally();

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -105,6 +105,7 @@ private:
 
     // dialog box
     void drawDialogBox();
+    void clearDialogBox();
     Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogBackdrop;
     Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
     std::vector<std::string> dialogText;
@@ -251,6 +252,11 @@ public:
     MenuGame(Steam::steam_manager& mSteamManager,
         Discord::discord_manager& mDiscordManager, HGAssets& mAssets,
         HexagonGame& mHexagonGame, ssvs::GameWindow& mGameWindow);
+
+    ~MenuGame()
+    {
+        clearDialogBox();
+    }
 
     void init(bool mErrored);
 

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -45,7 +45,7 @@ public:
     void createDialogBox(std::string& output, const int charSize);
     void drawDialogBox();
     void clearDialogBox();
-    bool empty()
+    [[nodiscard]] bool empty() const noexcept
     {
         return dialogText.empty();
     }

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -102,7 +102,9 @@ private:
         txtLName{"", imagine, 65}, txtLDesc{"", imagine, 32},
         txtLAuth{"", imagine, 20}, txtLMus{"", imagine, 20},
         txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14},
-        txtReload{"", imagine, 32};
+        txtDialog{"", imagine, 0};
+    bool dialogBox{false};
+    int noActions{0};
 
     void playLocally();
 
@@ -238,7 +240,6 @@ private:
     }
 
     void reloadLevelAssets();
-    float reloadMessageTimer{0.f};
 
 public:
     MenuGame(Steam::steam_manager& mSteamManager,

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -106,7 +106,6 @@ private:
     // dialog box
     void drawDialogBox();
     void clearDialogBox();
-    Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogBackdrop;
     Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
     std::vector<std::string> dialogText;
     sf::Text txtDialog{"", imagine, 0};
@@ -252,11 +251,6 @@ public:
     MenuGame(Steam::steam_manager& mSteamManager,
         Discord::discord_manager& mDiscordManager, HGAssets& mAssets,
         HexagonGame& mHexagonGame, ssvs::GameWindow& mGameWindow);
-
-    ~MenuGame()
-    {
-        clearDialogBox();
-    }
 
     void init(bool mErrored);
 

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -26,7 +26,7 @@
 namespace hg
 {
 
-class OHDialogBox
+class HexagonDialogBox // can't be named DialogBox due to a pre-existing C++ class
 {
 private:
     HGAssets& assets;
@@ -41,7 +41,7 @@ private:
     float dialogHeight{0.f}, dialogWidth{0.f}, frameOffset{0.f}, lineHeight{0.f};
 
 public:
-    OHDialogBox(HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
+    HexagonDialogBox(HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
     void createDialogBox(std::string& output, const int charSize);
     void drawDialogBox();
     void clearDialogBox();
@@ -128,7 +128,7 @@ private:
         txtLAuth{"", imagine, 20}, txtLMus{"", imagine, 20},
         txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14};
 
-    OHDialogBox dialogBox;
+    HexagonDialogBox dialogBox;
 
     void playLocally();
 

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -26,6 +26,31 @@
 namespace hg
 {
 
+class OHDialogBox
+{
+private:
+    HGAssets& assets;
+    ssvs::GameWindow& window;
+    StyleData& styleData;
+    sf::Font& imagine = assets.get<sf::Font>(
+        "forcedsquare.ttf"); // G++ bug (cannot initialize with curly braces)
+
+    Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
+    std::vector<std::string> dialogText;
+    sf::Text txtDialog{"", imagine, 0};
+    float dialogHeight{0.f}, dialogWidth{0.f}, frameOffset{0.f}, lineHeight{0.f};
+
+public:
+    OHDialogBox(HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
+    void createDialogBox(std::string& output, const int charSize);
+    void drawDialogBox();
+    void clearDialogBox();
+    bool empty()
+    {
+        return dialogText.empty();
+    }
+};
+
 enum class States
 {
     EpilepsyWarning,
@@ -103,14 +128,7 @@ private:
         txtLAuth{"", imagine, 20}, txtLMus{"", imagine, 20},
         txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14};
 
-    // dialog box
-    void drawDialogBox();
-    void clearDialogBox();
-    Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
-    std::vector<std::string> dialogText;
-    sf::Text txtDialog{"", imagine, 0};
-    float dialogHeight{0.f}, dialogWidth{0.f}, frameOffset{0.f}, lineHeight{0.f};
-    int noActions{0};
+    OHDialogBox dialogBox;
 
     void playLocally();
 
@@ -246,6 +264,7 @@ private:
     }
 
     void reloadLevelAssets();
+    int noActions{0};
 
 public:
     MenuGame(Steam::steam_manager& mSteamManager,

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -101,9 +101,12 @@ private:
     sf::Text txtVersion{"", imagine, 40}, txtProf{"", imagine, 21},
         txtLName{"", imagine, 65}, txtLDesc{"", imagine, 32},
         txtLAuth{"", imagine, 20}, txtLMus{"", imagine, 20},
-        txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14},
-        txtDialog{"", imagine, 0};
-    bool dialogBox{false};
+        txtFriends{"", imagine, 21}, txtPacks{"", imagine, 14};
+
+    // dialog box
+    sf::Text txtDialog{"", imagine, 0};
+    std::string dialogText;
+    float dialogHeight{0.f};
     int noActions{0};
 
     void playLocally();

--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -32,6 +32,8 @@ public:
     bool selectable{ssvuj::getExtr<bool>(root, "selectable", true)};
     std::string musicId{
         ssvuj::getExtr<std::string>(root, "musicId", "nullMusicId")};
+    std::string soundId{
+        ssvuj::getExtr<std::string>(root, "soundId", "nullSoundId")};
     std::string styleId{
         ssvuj::getExtr<std::string>(root, "styleId", "nullStyleId")};
     ssvufs::Path luaScriptPath{

--- a/include/SSVOpenHexagon/Global/Assets.hpp
+++ b/include/SSVOpenHexagon/Global/Assets.hpp
@@ -137,19 +137,24 @@ public:
     void loadMusicData(const std::string& mPackId, const ssvufs::Path& mPath);
     void loadStyleData(const std::string& mPackId, const ssvufs::Path& mPath);
     void loadLevelData(const std::string& mPackId, const ssvufs::Path& mPath);
-    void loadCustomSounds(
-        const std::string& mPackId, const ssvufs::Path& mPath);
-    void loadLocalProfiles();
-
-    void saveCurrentLocalProfile();
+    void loadCustomSounds(const std::string& mPackId, const ssvufs::Path& mPath);
 
     const MusicData& getMusicData(
         const std::string& mPackId, const std::string& mId);
     const StyleData& getStyleData(
         const std::string& mPackId, const std::string& mId);
 
+    void reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    void reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    void reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    void reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    void reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+
     float getLocalScore(const std::string& mId);
     void setLocalScore(const std::string& mId, float mScore);
+
+    void loadLocalProfiles();
+    void saveCurrentLocalProfile();
     void setCurrentLocalProfile(const std::string& mName);
     ProfileData& getCurrentLocalProfile();
     const ProfileData& getCurrentLocalProfile() const;

--- a/include/SSVOpenHexagon/Global/Assets.hpp
+++ b/include/SSVOpenHexagon/Global/Assets.hpp
@@ -144,11 +144,11 @@ public:
     const StyleData& getStyleData(
         const std::string& mPackId, const std::string& mId);
 
-    void reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    void reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    void reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    void reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    void reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    std::string reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    std::string reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    std::string reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    std::string reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    std::string reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId);
 
     float getLocalScore(const std::string& mId);
     void setLocalScore(const std::string& mId, float mScore);

--- a/include/SSVOpenHexagon/Global/Assets.hpp
+++ b/include/SSVOpenHexagon/Global/Assets.hpp
@@ -144,11 +144,11 @@ public:
     const StyleData& getStyleData(
         const std::string& mPackId, const std::string& mId);
 
-    std::string reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    std::string reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    std::string reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    std::string reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId);
-    std::string reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    [[nodiscard]] std::pair<bool, std::string> reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    [[nodiscard]] std::string reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    [[nodiscard]] std::string reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    [[nodiscard]] std::string reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId);
+    [[nodiscard]] std::string reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId);
 
     float getLocalScore(const std::string& mId);
     void setLocalScore(const std::string& mId, float mScore);

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -693,11 +693,10 @@ void MenuGame::initInput()
 
 void MenuGame::reloadLevelAssets()
 {
-    if(state != States::SMain || dialogBox) return;
-
-    game.ignoreNextInputs();
-    dialogBox = true;
+    if(state != States::SMain || dialogBox || !Config::getDebug()) return;
+    
     noActions = 2;
+    assets.playSound("beep.ogg");
 
     std::string reloadMessage = assets.reloadLevelData(levelData->packId, levelData->packPath, levelData->id);
     if(reloadMessage != "invalid level folder path\n" && reloadMessage != "no matching level data file found\n")
@@ -716,10 +715,11 @@ void MenuGame::reloadLevelAssets()
 
     reloadMessage += "\npress any key to close this message\n";
 
+    dialogBox = true;
     Utils::uppercasify(reloadMessage);
     txtDialog.setCharacterSize(26);
     txtDialog.setString(reloadMessage);
-    txtDialog.setPosition({(w - getGlobalWidth(txtDialog)) / 2.f, h / 2.f - getGlobalHeight(txtDialog)});
+    txtDialog.setPosition({(w - getGlobalWidth(txtDialog)) / 2.f, h / 2.f - getGlobalHeight(txtDialog) + 10.f});
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -59,41 +59,20 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     game.onEvent(Event::EventType::KeyReleased) +=
         [this](const Event& mEvent)
         {
-            if(!noActions) return;
-				
-            if(!(--noActions))
-            {
-                assets.playSound("beep.ogg");
-                dialogBackdrop.clear();
-                dialogFrame.clear();
-                dialogText.clear();
-            }
+          if(!noActions) return;
+          if(!(--noActions)) clearDialogBox();
         };
     game.onEvent(Event::EventType::MouseButtonReleased) +=
         [this](const Event& mEvent)
         {
 			if(!noActions) return;
-				
-            if(!(--noActions))
-            {
-                assets.playSound("beep.ogg");
-                dialogBackdrop.clear();
-                dialogFrame.clear();
-                dialogText.clear();
-            }
+            if(!(--noActions)) clearDialogBox();
         };
     game.onEvent(Event::EventType::JoystickButtonReleased) +=
         [this](const Event& mEvent)
         {
-            if(!noActions) return;
-				
-            if(!(--noActions))
-            {
-                assets.playSound("beep.ogg");
-                dialogBackdrop.clear();
-                dialogFrame.clear();
-                dialogText.clear();
-            }
+          if(!noActions) return;
+          if(!(--noActions)) clearDialogBox();
         };
     window.onRecreation += [this] { refreshCamera(); };
 
@@ -103,6 +82,14 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     setIndex(0);
     initMenus();
     initInput();
+}
+
+void MenuGame::clearDialogBox()
+{
+    assets.playSound("beep.ogg");
+    dialogBackdrop.clear();
+    dialogFrame.clear();
+    dialogText.clear();
 }
 
 void MenuGame::init(bool error)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -6,18 +6,6 @@
 #include "SSVOpenHexagon/Core/HexagonGame.hpp"
 #include "SSVOpenHexagon/Core/MenuGame.hpp"
 #include "SSVOpenHexagon/Core/Joystick.hpp"
-#include "SSVOpenHexagon/Core/Steam.hpp"
-#include "SSVOpenHexagon/Core/Discord.hpp"
-#include "SSVOpenHexagon/Online/Online.hpp"
-#include "SSVOpenHexagon/Utils/LuaWrapper.hpp"
-#include "SSVOpenHexagon/SSVUtilsJson/SSVUtilsJson.hpp"
-
-#include <SSVStart/Input/Input.hpp>
-#include <SSVStart/Utils/Vector2.hpp>
-
-#include <SSVMenuSystem/SSVMenuSystem.hpp>
-
-#include <SSVUtils/Core/Common/Frametime.hpp>
 
 using namespace std;
 using namespace sf;
@@ -638,6 +626,22 @@ void MenuGame::initInput()
             }
         },
         t::Once);
+    game.addInput(
+        {{k::F5}},
+        [this](ssvu::FT /*unused*/) { reloadLevelAssets(); },
+                t::Once);
+}
+
+void MenuGame::reloadLevelAssets()
+{
+    if(state != States::SMain) return;
+
+    assets.reloadLevelData(levelData->packId, levelData->packPath, levelData->id);
+    setIndex(currentIndex); // loads the new levelData
+    assets.reloadMusicData(levelData->packId, levelData->packPath, levelData->musicId);
+    assets.reloadStyleData(levelData->packId, levelData->packPath, levelData->styleId);
+    assets.reloadMusic(levelData->packId, levelData->packPath, levelData->musicId);
+    assets.reloadCustomSounds(levelData->packId, levelData->packPath, levelData->soundId);
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1539,12 +1539,12 @@ void MenuGame::drawWelcome()
 
 // dialog box
 
-OHDialogBox::OHDialogBox(HGAssets& mAssets, ssvs::GameWindow& mWindow, StyleData& mStyleData) :
+HexagonDialogBox::HexagonDialogBox(HGAssets& mAssets, ssvs::GameWindow& mWindow, StyleData& mStyleData) :
                          assets{mAssets}, window{mWindow}, styleData{mStyleData}
 {
 }
 
-void OHDialogBox::createDialogBox(std::string& output, const int charSize)
+void HexagonDialogBox::createDialogBox(std::string& output, const int charSize)
 {
     txtDialog.setCharacterSize(charSize);
     txtDialog.setString(output);
@@ -1556,8 +1556,6 @@ void OHDialogBox::createDialogBox(std::string& output, const int charSize)
     // So we assign an arbitrary text string and record the outputted value
     txtDialog.setString("A");
     lineHeight = getGlobalHeight(txtDialog);
-
-    cout << lineHeight << endl;
 
     frameOffset = 10.f;
 
@@ -1576,44 +1574,42 @@ void OHDialogBox::createDialogBox(std::string& output, const int charSize)
     }
 }
 
-void OHDialogBox::drawDialogBox()
+void HexagonDialogBox::drawDialogBox()
 {
     const sf::Color color = styleData.getTextColor();
-    float fw{1024.f / Config::getWidth()};
-    float fh{768.f / Config::getHeight()};
-    float fmax{max(fw, fh)};
-    float w = Config::getWidth() * fmax;
-    float h = Config::getHeight() * fmax;
+    const float fmax{max(1024.f / Config::getWidth(), 768.f / Config::getHeight())},
+                w = Config::getWidth() * fmax,
+                h = (Config::getHeight() * fmax) / 2.f;
 
     // Alright what's this: if I apply the clean txtDialog height value to these quads there is
-    // a small extra margin on the top and bottom (right and left and perfect). Luckily the height
+    // a small extra margin on the top and bottom (right and left are perfect). Luckily the height
     // of those margins are 0.85f of the height of one line for the top, and around 0.6f of the same
     // line height for the bottom. Is there a better way to do it? Maybe, but I printed some
     // txtDialog.getxxxx() values and cannot see an obvious answer.
     const float heightDif = lineHeight * 0.85f,
-        heightDifBottom = lineHeight * 0.6f;
+                heightDifBottom = lineHeight * 0.6f;
 
     // outer frame (text color)
     const float leftBorder = (w - dialogWidth) / 2.f,
-        rightBorder = (w + dialogWidth) / 2.f,
-        halfH = h / 2.f,
-        doubleOffset = frameOffset * 2.f;
+                rightBorder = (w + dialogWidth) / 2.f,
+                doubleOffset = frameOffset * 2.f;
 
     dialogFrame.clear();
-    sf::Vector2f p1{leftBorder - doubleOffset, halfH - dialogHeight - doubleOffset + heightDif};  // top left
-    sf::Vector2f p2{rightBorder + doubleOffset, halfH - dialogHeight - doubleOffset + heightDif}; // top right
-    sf::Vector2f p3{rightBorder + doubleOffset, halfH + doubleOffset - heightDifBottom};          // bottom right
-    sf::Vector2f p4{leftBorder - doubleOffset, halfH + doubleOffset - heightDifBottom};           // bottom left
-    dialogFrame.reserve_more(4);
+    dialogFrame.reserve_more(8);
+
+    sf::Vector2f p1{leftBorder - doubleOffset, h - dialogHeight - doubleOffset + heightDif};  // top left
+    sf::Vector2f p2{rightBorder + doubleOffset, h - dialogHeight - doubleOffset + heightDif}; // top right
+    sf::Vector2f p3{rightBorder + doubleOffset, h + doubleOffset - heightDifBottom};          // bottom right
+    sf::Vector2f p4{leftBorder - doubleOffset, h + doubleOffset - heightDifBottom};           // bottom left
     dialogFrame.batch_unsafe_emplace_back(color, p1, p2, p3, p4);
 
     // text backdrop (spinning background color)
-    p1 = {leftBorder - frameOffset, halfH - dialogHeight - frameOffset + heightDif};  // top left
-    p2 = {rightBorder + frameOffset, halfH - dialogHeight - frameOffset + heightDif}; // top right
-    p3 = {rightBorder + frameOffset, halfH + frameOffset - heightDifBottom};          // bottom right
-    p4 = {leftBorder - frameOffset, halfH + frameOffset - heightDifBottom};           // bottom left
-    dialogFrame.reserve_more(4);
+    p1 = {leftBorder - frameOffset, h - dialogHeight - frameOffset + heightDif};  // top left
+    p2 = {rightBorder + frameOffset, h - dialogHeight - frameOffset + heightDif}; // top right
+    p3 = {rightBorder + frameOffset, h + frameOffset - heightDifBottom};          // bottom right
+    p4 = {leftBorder - frameOffset, h + frameOffset - heightDifBottom};           // bottom left
     dialogFrame.batch_unsafe_emplace_back(styleData.getColor(0), p1, p2, p3, p4);
+
     window.draw(dialogFrame);
 
     // text
@@ -1626,14 +1622,14 @@ void OHDialogBox::drawDialogBox()
         {
             txtDialog.setString(str);
             txtDialog.setPosition({(w - getGlobalWidth(txtDialog)) / 2.f,
-                                   h / 2.f - dialogHeight + heightOffset});
+                                   h - dialogHeight + heightOffset});
             window.draw(txtDialog);
         }
         heightOffset += interlineSpace;
     }
 }
 
-void OHDialogBox::clearDialogBox()
+void HexagonDialogBox::clearDialogBox()
 {
     assets.playSound("beep.ogg");
     dialogFrame.clear();

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -87,7 +87,6 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
 void MenuGame::clearDialogBox()
 {
     assets.playSound("beep.ogg");
-    dialogBackdrop.clear();
     dialogFrame.clear();
     dialogText.clear();
 }
@@ -1311,17 +1310,14 @@ void MenuGame::drawDialogBox()
     sf::Vector2f p4{leftBorder - doubleOffset, halfH + doubleOffset - heightDifBottom};           // bottom left
     dialogFrame.reserve_more(4);
     dialogFrame.batch_unsafe_emplace_back(color, p1, p2, p3, p4);
-    render(dialogFrame);
-
     // text backdrop (spinning background color)
-    dialogBackdrop.clear();
     p1 = {leftBorder - frameOffset, halfH - dialogHeight - frameOffset + heightDif};  // top left
     p2 = {rightBorder + frameOffset, halfH - dialogHeight - frameOffset + heightDif}; // top right
     p3 = {rightBorder + frameOffset, halfH + frameOffset - heightDifBottom};          // bottom right
     p4 = {leftBorder - frameOffset, halfH + frameOffset - heightDifBottom};           // bottom left
-    dialogBackdrop.reserve_more(4);
-    dialogBackdrop.batch_unsafe_emplace_back(styleData.getColor(0), p1, p2, p3, p4);
-    render(dialogBackdrop);
+    dialogFrame.reserve_more(4);
+    dialogFrame.batch_unsafe_emplace_back(styleData.getColor(0), p1, p2, p3, p4);
+    render(dialogFrame);
 
     // text
     float heightOffsset = 0.f;

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -59,39 +59,34 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     game.onEvent(Event::EventType::KeyReleased) +=
         [this](const Event& mEvent)
         {
-            if(dialogBox)
+            if(!noActions) return;
+				
+            if(!(--noActions))
             {
-                // first key release is the one that activated action prevention
-                // second one is the one that counts
-                if(!(--noActions))
-                {
-                    assets.playSound("beep.ogg");
-                    dialogBox = false;
-                }
+                assets.playSound("beep.ogg");
+                dialogBox = false;
             }
         };
     game.onEvent(Event::EventType::MouseButtonReleased) +=
         [this](const Event& mEvent)
         {
-            if(dialogBox)
+			if(!noActions) return;
+				
+            if(!(--noActions))
             {
-                if(!(--noActions))
-                {
-                    assets.playSound("beep.ogg");
-                    dialogBox = false;
-                }
+                assets.playSound("beep.ogg");
+                dialogBox = false;
             }
         };
     game.onEvent(Event::EventType::JoystickButtonReleased) +=
         [this](const Event& mEvent)
         {
-            if(dialogBox)
+            if(!noActions) return;
+				
+            if(!(--noActions))
             {
-                if(!(--noActions))
-                {
-                    assets.playSound("beep.ogg");
-                    dialogBox = false;
-                }
+                assets.playSound("beep.ogg");
+                dialogBox = false;
             }
         };
     window.onRecreation += [this] { refreshCamera(); };

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -372,22 +372,22 @@ const StyleData& SSVU_ATTRIBUTE(pure) HGAssets::getStyleData(
 //**********************************************
 // RELOAD
 
-std::string HGAssets::reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
+std::pair<bool, std::string> HGAssets::reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
 {
     // get the styles folder and check it exists
     const std::string path = mPath + "Levels/";
     if(!ssvufs::Path{path}.exists<ssvufs::Type::Folder>())
-        return "invalid level folder path\n";
+        return std::make_pair(false, "invalid level folder path\n");
 
     // reload the style data
     for(const auto& p : scanSingleByName(path, mId + ".json"))
     {
         LevelData levelData{ssvuj::getFromFile(p), mPath, mPackId};
         levelDatas.find(mPackId + "_" + mId)->second = levelData;
-        return "level data " + mId + ".json successfully loaded\n";
+        return std::make_pair(true, "level data " + mId + ".json successfully loaded\n");
     }
 
-    return "no matching level data file found\n";
+    return std::make_pair(false, "no matching level data file found\n");
 }
 
 std::string HGAssets::reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId)

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -437,7 +437,7 @@ std::string HGAssets::reloadMusic(const std::string& mPackId, const std::string&
 
     // check if this music file is already loaded
     const std::string assetId = mPackId + "_" + mId;
-    if(!assetManager.has<sf::SoundBuffer>(assetId))
+    if(assetManager.has<sf::Music>(assetId))
         return "music file " + mId + ".ogg is already loaded\n";
 
     // load the new music file
@@ -461,7 +461,7 @@ std::string HGAssets::reloadCustomSounds(const std::string& mPackId, const std::
 
     // check if this custom sound file is already loaded
     const std::string assetId = mPackId + "_" + mId;
-    if(!assetManager.has<sf::SoundBuffer>(assetId))
+    if(assetManager.has<sf::SoundBuffer>(assetId))
         return "custom sound file " + mId + ".ogg is already loaded\n";
 
     for(const auto& p : scanSingleByName(path, mId + ".ogg"))

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -384,7 +384,7 @@ std::string HGAssets::reloadLevelData(const std::string& mPackId, const std::str
     {
         LevelData levelData{ssvuj::getFromFile(p), mPath, mPackId};
         levelDatas.find(mPackId + "_" + mId)->second = levelData;
-        return "level data successfully reloaded\n";
+        return "level data " + mId + ".json successfully loaded\n";
     }
 
     return "no matching level data file found\n";
@@ -403,7 +403,7 @@ std::string HGAssets::reloadMusicData(const std::string& mPackId, const std::str
         // get pointer to updated map pair
         MusicData musicData{Utils::loadMusicFromJson(ssvuj::getFromFile(p))};
         musicDataMap.find(mPackId + "_" + mId)->second = musicData;
-        return "music data successfully reloaded\n";
+        return "music data " + mId + ".json successfully loaded\n";
     }
 
     return "no matching music data file found\n";
@@ -421,7 +421,8 @@ std::string HGAssets::reloadStyleData(const std::string& mPackId, const std::str
     {
         // update the value
         StyleData styleData{ssvuj::getFromFile(p), p};
-        return "style data successfully reloaded\n";
+        styleDataMap.find(mPackId + "_" + mId)->second = styleData;
+        return "style data " + mId + ".json successfully loaded\n";
     }
 
     return "no matching style data file found\n";
@@ -437,7 +438,7 @@ std::string HGAssets::reloadMusic(const std::string& mPackId, const std::string&
     // check if this music file is already loaded
     const std::string assetId = mPackId + "_" + mId;
     if(!assetManager.has<sf::SoundBuffer>(assetId))
-        return "music file is already loaded\n";
+        return "music file " + mId + ".ogg is already loaded\n";
 
     // load the new music file
     for(const auto& p : scanSingleByName(path, mId + ".ogg"))
@@ -445,7 +446,7 @@ std::string HGAssets::reloadMusic(const std::string& mPackId, const std::string&
         auto& music(assetManager.load<sf::Music>(assetId, p));
         music.setVolume(Config::getMusicVolume());
         music.setLoop(true);
-        return "new music file successfully loaded\n";
+        return "new music file " + mId + ".ogg successfully loaded\n";
     }
 
     return "no matching music file found\n";
@@ -461,12 +462,12 @@ std::string HGAssets::reloadCustomSounds(const std::string& mPackId, const std::
     // check if this custom sound file is already loaded
     const std::string assetId = mPackId + "_" + mId;
     if(!assetManager.has<sf::SoundBuffer>(assetId))
-        return "custom sound file is already loaded\n";
+        return "custom sound file " + mId + ".ogg is already loaded\n";
 
     for(const auto& p : scanSingleByName(path, mId + ".ogg"))
     {
         assetManager.load<sf::SoundBuffer>(assetId, p);
-        return "new custom sound file successfully loaded\n";
+        return "new custom sound file " + mId + ".ogg successfully loaded\n";
     }
 
     return "no matching custom sound file found\n";

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -3,8 +3,17 @@
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
 #include "SSVOpenHexagon/Global/Assets.hpp"
+#include "SSVOpenHexagon/Global/Config.hpp"
+#include "SSVOpenHexagon/Online/Definitions.hpp"
+#include "SSVOpenHexagon/Online/Online.hpp"
 #include "SSVOpenHexagon/Utils/Utils.hpp"
+#include "SSVOpenHexagon/Data/MusicData.hpp"
+#include "SSVOpenHexagon/SSVUtilsJson/SSVUtilsJson.hpp"
 #include "SSVOpenHexagon/Core/Steam.hpp"
+
+#include <SSVStart/SoundPlayer/SoundPlayer.hpp>
+
+#include <SSVUtils/Core/FileSystem/FileSystem.hpp>
 
 namespace hg
 {

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -372,38 +372,30 @@ const StyleData& SSVU_ATTRIBUTE(pure) HGAssets::getStyleData(
 //**********************************************
 // RELOAD
 
-void HGAssets::reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
+std::string HGAssets::reloadLevelData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
 {
     // get the styles folder and check it exists
     const std::string path = mPath + "Levels/";
     if(!ssvufs::Path{path}.exists<ssvufs::Type::Folder>())
-    {
-        ssvu::lo("reloadAssets")
-            << "path " << path << " does not exist\n";
-        return;
-    }
+        return "invalid level folder path\n";
 
     // reload the style data
     for(const auto& p : scanSingleByName(path, mId + ".json"))
     {
-        const auto it = levelDatas.find(mPackId + "_" + mId);
         LevelData levelData{ssvuj::getFromFile(p), mPath, mPackId};
-        it->second = levelData;
-        ssvu::lo("reloadAssets")
-            << "reloaded level data " << path << mId + ".json\n";
+        levelDatas.find(mPackId + "_" + mId)->second = levelData;
+        return "level data successfully reloaded\n";
     }
+
+    return "no matching level data file found\n";
 }
 
-void HGAssets::reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
+std::string HGAssets::reloadMusicData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
 {
     // get the styles folder and check it exists
     const std::string path = mPath + "Music/";
     if(!ssvufs::Path{path}.exists<ssvufs::Type::Folder>())
-    {
-        ssvu::lo("reloadAssets")
-            << "path " << path << " does not exist\n";
-        return;
-    }
+        return "invalid music folder path\n";
 
     // reload the specific music data
     for(const auto& p : scanSingleByName(path, mId + ".json"))
@@ -411,52 +403,41 @@ void HGAssets::reloadMusicData(const std::string& mPackId, const std::string& mP
         // get pointer to updated map pair
         MusicData musicData{Utils::loadMusicFromJson(ssvuj::getFromFile(p))};
         musicDataMap.find(mPackId + "_" + mId)->second = musicData;
-        ssvu::lo("reloadAssets")
-            << "reloaded music data " << path << mId + ".json\n";
+        return "music data successfully reloaded\n";
     }
+
+    return "no matching music data file found\n";
 }
 
-void HGAssets::reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
+std::string HGAssets::reloadStyleData(const std::string& mPackId, const std::string& mPath, const std::string& mId)
 {
     // get the styles folder and check it exists
     const std::string path = mPath + "Styles/";
     if(!ssvufs::Path{path}.exists<ssvufs::Type::Folder>())
-    {
-        ssvu::lo("reloadAssets")
-            << "path " << path << " does not exist\n";
-        return;
-    }
+        return "invalid style folder path\n";
 
     // reload the style data
     for(const auto& p : scanSingleByName(path, mId + ".json"))
     {
         // update the value
         StyleData styleData{ssvuj::getFromFile(p), p};
-        styleDataMap.find(mPackId + "_" + mId)->second = styleData;
-        ssvu::lo("reloadAssets")
-            << "reloaded style data " << path << mId + ".json\n";
+        return "style data successfully reloaded\n";
     }
+
+    return "no matching style data file found\n";
 }
 
-void HGAssets::reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId)
+std::string HGAssets::reloadMusic(const std::string& mPackId, const std::string& mPath, const std::string& mId)
 {
     // get the music folder and check it exists
     const std::string path = mPath + "Music/";
     if(!ssvufs::Path{path}.exists<ssvufs::Type::Folder>())
-    {
-        ssvu::lo("reloadAssets")
-            << "path " << path << " does not exist\n";
-        return;
-    }
+        return "invalid music folder path\n";
 
     // check if this music file is already loaded
     const std::string assetId = mPackId + "_" + mId;
     if(!assetManager.has<sf::SoundBuffer>(assetId))
-    {
-        ssvu::lo("reloadAssets")
-            << "music file " << assetId << " is already loaded\n";
-        return;
-    }
+        return "music file is already loaded\n";
 
     // load the new music file
     for(const auto& p : scanSingleByName(path, mId + ".ogg"))
@@ -464,37 +445,31 @@ void HGAssets::reloadMusic(const std::string& mPackId, const std::string& mPath,
         auto& music(assetManager.load<sf::Music>(assetId, p));
         music.setVolume(Config::getMusicVolume());
         music.setLoop(true);
-        ssvu::lo("reloadAssets")
-            << "loaded music file " << path << mId + ".ogg\n";
+        return "new music file successfully loaded\n";
     }
+
+    return "no matching music file found\n";
 }
 
-void HGAssets::reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId)
+std::string HGAssets::reloadCustomSounds(const std::string& mPackId, const std::string& mPath, const std::string& mId)
 {
     // get the sound folder and check it exists
     const std::string path = mPath + "Sounds/";
     if(!ssvufs::Path{path}.exists<ssvufs::Type::Folder>())
-    {
-        ssvu::lo("reloadAssets")
-            << "path " << path << " does not exist\n";
-        return;
-    }
+        return "invalid custom sound folder path\n";
 
     // check if this custom sound file is already loaded
     const std::string assetId = mPackId + "_" + mId;
     if(!assetManager.has<sf::SoundBuffer>(assetId))
-    {
-        ssvu::lo("reloadAssets")
-            << "custom sound file " << assetId << " is already loaded\n";
-        return;
-    }
+        return "custom sound file is already loaded\n";
 
     for(const auto& p : scanSingleByName(path, mId + ".ogg"))
     {
         assetManager.load<sf::SoundBuffer>(assetId, p);
-        ssvu::lo("reloadAssets")
-            << "loaded custom sound file " << path << mId + ".ogg\n";
+        return "new custom sound file successfully loaded\n";
     }
+
+    return "no matching custom sound file found\n";
 }
 
 //**********************************************


### PR DESCRIPTION
Brief:
press F5 in the main menu to reload the assets of the currently selected level. To be used by pack developers so that they don't have to turn OH off and on to test small changes.
https://youtu.be/DPiZLw8cshQ

Details:
- press F5 in the main menu to reload assets of the level;
- function reload the level data and then music, style, and custom sounds files the level data .json is pointing to;
- error messages are printed in console if the file does not exist;
- files to be reloaded must be in the pack directory subfolders (ex. PackPath/Music/ or PackPath/Style/);
- new music and custom sound files are not reloaded if they have been already cached at boot.

Extra notes:
- removed some redundant includes;
- added soundId to LevelData class;
- slightly reorganized Assets.hpp and Assets.cpp