### PR TITLE
Fix onUnload's priority

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -129,6 +129,7 @@ private:
 
     random_number_generator::seed_type lastSeed;
     replay_data lastReplayData;
+    bool lastFirstPlay;
     double lastPlayedScore;
 
     std::string restartId;

--- a/include/SSVOpenHexagon/Core/Replay.hpp
+++ b/include/SSVOpenHexagon/Core/Replay.hpp
@@ -113,7 +113,7 @@ struct replay_file
     replay_data _data;        // Input data.
     std::string _pack_id;     // Id of the selected pack.
     std::string _level_id;    // Id of the played level.
-    bool _first_play;		  // If this was achieved on first level play
+    bool _first_play;		// If this was achieved on first level play.
     float _difficulty_mult;   // Played difficulty multiplier.
     double _played_score; // Played score (This can be an overridden score or
                           // frametime, excluding pauses).

--- a/include/SSVOpenHexagon/Core/Replay.hpp
+++ b/include/SSVOpenHexagon/Core/Replay.hpp
@@ -113,6 +113,7 @@ struct replay_file
     replay_data _data;        // Input data.
     std::string _pack_id;     // Id of the selected pack.
     std::string _level_id;    // Id of the played level.
+    bool _first_play;		  // If this was achieved on first level play
     float _difficulty_mult;   // Played difficulty multiplier.
     double _played_score; // Played score (This can be an overridden score or
                           // frametime, excluding pauses).

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -262,6 +262,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
         // Save data for immediate replay.
         lastSeed = rng.seed();
         lastReplayData = replay_data{};
+        lastFirstPlay = mFirstPlay;
 
         // Clear any existing active replay.
         activeReplay.reset();
@@ -283,6 +284,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
             ._data{lastReplayData},
             ._pack_id{mPackId},
             ._level_id{mId},
+            ._first_play{lastFirstPlay},
             ._difficulty_mult{mDifficultyMult},
             ._played_score{lastPlayedScore},
         });
@@ -293,6 +295,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
         activeReplay->replayLevelName = Utils::toUppercase(levelData->name);
 
         rng = random_number_generator{activeReplay->replayFile._seed};
+		firstPlay = activeReplay->replayFile._first_play;
     }
 
     // Audio cleanup
@@ -365,11 +368,11 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     initLua();
     runLuaFile(levelData->luaScriptPath);
 
-    if(!mFirstPlay)
+    if(!firstPlay)
     {
         runLuaFunction<void>("onUnload");
     }
-    
+
     runLuaFunction<void>("onInit");
 
     restartId = mId;

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -361,14 +361,15 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     // LUA context and game status cleanup
     inputImplCCW = inputImplCW = inputImplBothCWCCW = false;
 
+    lua = Lua::LuaContext{};
+    initLua();
+    runLuaFile(levelData->luaScriptPath);
+
     if(!mFirstPlay)
     {
         runLuaFunction<void>("onUnload");
     }
-
-    lua = Lua::LuaContext{};
-    initLua();
-    runLuaFile(levelData->luaScriptPath);
+    
     runLuaFunction<void>("onInit");
 
     restartId = mId;

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -295,7 +295,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
         activeReplay->replayLevelName = Utils::toUppercase(levelData->name);
 
         rng = random_number_generator{activeReplay->replayFile._seed};
-		firstPlay = activeReplay->replayFile._first_play;
+        firstPlay = activeReplay->replayFile._first_play;
     }
 
     // Audio cleanup

--- a/src/SSVOpenHexagon/Core/Replay.cpp
+++ b/src/SSVOpenHexagon/Core/Replay.cpp
@@ -173,6 +173,7 @@ replay_player::get_current_and_move_forward() noexcept
            _data == rhs._data &&                       //
            _pack_id == rhs._pack_id &&                 //
            _level_id == rhs._level_id &&               //
+           _first_play == rhs._first_play && 		   //
            _difficulty_mult == rhs._difficulty_mult && //
            _played_score == rhs._played_score;
 }
@@ -230,6 +231,7 @@ replay_player::get_current_and_move_forward() noexcept
 
     SSVOH_TRY(write_str(_pack_id));
     SSVOH_TRY(write_str(_level_id));
+    SSVOH_TRY(write(_first_play));
     SSVOH_TRY(write(_difficulty_mult));
     SSVOH_TRY(write(_played_score));
 
@@ -276,6 +278,7 @@ replay_player::get_current_and_move_forward() noexcept
 
     SSVOH_TRY(read_str(_pack_id));
     SSVOH_TRY(read_str(_level_id));
+    SSVOH_TRY(read(_first_play));
     SSVOH_TRY(read(_difficulty_mult));
     SSVOH_TRY(read(_played_score));
 

--- a/test/Replay.t.cpp
+++ b/test/Replay.t.cpp
@@ -141,6 +141,7 @@ static void test_replay_file_serialization_to_buffer()
         ._data{rd},
         ._pack_id{"totally real pack id"},
         ._level_id{"legit level id"},
+        ._first_play{false},
         ._difficulty_mult{2.5f},
         ._played_score{100.f}
         //
@@ -176,6 +177,7 @@ static void test_replay_file_serialization_to_file()
         ._data{rd},
         ._pack_id{"totally real pack id"},
         ._level_id{"legit level id"},
+        ._first_play{false},
         ._difficulty_mult{2.5f},
         ._played_score{100.f}
         //


### PR DESCRIPTION
This is a minor shift in the code so that way onUnload is now called after an initial runthrough of the entire Lua file. This is done to help ensure that onUnload is used for the purpose of changing level features after a first playthrough of the level, like intended.