### PR TITLE
Bind controls beta testers suggestions

### DIFF
--- a/_RELEASE/config.json
+++ b/_RELEASE/config.json
@@ -60,56 +60,85 @@
 	"t_down" : 
 	[
 		[ "kS" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_exit" : 
 	[
-		[ "kC" ],
+		[ "kT" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_focus" : 
 	[
 		[ "kLShift" ],
-		[ "bXButton1" ]
+		[ "bXButton1" ],
+		[ "" ],
+		[ "" ]
 	],
 	"t_force_restart" : 
 	[
+		[ "kUp" ],
+		[ "kR" ],
 		[ "" ],
 		[ "" ]
 	],
 	"t_replay" : 
 	[
+		[ "kY" ],
+		[ "" ],
 		[ "" ],
 		[ "" ]
 	],
 	"t_restart" : 
 	[
-		[ "" ],
+		[ "bMiddle" ],
+		[ "kSpace" ],
+		[ "kReturn" ],
 		[ "" ]
 	],
 	"t_rotate_ccw" : 
 	[
+		[ "kA" ],
 		[ "kLeft" ],
-		[ "kA" ]
+		[ "bLeft" ],
+		[ "" ]
 	],
 	"t_rotate_cw" : 
 	[
+		[ "kD" ],
 		[ "kRight" ],
-		[ "kD" ]
+		[ "bRight" ],
+		[ "" ]
 	],
 	"t_screenshot" : 
 	[
 		[ "kF12" ],
+		[ "" ],
+		[ "" ],
+		[ "" ]
+	],
+	"t_select" : 
+	[
+		[ "kSpace" ],
+		[ "bMiddle" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_swap" : 
 	[
+		[ "bMiddle" ],
 		[ "kSpace" ],
-		[ "bMiddle" ]
+		[ "" ],
+		[ "" ]
 	],
 	"t_up" : 
 	[
 		[ "kW" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"text_padding" : 8.0,

--- a/include/SSVOpenHexagon/Core/BindControl.hpp
+++ b/include/SSVOpenHexagon/Core/BindControl.hpp
@@ -35,19 +35,24 @@ private:
     using Trigger = ssvs::Input::Trigger;
     using TriggerGetter = std::function<ssvs::Input::Trigger()>;
     using SizeGetter = std::function<int()>;
-    using BindReturn =
-        std::function<std::pair<int, Trigger>(ssvs::KKey, ssvs::MBtn)>;
+    using AddBind =
+        std::function<void(ssvs::KKey, ssvs::MBtn)>;
     using Callback =
         std::function<void(const ssvs::Input::Trigger&, const int)>;
 
     TriggerGetter triggerGetter;
     SizeGetter sizeGetter;
-    BindReturn addBind;
+    AddBind addBind;
     ssvms::Action clearBind;
     Callback callback;
 
     [[nodiscard]] int getRealSize(
         const std::vector<ssvs::Input::Combo>& combos) const;
+
+    [[nodiscard]] std::string bindToHumanReadableName(const std::string_view s) const
+    {
+        return std::string(s.substr(1, s.length() - 1));
+    }
 
 public:
     template <typename TFuncGet, typename TFuncSet, typename TFuncClear,
@@ -61,7 +66,7 @@ public:
           }},
           addBind{[this, mFuncSet](
                       const ssvs::KKey setKey, const ssvs::MBtn setBtn) {
-              return mFuncSet(setKey, setBtn, sizeGetter());
+              mFuncSet(setKey, setBtn, sizeGetter());
           }},
           clearBind{[this, mFuncClear] { mFuncClear(sizeGetter()); }},
           callback{mCallback}

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -49,6 +49,7 @@ enum Tid
     RotateCCW = 0,
     RotateCW,
     Focus,
+    Select,
     Exit,
     ForceRestart,
     Restart,
@@ -239,19 +240,6 @@ private:
     [[nodiscard]] bool isEnteringText()
     {
         return state == States::ETLPNew;
-    }
-
-    [[nodiscard]] bool isValidKeyBind(ssvs::KKey key) const noexcept
-    {
-        using KKey = ssvs::KKey;
-
-        // do not allow keys with hardcoded behaviors
-        return key != KKey::Unknown && key != KKey::F1 && key != KKey::F2 &&
-               key != KKey::F3 && key != KKey::F4 && key != KKey::LAlt &&
-               key != KKey::Return && key != KKey::BackSpace &&
-               key != KKey::Escape && key != KKey::J && key != KKey::K &&
-               key != KKey::L && key != KKey::Up && key != KKey::Down &&
-               key != KKey::R && key != KKey::Y;
     }
 
     [[nodiscard]] ssvms::Menu* getCurrentMenu() noexcept

--- a/include/SSVOpenHexagon/Global/Config.hpp
+++ b/include/SSVOpenHexagon/Global/Config.hpp
@@ -144,6 +144,7 @@ void keyboardBindsSanityCheck();
 [[nodiscard]] ssvs::Input::Trigger getTriggerRotateCCW();
 [[nodiscard]] ssvs::Input::Trigger getTriggerRotateCW();
 [[nodiscard]] ssvs::Input::Trigger getTriggerFocus();
+[[nodiscard]] ssvs::Input::Trigger getTriggerSelect();
 [[nodiscard]] ssvs::Input::Trigger getTriggerExit();
 [[nodiscard]] ssvs::Input::Trigger getTriggerForceRestart();
 [[nodiscard]] ssvs::Input::Trigger getTriggerRestart();
@@ -153,32 +154,23 @@ void keyboardBindsSanityCheck();
 [[nodiscard]] ssvs::Input::Trigger getTriggerUp();
 [[nodiscard]] ssvs::Input::Trigger getTriggerDown();
 
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerRotateCCW(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerRotateCW(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerFocus(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerExit(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger>
-reassignBindTriggerForceRestart(int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerRestart(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerReplay(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger>
-reassignBindTriggerScreenshot(int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerSwap(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerUp(
-    int key, int btn, int index);
-[[nodiscard]] std::pair<int, ssvs::Input::Trigger> reassignBindTriggerDown(
-    int key, int btn, int index);
+void addBindTriggerRotateCCW(int key, int btn, int index);
+void addBindTriggerRotateCW(int key, int btn, int index);
+void addBindTriggerFocus(int key, int btn, int index);
+void addBindTriggerSelect(int key, int btn, int index);
+void addBindTriggerExit(int key, int btn, int index);
+void addBindTriggerForceRestart(int key, int btn, int index);
+void addBindTriggerRestart(int key, int btn, int index);
+void addBindTriggerReplay(int key, int btn, int index);
+void addBindTriggerScreenshot(int key, int btn, int index);
+void addBindTriggerSwap(int key, int btn, int index);
+void addBindTriggerUp(int key, int btn, int index);
+void addBindTriggerDown(int key, int btn, int index);
 
 void setTriggerRotateCCW(ssvs::Input::Trigger trig);
 void setTriggerRotateCW(ssvs::Input::Trigger trig);
 void setTriggerFocus(ssvs::Input::Trigger trig);
+void setTriggerSelect(ssvs::Input::Trigger trig);
 void setTriggerExit(ssvs::Input::Trigger trig);
 void setTriggerForceRestart(ssvs::Input::Trigger trig);
 void setTriggerRestart(ssvs::Input::Trigger trig);
@@ -191,6 +183,7 @@ void setTriggerDown(ssvs::Input::Trigger trig);
 void clearBindTriggerRotateCCW(int index);
 void clearBindTriggerRotateCW(int index);
 void clearBindTriggerFocus(int index);
+void clearBindTriggerSelect(int index);
 void clearBindTriggerExit(int index);
 void clearBindTriggerForceRestart(int index);
 void clearBindTriggerRestart(int index);

--- a/include/SSVOpenHexagon/Global/UtilsJson.hpp
+++ b/include/SSVOpenHexagon/Global/UtilsJson.hpp
@@ -66,7 +66,8 @@ struct Converter<ssvs::KKey>
     {
         if(mValue == T::Unknown)
         {
-            arch(mObj, "");
+            std::string empty;
+            arch(mObj, empty);
             return;
         }
 
@@ -105,16 +106,6 @@ struct Converter<ssvs::Input::Combo>
 
             if(str.empty())
             {
-                mValue.addKey(ssvs::KKey::Unknown);
-            }
-            else if(ssvs::isKKeyHardcoded(str))
-            {
-                ssvu::lo("ssvs::getInputComboFromJSON")
-                    << "<" << i
-                    << "> is an hardcoded key bind, an empty bind has been put "
-                       "in its place"
-                    << std::endl;
-
                 mValue.addKey(ssvs::KKey::Unknown);
             }
             else if(ssvs::isKKeyNameValid(str))

--- a/include/SSVOpenHexagon/Global/UtilsJson.hpp
+++ b/include/SSVOpenHexagon/Global/UtilsJson.hpp
@@ -67,7 +67,7 @@ struct Converter<ssvs::KKey>
         if(mValue == T::Unknown)
         {
             std::string empty;
-            arch(mObj, empty);
+            arch(mObj, empty);  // TODO: using `""` seems to be bugged
             return;
         }
 

--- a/misc/default_config.json
+++ b/misc/default_config.json
@@ -49,56 +49,85 @@
 	"t_down" : 
 	[
 		[ "kS" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_exit" : 
 	[
 		[ "kT" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_focus" : 
 	[
 		[ "kLShift" ],
-		[ "bXButton1" ]
+		[ "bXButton1" ],
+		[ "" ],
+		[ "" ]
 	],
 	"t_force_restart" : 
 	[
-		[ "kG" ],
+		[ "kUp" ],
+		[ "kR" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_replay" : 
 	[
-		[ "bMiddle" ],
+		[ "kY" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_restart" : 
 	[
-		[ "kB" ],
+		[ "bMiddle" ],
+		[ "kSpace" ],
+		[ "kReturn" ],
 		[ "" ]
 	],
 	"t_rotate_ccw" : 
 	[
+		[ "kA" ],
 		[ "kLeft" ],
-		[ "kA" ]
+		[ "bLeft" ],
+		[ "" ]
 	],
 	"t_rotate_cw" : 
 	[
+		[ "kD" ],
 		[ "kRight" ],
-		[ "kD" ]
+		[ "bRight" ],
+		[ "" ]
 	],
 	"t_screenshot" : 
 	[
 		[ "kF12" ],
+		[ "" ],
+		[ "" ],
+		[ "" ]
+	],
+	"t_select" : 
+	[
+		[ "kSpace" ],
+		[ "bMiddle" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_swap" : 
 	[
+		[ "bMiddle" ],
 		[ "kSpace" ],
+		[ "" ],
 		[ "" ]
 	],
 	"t_up" : 
 	[
 		[ "kW" ],
+		[ "" ],
+		[ "" ],
 		[ "" ]
 	],
 	"j_select" : 0,

--- a/src/SSVOpenHexagon/Core/BindControl.cpp
+++ b/src/SSVOpenHexagon/Core/BindControl.cpp
@@ -104,14 +104,7 @@ void KeyboardBindControl::newKeyboardBind(
     }
 
     // assign the pressed key to the config value
-    auto [unboundID, trig] = addBind(key, btn);
-
-    // key was assigned to another function and was unbound.
-    // This trigger must be refreshed as well
-    if(unboundID > -1)
-    {
-        callback(trig, unboundID);
-    }
+    addBind(key, btn);
 
     // apply the new bind in game
     callback(triggerGetter(), ID);
@@ -144,7 +137,7 @@ void KeyboardBindControl::newKeyboardBind(
             }
 
             // names are shifted compared to the Key enum
-            bindNames += ssvs::getKKeyName(ssvs::KKey(j - 1));
+            bindNames += bindToHumanReadableName(ssvs::getKKeyName(ssvs::KKey(j - 1)));
             break;
         }
 
@@ -162,7 +155,7 @@ void KeyboardBindControl::newKeyboardBind(
             }
 
             // same as with keys
-            bindNames += ssvs::getMBtnName(ssvs::MBtn(j - 1));
+            bindNames += bindToHumanReadableName(ssvs::getMBtnName(ssvs::MBtn(j - 1)));
             break;
         }
     }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -166,16 +166,6 @@ HexagonGame::HexagonGame(Steam::steam_manager& mSteamManager,
         ssvs::Input::Type::Once, Tid::ForceRestart);
 
     game.addInput(
-        {{sf::Keyboard::Key::R}}, // hardcoded
-        [this](ssvu::FT /*unused*/) {
-            if(status.hasDied)
-            {
-                status.mustStateChange = StateChange::MustRestart;
-            }
-        },
-        ssvs::Input::Type::Once);
-
-    game.addInput(
         Config::getTriggerRestart(), // editable
         [this](ssvu::FT /*unused*/) {
             if(status.hasDied)
@@ -184,16 +174,6 @@ HexagonGame::HexagonGame(Steam::steam_manager& mSteamManager,
             }
         },
         ssvs::Input::Type::Once, Tid::Restart);
-
-    game.addInput(
-        {{sf::Keyboard::Key::Y}}, // hardcoded
-        [this](ssvu::FT /*unused*/) {
-            if(status.hasDied)
-            {
-                status.mustStateChange = StateChange::MustReplay;
-            }
-        },
-        ssvs::Input::Type::Once);
 
     game.addInput(
         Config::getTriggerReplay(), // editable

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -880,18 +880,23 @@ void setSaveLocalBestReplayToFile(bool mX)
 
     // Agglomerate binds close to each other, leave empty
     // spots at the end
-    decltype(combos.size()) i = combos.size() - 1;
-    Combo *firstCombo, *secondCombo;
-    for(; i > 0; --i)
+    for(auto it1 = combos.begin(), it2 = it1 + 1; it1 != combos.end() - 1; ++it1, it2 = it1 + 1)
     {
-        firstCombo = &combos.at(i - 1);
-        secondCombo = &combos.at(i);
-
-        if(firstCombo->isUnbound() && !secondCombo->isUnbound())
+        if(!it1->isUnbound())
         {
-            *firstCombo = *secondCombo;
-            secondCombo->clearBind();
+            continue;
         }
+
+        while(it2->isUnbound() && it2++ != combos.end())
+            ;
+
+        if(it2 == combos.end())
+        {
+            break;
+        }
+
+        *it1 = *it2;
+        it2->clearBind();
     }
 
     return trig;

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -93,6 +93,7 @@ using namespace ssvu;
     X(triggerRotateCCW, Trigger, "t_rotate_ccw")                           \
     X(triggerRotateCW, Trigger, "t_rotate_cw")                             \
     X(triggerFocus, Trigger, "t_focus")                                    \
+    X(triggerSelect, Trigger, "t_select")                                  \
     X(triggerExit, Trigger, "t_exit")                                      \
     X(triggerForceRestart, Trigger, "t_force_restart")                     \
     X(triggerRestart, Trigger, "t_restart")                                \
@@ -860,9 +861,9 @@ void setSaveLocalBestReplayToFile(bool mX)
 //**************************************************
 // Game start check
 
-#define MAX_BINDS 2
+#define MAX_BINDS 4
 
-[[nodiscard]] Trigger resizeTrigger(Trigger trig, Combo& bindList) noexcept
+[[nodiscard]] Trigger resizeTrigger(Trigger trig) noexcept
 {
     std::vector<Combo>& combos = trig.getCombos();
 
@@ -877,72 +878,19 @@ void setSaveLocalBestReplayToFile(bool mX)
         combos.emplace_back(Combo({KKey::Unknown}));
     }
 
-    // having the first spot unbound and the second bound may raise issues
-    Combo& firstCombo = combos.at(0);
-    Combo& secondCombo = combos.at(1);
-    if(firstCombo.isUnbound() && !secondCombo.isUnbound())
+    // Agglomerate binds close to each other, leave empty
+    // spots at the end
+    decltype(combos.size()) i = combos.size() - 1;
+    Combo *firstCombo, *secondCombo;
+    for(; i > 0; --i)
     {
-        firstCombo = secondCombo;
-        secondCombo.clearBind();
-    }
+        firstCombo = &combos.at(i - 1);
+        secondCombo = &combos.at(i);
 
-    // now check if the keys in the combos are already assigned
-    // to another function, and if so unbind them
-    int i;
-    KKey keyBind;
-    MBtn btnBind;
-    for(auto& b : combos)
-    {
-        bool alreadyBound = false;
-        const auto& keys = b.getKeys();
-        for(i = 0; i < int(kKeyCount); ++i)
+        if(firstCombo->isUnbound() && !secondCombo->isUnbound())
         {
-            keyBind = KKey(i);
-
-            // if the key is assigned to the combo we are scanning...
-            if(getKeyBit(keys, keyBind))
-            {
-                // ...but it has already been assigned to a previous combo...
-                if(getKeyBit(bindList.getKeys(), keyBind))
-                {
-                    // ...remove it from this bind
-                    b.clearBind();
-                    alreadyBound = true;
-                }
-                else
-                {
-                    // ...otherwise add it to the list for future checks
-                    bindList.addKey(keyBind);
-                    alreadyBound = true;
-                }
-            }
-        }
-
-        // A combo either has a key or a mouse button bound.
-        // If a key is already detected to be assigned there
-        // is no need to check the buttons
-        if(alreadyBound)
-        {
-            continue;
-        }
-
-        const auto& btns = b.getBtns();
-        for(i = 0; i < int(mBtnCount); ++i)
-        {
-            btnBind = MBtn(i);
-
-            // same as with the keys above
-            if(getBtnBit(btns, btnBind))
-            {
-                if(getBtnBit(bindList.getBtns(), btnBind))
-                {
-                    b.clearBind();
-                }
-                else
-                {
-                    bindList.addBtn(btnBind);
-                }
-            }
+            *firstCombo = *secondCombo;
+            secondCombo->clearBind();
         }
     }
 
@@ -951,99 +899,22 @@ void setSaveLocalBestReplayToFile(bool mX)
 
 void keyboardBindsSanityCheck()
 {
-    ssvs::Input::Combo bindList =
-        ssvs::Input::Combo({KKey::Unknown}, {MBtn::Left});
-    triggerRotateCCW() = resizeTrigger(triggerRotateCCW(), bindList);
-    triggerRotateCW() = resizeTrigger(triggerRotateCW(), bindList);
-    triggerFocus() = resizeTrigger(triggerFocus(), bindList);
-    triggerExit() = resizeTrigger(triggerExit(), bindList);
-    triggerForceRestart() = resizeTrigger(triggerForceRestart(), bindList);
-    triggerRestart() = resizeTrigger(triggerRestart(), bindList);
-    triggerReplay() = resizeTrigger(triggerReplay(), bindList);
-    triggerScreenshot() = resizeTrigger(triggerScreenshot(), bindList);
-    triggerSwap() = resizeTrigger(triggerSwap(), bindList);
-    triggerUp() = resizeTrigger(triggerUp(), bindList);
-    triggerDown() = resizeTrigger(triggerDown(), bindList);
+    triggerRotateCCW() = resizeTrigger(triggerRotateCCW());
+    triggerRotateCW() = resizeTrigger(triggerRotateCW());
+    triggerFocus() = resizeTrigger(triggerFocus());
+    triggerSelect() = resizeTrigger(triggerSelect());
+    triggerExit() = resizeTrigger(triggerExit());
+    triggerForceRestart() = resizeTrigger(triggerForceRestart());
+    triggerRestart() = resizeTrigger(triggerRestart());
+    triggerReplay() = resizeTrigger(triggerReplay());
+    triggerScreenshot() = resizeTrigger(triggerScreenshot());
+    triggerSwap() = resizeTrigger(triggerSwap());
+    triggerUp() = resizeTrigger(triggerUp());
+    triggerDown() = resizeTrigger(triggerDown());
 }
 
 //**************************************************
 // Add new key binds
-
-typedef void (*setFuncTrig)(Trigger trig);
-typedef std::pair<setFuncTrig, Trigger> keyboardBindsConfigs;
-
-[[nodiscard]] std::pair<int, Trigger> checkTriggerReassignment(
-    KKey key, MBtn btn)
-{
-    keyboardBindsConfigs funcs[] = {{setTriggerRotateCCW, triggerRotateCCW()},
-        {setTriggerRotateCW, triggerRotateCW()},
-        {setTriggerFocus, triggerFocus()}, {setTriggerExit, triggerExit()},
-        {setTriggerForceRestart, triggerForceRestart()},
-        {setTriggerRestart, triggerRestart()},
-        {setTriggerReplay, triggerReplay()},
-        {setTriggerScreenshot, triggerScreenshot()},
-        {setTriggerSwap, triggerSwap()}, {setTriggerUp, triggerUp()},
-        {setTriggerDown, triggerDown()}};
-
-    for(int i = 0; i < int(sizeof(funcs) / sizeof(funcs[0])); ++i)
-    {
-        auto& trig = get<Trigger>(funcs[i]);
-        std::vector<Combo>& Combos = trig.getCombos();
-        for(int j = 0; j < MAX_BINDS; ++j)
-        {
-            Combo& combo = Combos.at(j);
-
-            // if key is not -1 this combo has a keyboard key assigned
-            if(key > KKey::Unknown)
-            {
-                // if the key is the one that has just been
-                // assigned to a new trigger...
-                if(getKeyBit(combo.getKeys(), key))
-                {
-                    // ...if the combo after this one is not empty
-                    // move the bind to the current one
-                    if(!j && !Combos.at(j + 1).isUnbound())
-                    {
-                        Combo& secondCombo = Combos.at(j + 1);
-                        combo = secondCombo;
-                        secondCombo.clearBind();
-                    }
-                    else
-                    {
-                        // ...otherwise just clear it
-                        combo.clearBind();
-                    }
-
-                    get<setFuncTrig>(funcs[i])(trig);
-                    return {i, trig};
-                }
-            }
-            else
-            {
-                // Same as above except with mouse buttons
-                if(getBtnBit(combo.getBtns(), btn))
-                {
-                    if(!j && !Combos.at(j + 1).isUnbound())
-                    {
-                        Combo& secondCombo = Combos.at(j + 1);
-                        combo = secondCombo;
-                        secondCombo.clearBind();
-                    }
-                    else
-                    {
-                        combo.clearBind();
-                    }
-
-                    get<setFuncTrig>(funcs[i])(trig);
-                    return {i, trig};
-                }
-            }
-        }
-    }
-
-    // key had no previous bind, second returned value does not matter
-    return {-1, get<Trigger>(funcs[0])};
-}
 
 [[nodiscard]] Trigger rebindTrigger(
     Trigger trig, int key, int btn, int index) noexcept
@@ -1066,86 +937,53 @@ typedef std::pair<setFuncTrig, Trigger> keyboardBindsConfigs;
     return trig;
 }
 
-std::pair<int, Trigger> reassignBindTriggerRotateCCW(
-    int key, int btn, int index)
+void addBindTriggerRotateCCW(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerRotateCCW() = rebindTrigger(triggerRotateCCW(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerRotateCW(int key, int btn, int index)
+void addBindTriggerRotateCW(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerRotateCW() = rebindTrigger(triggerRotateCW(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerFocus(int key, int btn, int index)
+void addBindTriggerFocus(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerFocus() = rebindTrigger(triggerFocus(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerExit(int key, int btn, int index)
+void addBindTriggerSelect(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
+    triggerSelect() = rebindTrigger(triggerSelect(), key, btn, index);
+}
+void addBindTriggerExit(int key, int btn, int index)
+{
     triggerExit() = rebindTrigger(triggerExit(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerForceRestart(
-    int key, int btn, int index)
+void addBindTriggerForceRestart(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
-    triggerForceRestart() =
-        rebindTrigger(triggerForceRestart(), key, btn, index);
-    return reassign;
+    triggerForceRestart() = rebindTrigger(triggerForceRestart(), key, btn, index);
 }
-std::pair<int, Trigger> reassignBindTriggerRestart(int key, int btn, int index)
+void addBindTriggerRestart(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerRestart() = rebindTrigger(triggerRestart(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerReplay(int key, int btn, int index)
+void addBindTriggerReplay(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerReplay() = rebindTrigger(triggerReplay(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerScreenshot(
-    int key, int btn, int index)
+void addBindTriggerScreenshot(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerScreenshot() = rebindTrigger(triggerScreenshot(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerSwap(int key, int btn, int index)
+void addBindTriggerSwap(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerSwap() = rebindTrigger(triggerSwap(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerUp(int key, int btn, int index)
+void addBindTriggerUp(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerUp() = rebindTrigger(triggerUp(), key, btn, index);
-    return reassign;
 }
-std::pair<int, Trigger> reassignBindTriggerDown(int key, int btn, int index)
+void addBindTriggerDown(int key, int btn, int index)
 {
-    std::pair<int, Trigger> reassign =
-        checkTriggerReassignment(KKey(key), MBtn(btn));
     triggerDown() = rebindTrigger(triggerDown(), key, btn, index);
-    return reassign;
 }
 
 //**************************************************
@@ -1167,6 +1005,10 @@ void clearBindTriggerRotateCW(int index)
 void clearBindTriggerFocus(int index)
 {
     triggerFocus() = clearTriggerBind(triggerFocus(), index);
+}
+void clearBindTriggerSelect(int index)
+{
+    triggerSelect() = clearTriggerBind(triggerSelect(), index);
 }
 void clearBindTriggerExit(int index)
 {
@@ -1216,6 +1058,10 @@ Trigger getTriggerFocus()
 {
     return triggerFocus();
 }
+Trigger getTriggerSelect()
+{
+    return triggerSelect();
+}
 Trigger getTriggerExit()
 {
     return triggerExit();
@@ -1263,6 +1109,10 @@ void setTriggerRotateCW(Trigger trig)
 void setTriggerFocus(Trigger trig)
 {
     triggerFocus() = trig;
+}
+void setTriggerSelect(Trigger trig)
+{
+    triggerSelect() = trig;
 }
 void setTriggerExit(Trigger trig)
 {


### PR DESCRIPTION
- Increased keys per bind cap from 2 to 4;
- allowed assigning a same key to multiple binds;
- fixed an issue that caused OH to crash when the config was saved closing the game (fix in UtilJson.hpp, solution looks cheap and something else might fit better);
- added "t_select" to config.json, and added such bind customization in the menu;
- removed hardcoded keys bind prohibition;
- removed a slew of now useless Config functions;
- limited hardcoded key actions to Enter, Escape, Up, Down, Right, and Left.