### PR TITLE
Lua function to edit the player movement speed

### DIFF
--- a/include/SSVOpenHexagon/Components/CPlayer.hpp
+++ b/include/SSVOpenHexagon/Components/CPlayer.hpp
@@ -31,6 +31,7 @@ private:
     float size;
     float speed;
     float focusSpeed;
+    float* playerSpeedMult;
 
     bool dead;
     bool justSwapped;
@@ -43,7 +44,7 @@ private:
     void drawDeathEffect(HexagonGame& mHexagonGame);
 
 public:
-    CPlayer(const sf::Vector2f& mStartPos, const float swapCooldown) noexcept;
+    CPlayer(const sf::Vector2f& mPos, const float swapCooldown, float* mPlayerSpeedMulti) noexcept;
 
     [[gnu::always_inline, nodiscard]] const sf::Vector2f&
     getPosition() const noexcept

--- a/include/SSVOpenHexagon/Components/CPlayer.hpp
+++ b/include/SSVOpenHexagon/Components/CPlayer.hpp
@@ -31,7 +31,6 @@ private:
     float size;
     float speed;
     float focusSpeed;
-    float* playerSpeedMult;
 
     bool dead;
     bool justSwapped;
@@ -44,7 +43,7 @@ private:
     void drawDeathEffect(HexagonGame& mHexagonGame);
 
 public:
-    CPlayer(const sf::Vector2f& mPos, const float swapCooldown, float* mPlayerSpeedMulti) noexcept;
+    CPlayer(const sf::Vector2f& mPos, const float swapCooldown) noexcept;
 
     [[gnu::always_inline, nodiscard]] const sf::Vector2f&
     getPosition() const noexcept

--- a/include/SSVOpenHexagon/Components/CPlayer.hpp
+++ b/include/SSVOpenHexagon/Components/CPlayer.hpp
@@ -43,7 +43,7 @@ private:
     void drawDeathEffect(HexagonGame& mHexagonGame);
 
 public:
-    CPlayer(const sf::Vector2f& mPos, const float swapCooldown) noexcept;
+    CPlayer(const sf::Vector2f& mStartPos, const float swapCooldown) noexcept;
 
     [[gnu::always_inline, nodiscard]] const sf::Vector2f&
     getPosition() const noexcept

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -448,6 +448,7 @@ public:
 
     // Input
     [[nodiscard]] bool getInputFocused() const;
+    [[nodiscard]] float getPlayerSpeedMult() const;
     [[nodiscard]] bool getInputSwap() const;
     [[nodiscard]] int getInputMovement() const;
 

--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -58,6 +58,7 @@ struct LevelStatus
     std::vector<TrackedVariable> trackedVariables;
 
     float speedMult{1.f};
+    float playerSpeedMult{1.f};
     float speedInc{0.f};
     float speedMax{0.f};
     float rotationSpeed{0.f};

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -10,11 +10,11 @@ namespace hg
 
 inline constexpr float baseThickness{5.f};
 
-CPlayer::CPlayer(const sf::Vector2f& mPos, const float swapCooldown, float* mPlayerSpeedMulti) noexcept
+CPlayer::CPlayer(const sf::Vector2f& mPos, const float swapCooldown) noexcept
     : startPos{mPos}, pos{mPos}, lastPos{mPos}, hue{0}, angle{0}, lastAngle{0},
       size{Config::getPlayerSize()}, speed{Config::getPlayerSpeed()},
-      focusSpeed{Config::getPlayerFocusSpeed()}, playerSpeedMult{mPlayerSpeedMulti},
-      dead{false}, justSwapped{false}, swapTimer{swapCooldown},
+      focusSpeed{Config::getPlayerFocusSpeed()}, dead{false},
+      justSwapped{false}, swapTimer{swapCooldown},
       swapBlinkTimer{swapCooldown / 6.f}, deadEffectTimer{80.f, false}
 {
 }
@@ -264,7 +264,7 @@ void CPlayer::updateInput(HexagonGame& mHexagonGame, ssvu::FT mFT)
     const int movement{mHexagonGame.getInputMovement()};
 
     const float currentSpeed =
-        *playerSpeedMult * (mHexagonGame.getInputFocused() ? focusSpeed : speed);
+        mHexagonGame.getPlayerSpeedMult() * (mHexagonGame.getInputFocused() ? focusSpeed : speed);
 
     angle += ssvu::toRad(currentSpeed * movement * mFT);
 

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -2,8 +2,21 @@
 // License: Academic Free License ("AFL") v. 3.0
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
-#include "SSVOpenHexagon/Core/HexagonGame.hpp"
+#include "SSVOpenHexagon/Components/CWall.hpp"
+#include "SSVOpenHexagon/Components/CCustomWall.hpp"
 #include "SSVOpenHexagon/Utils/Color.hpp"
