### PR TITLE
Options menu items to reset configs to defaults

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -262,6 +262,7 @@ private:
     }
 
     void reloadLevelAssets();
+    void refreshBinds();
     int noActions{0};
 
 public:

--- a/include/SSVOpenHexagon/Global/Config.hpp
+++ b/include/SSVOpenHexagon/Global/Config.hpp
@@ -21,6 +21,8 @@ namespace hg::Config
 {
 
 void loadConfig(const std::vector<std::string>& mOverridesIds);
+void resetConfigToDefaults();
+void resetBindsToDefaults();
 void saveConfig();
 
 [[nodiscard]] bool isEligibleForScore();

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -442,6 +442,10 @@ void MenuGame::initMenus()
     main.create<i::Toggle>(
         "official mode", &Config::getOfficial, &Config::setOfficial);
     main.create<i::Single>("exit game", [this] { window.stop(); });
+    main.create<i::Single>("reset configs to default", [this]{
+        Config::resetConfigToDefaults();
+        refreshBinds();
+    });
     main.create<i::Single>("back", [this] { state = States::SMain; });
 
 
@@ -570,6 +574,10 @@ void MenuGame::initMenus()
         &Config::setRotateToStart);
     play.create<i::Goto>("keyboard and mouse", keyboard);
     play.create<i::Goto>("joystick", joystick);
+    play.create<i::Single>("reset binds to defaults",[this]{
+        Config::resetBindsToDefaults();
+        refreshBinds();
+    });
     play.create<i::GoBack>("back");
 
     // Keyboard binds
@@ -679,6 +687,41 @@ void MenuGame::initMenus()
     debug.create<i::Slider>("timescale", &Config::getTimescale,
         &Config::setTimescale, 0.1f, 2.f, 0.05f);
     debug.create<i::GoBack>("back");
+}
+
+void MenuGame::refreshBinds()
+{
+    // Keyboard-mouse
+    Trigger triggers[] = {
+        Config::getTriggerRotateCCW(), Config::getTriggerRotateCW(),
+        Config::getTriggerFocus(), Config::getTriggerSelect(),
+        Config::getTriggerExit(), Config::getTriggerForceRestart(),
+        Config::getTriggerRestart(), Config::getTriggerReplay(),
+        Config::getTriggerScreenshot(), Config::getTriggerSwap(),
+        Config::getTriggerUp(), Config::getTriggerDown()
+    };
+
+    size_t i;
+    for(i = 0; i < sizeof(triggers) / sizeof(triggers[0]); ++i)
+    {
+        game.refreshTrigger(triggers[i], i);
+        hexagonGame.refreshTrigger(triggers[i], i);
+    }
+
+    // Joystick
+    unsigned int buttons[] = {
+        Config::getJoystickSelect(), Config::getJoystickExit(),
+        Config::getJoystickFocus(), Config::getJoystickSwap(),
+        Config::getJoystickForceRestart(), Config::getJoystickRestart(),
+        Config::getJoystickReplay(), Config::getJoystickScreenshot(),
+        Config::getJoystickOptionMenu(), Config::getJoystickChangePack(),
+        Config::getJoystickCreateProfile()
+    };
+
+    for(i = 0; i < sizeof(buttons) / sizeof(buttons[0]); ++i)
+    {
+        hg::Joystick::setJoystickBind(buttons[i], i);
+    }
 }
 
 void MenuGame::leftAction()

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -167,14 +167,14 @@ static void syncAllToObj()
 
 static void resetAllFromObj()
 {
-#define X(name, type, key) name().syncFrom(ssvuj::getFromFile("../misc/default_config.json"));
+#define X(name, type, key) name().syncFrom(ssvuj::getFromFile("default_config.json"));
     X_LINKEDVALUES
 #undef X
 }
 
 static void resetBindsFromObj()
 {
-#define X(name, type, key) name().syncFrom(ssvuj::getFromFile("../misc/default_config.json"));
+#define X(name, type, key) name().syncFrom(ssvuj::getFromFile("default_config.json"));
     X_BINDSLINKEDVALUES
 #undef X
 }
@@ -236,7 +236,7 @@ void resetConfigToDefaults()
 {
     lo("::resetConfigToDefaults") << "resetting configs\n";
 
-    if(!ssvufs::Path{"../misc/default_config.json"}.exists<ssvufs::Type::File>())
+    if(!ssvufs::Path{"default_config.json"}.exists<ssvufs::Type::File>())
     {
         ssvu::lo("hg::Config::resetConfigToDefaults()")
             << "`default_config.json` file not found, config reset aborted\n";
@@ -262,7 +262,7 @@ void resetBindsToDefaults()
 {
     lo("::resetBindsToDefaults") << "resetting binds to defaults\n";
 
-    if(!ssvufs::Path{"../misc/default_config.json"}.exists<ssvufs::Type::File>())
+    if(!ssvufs::Path{"default_config.json"}.exists<ssvufs::Type::File>())
     {
         ssvu::lo("hg::Config::resetBindsToDefaults()")
             << "`default_config.json` file not found, config reset aborted\n";


### PR DESCRIPTION
"reset configs to default" in the main options menu resets all configs.
"reset binds to defaults" in the gameplay submenu only resets all the keyboard-mouse-joystick binds.