### PR TITLE
Fix pack list in main menu shifting horizontally when longest named pack is selected

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1320,24 +1320,22 @@ void MenuGame::drawLevelSelection()
         "(" + toStr(currentIndex + 1) + "/" + toStr(levelDataIds.size()) + ")",
         txtLMus, {20.f, getGlobalTop(lname) - 30.f});
 
-    string packNames{"Installed packs:\n"}, longestPackName;
+    string packNames{"Installed packs:\n"}, curPack, longestPackName;
     for(const auto& n : assets.getPackInfos())
     {
         if(packData.id == n.id)
-            packNames += "  >>> ";
+            curPack = "  >>> ";
         else
-            packNames += "      ";
+            curPack = "      ";
 
         const PackData& nPD{assets.getPackData(n.id)};
-
-        string curPack = nPD.name + " (by " + nPD.author + ") [v" +
+        curPack += nPD.name + " (by " + nPD.author + ") [v" +
                   std::to_string(nPD.version) + "]\n";
         packNames.append(curPack);
 
-        // Width used to calculate origin should always be the longest pack name + ">>> "
+        // Width used to calculate origin should always be the longest pack name + "  >>> "
         // otherwise the list shifts around depending on the currently selected item
-        curPack = ">>> " + curPack;
-        if(string(curPack).length() > longestPackName.length())
+        if(curPack.length() > longestPackName.length())
             longestPackName = curPack;
     }
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1320,30 +1320,36 @@ void MenuGame::drawLevelSelection()
         "(" + toStr(currentIndex + 1) + "/" + toStr(levelDataIds.size()) + ")",
         txtLMus, {20.f, getGlobalTop(lname) - 30.f});
 
-    std::string packNames{"Installed packs:\n"};
+    string packNames{"Installed packs:\n"}, longestPackName;
     for(const auto& n : assets.getPackInfos())
     {
-        packNames += "  ";
-
         if(packData.id == n.id)
-        {
-            packNames += ">>> ";
-        }
+            packNames += "  >>> ";
         else
-        {
-            packNames += "    ";
-        }
+            packNames += "      ";
 
         const PackData& nPD{assets.getPackData(n.id)};
 
-        packNames.append(nPD.name + " (by " + nPD.author + ") [v" +
-                         std::to_string(nPD.version) + "]\n");
+        string curPack = nPD.name + " (by " + nPD.author + ") [v" +
+                  std::to_string(nPD.version) + "]\n";
+        packNames.append(curPack);
+
+        // Width used to calculate origin should always be the longest pack name + ">>> "
+        // otherwise the list shifts around depending on the currently selected item
+        curPack = ">>> " + curPack;
+        if(string(curPack).length() > longestPackName.length())
+            longestPackName = curPack;
     }
 
-    Utils::uppercasify(packNames);
+    // calculate origin offset
+    Utils::uppercasify(longestPackName);
+    txtPacks.setString(longestPackName);
+    float packsWidth = getGlobalWidth(txtPacks);
 
+    // render packs list
+    Utils::uppercasify(packNames);
     txtPacks.setString(packNames);
-    txtPacks.setOrigin(getGlobalWidth(txtPacks), getGlobalHeight(txtPacks));
+    txtPacks.setOrigin(packsWidth, getGlobalHeight(txtPacks));
     txtPacks.setPosition({w - 20.f, getGlobalTop(bottomBar) - 15.f});
     txtPacks.setFillColor(styleData.getTextColor());
     render(txtPacks);


### PR DESCRIPTION
As the title states.

The issue is caused by the fact that the position of the text to be rendered is calculated depending on the width of the longest line.
Although this length has a different value when the longest line is selected because extra the selected pack indicator ">>> " takes more horizontal space than "    ".

To solve the problem, while the string of the pack list is being created the longest line is found and stored, and the horizontal offset of the list is calculates depending on its length.