+#include "SSVOpenHexagon/Utils/Ticker.hpp"
+
+#include "SSVOpenHexagon/Global/Config.hpp"
+
+#include <SSVStart/Utils/SFML.hpp>
+#include <SSVStart/Utils/Vector2.hpp>
+
+#include <SSVUtils/Core/Common/Frametime.hpp>
+#include <SSVUtils/Core/Utils/Math.hpp>
+
+#include <SFML/System/Vector2.hpp>
+#include <SFML/Graphics/Color.hpp>
 
 namespace hg
 {

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -3,32 +3,18 @@
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
 #include "SSVOpenHexagon/Core/HexagonGame.hpp"
-#include "SSVOpenHexagon/Components/CWall.hpp"
-#include "SSVOpenHexagon/Components/CCustomWall.hpp"
 #include "SSVOpenHexagon/Utils/Color.hpp"
-#include "SSVOpenHexagon/Utils/Ticker.hpp"
-
-#include "SSVOpenHexagon/Global/Config.hpp"
-
-#include <SSVStart/Utils/SFML.hpp>
-#include <SSVStart/Utils/Vector2.hpp>
-
-#include <SSVUtils/Core/Common/Frametime.hpp>
-#include <SSVUtils/Core/Utils/Math.hpp>
-
-#include <SFML/System/Vector2.hpp>
-#include <SFML/Graphics/Color.hpp>
 
 namespace hg
 {
 
 inline constexpr float baseThickness{5.f};
 
-CPlayer::CPlayer(const sf::Vector2f& mPos, const float swapCooldown) noexcept
+CPlayer::CPlayer(const sf::Vector2f& mPos, const float swapCooldown, float* mPlayerSpeedMulti) noexcept
     : startPos{mPos}, pos{mPos}, lastPos{mPos}, hue{0}, angle{0}, lastAngle{0},
       size{Config::getPlayerSize()}, speed{Config::getPlayerSpeed()},
-      focusSpeed{Config::getPlayerFocusSpeed()}, dead{false},
-      justSwapped{false}, swapTimer{swapCooldown},
+      focusSpeed{Config::getPlayerFocusSpeed()}, playerSpeedMult{mPlayerSpeedMulti},
+      dead{false}, justSwapped{false}, swapTimer{swapCooldown},
       swapBlinkTimer{swapCooldown / 6.f}, deadEffectTimer{80.f, false}
 {
 }
@@ -278,7 +264,7 @@ void CPlayer::updateInput(HexagonGame& mHexagonGame, ssvu::FT mFT)
     const int movement{mHexagonGame.getInputMovement()};
 
     const float currentSpeed =
-        mHexagonGame.getInputFocused() ? focusSpeed : speed;
+        *playerSpeedMult * (mHexagonGame.getInputFocused() ? focusSpeed : speed);
 
     angle += ssvu::toRad(currentSpeed * movement * mFT);
 

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -2,6 +2,7 @@
 // License: Academic Free License ("AFL") v. 3.0
 // AFL License page: http://opensource.org/licenses/AFL-3.0
 
+#include "SSVOpenHexagon/Core/HexagonGame.hpp"
 #include "SSVOpenHexagon/Components/CWall.hpp"
 #include "SSVOpenHexagon/Components/CCustomWall.hpp"
 #include "SSVOpenHexagon/Utils/Color.hpp"

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -10,7 +10,7 @@ namespace hg
 
 inline constexpr float baseThickness{5.f};
 
-CPlayer::CPlayer(const sf::Vector2f& mPos, const float swapCooldown) noexcept
+CPlayer::CPlayer(const sf::Vector2f& mStartPos, const float swapCooldown) noexcept
     : startPos{mPos}, pos{mPos}, lastPos{mPos}, hue{0}, angle{0}, lastAngle{0},
       size{Config::getPlayerSize()}, speed{Config::getPlayerSpeed()},
       focusSpeed{Config::getPlayerFocusSpeed()}, dead{false},

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -417,9 +417,9 @@ void HexagonGame::initLua_LevelControl()
         "is created.");
 
     lsVar("PlayerSpeedMult", &LevelStatus::playerSpeedMult,
-          "Gets the speed multiplier of the player",
+          "Gets the speed multiplier of the player.",
 
-          "Sets the speed multiplier of the player");
+          "Sets the speed multiplier of the player.");
 
     lsVar("SpeedInc", &LevelStatus::speedInc,
         "Gets the speed increment of the level. This is applied every level "

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -416,6 +416,11 @@ void HexagonGame::initLua_LevelControl()
         "all walls immediately, and changes apply as soon as the next wall "
         "is created.");
 
