### PR TITLE
Keyboard bind menu item bugfix

### DIFF
--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -1042,6 +1042,7 @@ typedef std::pair<setFuncTrig, Trigger> keyboardBindsConfigs;
     if(index >= MAX_BINDS)
     {
         index = 0;
+        trig.getCombos()[index].clearBind();
     }
 
     if(key > -1)


### PR DESCRIPTION
When a new key was assigned to a bind slot already taken by another key, the latter one was not wiped beforehand, causing load/read/save config issues.
This is what happened to the config.json file
```
"t_rotate_ccw" : 
[
	[ "kD", "kP" ], // causes issues
	[ "kC" ]
],
```