+    lsVar("PlayerSpeedMult", &LevelStatus::playerSpeedMult,
+          "Gets the speed multiplier of the player",
+
+          "Sets the speed multiplier of the player");
+
     lsVar("SpeedInc", &LevelStatus::speedInc,
         "Gets the speed increment of the level. This is applied every level "
         "increment to the speed multiplier. Increments are additive.",

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -108,7 +108,7 @@ HexagonGame::HexagonGame(Steam::steam_manager& mSteamManager,
     ssvs::GameWindow& mGameWindow)
     : steamManager(mSteamManager), discordManager(mDiscordManager),
       assets(mAssets), window(mGameWindow),
-      player{ssvs::zeroVec2f, getSwapCooldown(), NULL}, rng{initializeRng()},
+      player{ssvs::zeroVec2f, getSwapCooldown()}, rng{initializeRng()},
       fpsWatcher(window)
 {
     game.onUpdate += [this](ssvu::FT mFT) { update(mFT); };
@@ -252,6 +252,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     // Manager cleanup
     walls.clear();
     cwManager.clear();
+    player = CPlayer{ssvs::zeroVec2f, getSwapCooldown()};
 
     // Timeline cleanup
     timeline.clear();
@@ -290,8 +291,6 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     runLuaFile(levelData->luaScriptPath);
     runLuaFunction<void>("onInit");
     runLuaFunction<void>("onLoad");
-
-    player = CPlayer{ssvs::zeroVec2f, getSwapCooldown(), &levelStatus.playerSpeedMult};
 
     restartId = mId;
     restartFirstTime = false;
@@ -594,6 +593,11 @@ void HexagonGame::setSides(unsigned int mSides)
 [[nodiscard]] bool HexagonGame::getInputFocused() const
 {
     return inputFocused;
+}
+
+[[nodiscard]] float HexagonGame::getPlayerSpeedMult() const
+{
+    return levelStatus.playerSpeedMult;
 }
 
 [[nodiscard]] bool HexagonGame::getInputSwap() const

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -108,7 +108,7 @@ HexagonGame::HexagonGame(Steam::steam_manager& mSteamManager,
     ssvs::GameWindow& mGameWindow)
     : steamManager(mSteamManager), discordManager(mDiscordManager),
       assets(mAssets), window(mGameWindow),
-      player{ssvs::zeroVec2f, getSwapCooldown()}, rng{initializeRng()},
+      player{ssvs::zeroVec2f, getSwapCooldown(), NULL}, rng{initializeRng()},
       fpsWatcher(window)
 {
     game.onUpdate += [this](ssvu::FT mFT) { update(mFT); };
@@ -252,7 +252,6 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     // Manager cleanup
     walls.clear();
     cwManager.clear();
-    player = CPlayer{ssvs::zeroVec2f, getSwapCooldown()};
 
     // Timeline cleanup
     timeline.clear();
@@ -288,10 +287,12 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
     lua = Lua::LuaContext{};
     initLua();
-
     runLuaFile(levelData->luaScriptPath);
     runLuaFunction<void>("onInit");
     runLuaFunction<void>("onLoad");
+
+    player = CPlayer{ssvs::zeroVec2f, getSwapCooldown(), &levelStatus.playerSpeedMult};
+
     restartId = mId;
     restartFirstTime = false;
     setSides(levelStatus.sides);

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -690,7 +690,7 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
         "s_getHueIncrement", [this] { return styleData.hueIncrement; });
 
     // Unused functions
-    for(const auto& un : {"l_setSpeedMult", "l_setSpeedInc", "l_setSpeedMax",
+    for(const auto& un : {"l_setSpeedMult", "l_setPlayerSpeedMult", "l_setSpeedInc", "l_setSpeedMax",
             "l_getSpeedMax", "l_getDelayMin", "l_setDelayMin", "l_setDelayMax",
             "l_getDelayMax", "l_setRotationSpeedMax", "l_setRotationSpeedInc",
             "l_setDelayInc", "l_setFastSpin", "l_setSidesMin", "l_setSidesMax",
@@ -703,7 +703,7 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "l_setRadiusMin", "l_setSwapEnabled", "l_setTutorialMode",
             "l_setIncEnabled", "l_get3dRequired", "l_enableRndSideChanges",
             "l_setDarkenUnevenBackgroundChunk",
-            "l_getDarkenUnevenBackgroundChunk", "l_getSpeedMult",
+            "l_getDarkenUnevenBackgroundChunk", "l_getSpeedMult", "l_getPlayerSpeedMult",
             "l_getDelayMult", "l_addTracked", "l_getRotation", "l_setRotation",
             "l_setDelayMult", "l_getOfficial", "l_getSwapCooldownMult",
             "l_setSwapCooldownMult",


### PR DESCRIPTION
Brief:
use l_setPlayerSpeedMult() to apply a multiplier to the player speed. If not used, by default the multiplier is 1.f. l_getPlayerSpeedMult() returns the value.

Details:
- when player is created a reference to the LevelStatus value playerSpeedMult is passed, so that it can be checked upon during the level;
- the multiplier is applied onto the player speed in CPlayer::updateInput().

Extra notes:
removed a few redundant includes.