### PR TITLE
Increased Dialog Box Customization

### DIFF
--- a/include/SSVOpenHexagon/Core/BindControl.hpp
+++ b/include/SSVOpenHexagon/Core/BindControl.hpp
@@ -107,7 +107,7 @@ class JoystickBindControl final : public BindControlBase
 {
 private:
     using ValueGetter = std::function<unsigned int()>;
-    using ValueSetter = std::function<unsigned int(const unsigned int)>;
+    using ValueSetter = std::function<int(const unsigned int)>;
     using Callback = std::function<void(const unsigned int, const unsigned int)>;
 
     ValueGetter valueGetter;

--- a/include/SSVOpenHexagon/Core/BindControl.hpp
+++ b/include/SSVOpenHexagon/Core/BindControl.hpp
@@ -106,9 +106,9 @@ public:
 class JoystickBindControl final : public BindControlBase
 {
 private:
-    using ValueGetter = std::function<int()>;
-    using ValueSetter = std::function<int(const int)>;
-    using Callback = std::function<void(const unsigned int, const int)>;
+    using ValueGetter = std::function<unsigned int()>;
+    using ValueSetter = std::function<unsigned int(const unsigned int)>;
+    using Callback = std::function<void(const unsigned int, const unsigned int)>;
 
     ValueGetter valueGetter;
     ValueSetter setButton;
@@ -129,7 +129,7 @@ public:
     [[nodiscard]] bool isWaitingForBind() override;
     [[nodiscard]] bool erase() override;
 
-    void newJoystickBind(const int joy);
+    void newJoystickBind(const unsigned int joy);
 
     [[nodiscard]] std::string getName() const override;
 };

--- a/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
@@ -20,8 +20,8 @@ class StyleData;
 enum DBoxDraw
 {
     topLeft = 0,
-    centered,
-    centeredUpperHalf
+    center,
+    centerUpperHalf
 };
 
 class HexagonDialogBox
@@ -29,6 +29,7 @@ class HexagonDialogBox
 private:
     using KKey = sf::Keyboard::Key;
     using Color = sf::Color;
+    using Vector2 = sf::Vector2f;
 
     HGAssets& assets;
     ssvs::GameWindow& window;
@@ -53,19 +54,22 @@ private:
     KKey keyToClose{KKey::Unknown};
 
     void drawText(const Color& txtColor, const float xOffset, const float yOffset);
-    void drawCentered(const Color& txtColor, const Color& backdropColor);
-    void drawCenteredUpperHalf(const Color& txtColor, const Color& backdropColor);
+    void drawBox(const Color& frameColor, const float x1, const float x2,
+        const float y1, const float y2);
+    void drawCenter(const Color& txtColor, const Color& backdropColor);
+    void drawCenterUpperHalf(const Color& txtColor, const Color& backdropColor);
     void drawTopLeft(const Color& txtColor, const Color& backdropColor);
 
 public:
     HexagonDialogBox(HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
 
-    void createDialogBox(const std::string& output, const int charSize,
+    void create(const std::string& output, const int charSize,
         const float mFrameSize, const int mDrawMode,
         const float xPos = 0.f, const float yPos = 0.f);
-    void createDialogBox(const std::string& output, const int charSize,
+    void create(const std::string& output, const int charSize,
         const float mFrameSize, const int mDrawMode,
-        const KKey mKeyToClose, const float mXPos = 0.f, const float mYPos = 0.f);
+        const KKey mKeyToClose, const float mXPos = 0.f,
+        const float mYPos = 0.f);
 
     void draw(const Color& txtColor, const Color& backdropColor);
     void clearDialogBox();

--- a/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
@@ -17,6 +17,13 @@ namespace hg
 class HGAssets;
 class StyleData;
 
+enum DBoxDraw
+{
+    regular = 0,
+    centered,
+    levelReload
+};
+
 class HexagonDialogBox
 {
 private:
@@ -31,15 +38,22 @@ private:
 
     float dialogHeight{0.f};
     float dialogWidth{0.f};
-    float frameOffset{0.f};
+    float frameSize{0.f};
+    float doubleFrameSize{0.f};
     float lineHeight{0.f};
+
+    int drawMode{0};
+    float xPos{0.f};
+    float yPos{0.f};
 
 public:
     HexagonDialogBox(
         HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
 
-    void createDialogBox(const std::string& output, const int charSize);
+    void createDialogBox(const std::string& output, const int charSize,
+        const float frameSize, const int mDrawMode, const float xPos = 0.f, const float yPos = 0.f);
     void drawDialogBox();
+    void drawDialogBoxCentered();
     void clearDialogBox();
 
     [[nodiscard]] bool empty() const noexcept

--- a/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
@@ -21,18 +21,21 @@ enum DBoxDraw
 {
     topLeft = 0,
     centered,
-    levelReload
+    centeredUpperHalf
 };
 
 class HexagonDialogBox
 {
 private:
     using KKey = sf::Keyboard::Key;
+    using Color = sf::Color;
 
     HGAssets& assets;
     ssvs::GameWindow& window;
     StyleData& styleData;
     sf::Font& imagine;
+
+    std::function<void(const Color&, const Color&)> drawFunc;
 
     Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
     std::vector<std::string> dialogText;
@@ -44,15 +47,18 @@ private:
     float doubleFrameSize{0.f};
     float lineHeight{0.f};
 
-    int drawMode{0};
     float xPos{0.f};
     float yPos{0.f};
 
     KKey keyToClose{KKey::Unknown};
 
+    void drawText(const Color& txtColor, const float xOffset, const float yOffset);
+    void drawCentered(const Color& txtColor, const Color& backdropColor);
+    void drawCenteredUpperHalf(const Color& txtColor, const Color& backdropColor);
+    void drawTopLeft(const Color& txtColor, const Color& backdropColor);
+
 public:
-    HexagonDialogBox(
-        HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
+    HexagonDialogBox(HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
 
     void createDialogBox(const std::string& output, const int charSize,
         const float mFrameSize, const int mDrawMode,
@@ -60,8 +66,8 @@ public:
     void createDialogBox(const std::string& output, const int charSize,
         const float mFrameSize, const int mDrawMode,
         const KKey mKeyToClose, const float mXPos = 0.f, const float mYPos = 0.f);
-    void drawDialogBox();
-    void drawDialogBoxCentered();
+
+    void draw(const Color& txtColor, const Color& backdropColor);
     void clearDialogBox();
 
     [[nodiscard]] KKey getKeyToClose() const noexcept

--- a/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
@@ -17,7 +17,7 @@ namespace hg
 class HGAssets;
 class StyleData;
 
-enum DBoxDraw
+enum class DBoxDraw
 {
     topLeft = 0,
     center,
@@ -29,14 +29,14 @@ class HexagonDialogBox
 private:
     using KKey = sf::Keyboard::Key;
     using Color = sf::Color;
-    using Vector2 = sf::Vector2f;
+    using DrawFunc = std::function<void(const Color&, const Color&)>;
 
     HGAssets& assets;
     ssvs::GameWindow& window;
     StyleData& styleData;
     sf::Font& imagine;
 
-    std::function<void(const Color&, const Color&)> drawFunc;
+    DrawFunc drawFunc;
 
     Utils::FastVertexVector<sf::PrimitiveType::Quads> dialogFrame;
     std::vector<std::string> dialogText;
@@ -53,6 +53,8 @@ private:
 
     KKey keyToClose{KKey::Unknown};
 
+    [[nodiscard]] DrawFunc drawModeToDrawFunc(DBoxDraw drawMode);
+
     void drawText(const Color& txtColor, const float xOffset, const float yOffset);
     void drawBox(const Color& frameColor, const float x1, const float x2,
         const float y1, const float y2);
@@ -64,10 +66,10 @@ public:
     HexagonDialogBox(HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
 
     void create(const std::string& output, const int charSize,
-        const float mFrameSize, const int mDrawMode,
+        const float mFrameSize, const DBoxDraw mDrawMode,
         const float xPos = 0.f, const float yPos = 0.f);
     void create(const std::string& output, const int charSize,
-        const float mFrameSize, const int mDrawMode,
+        const float mFrameSize, const DBoxDraw mDrawMode,
         const KKey mKeyToClose, const float mXPos = 0.f,
         const float mYPos = 0.f);
 

--- a/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
@@ -19,7 +19,7 @@ class StyleData;
 
 enum DBoxDraw
 {
-    regular = 0,
+    topLeft = 0,
     centered,
     levelReload
 };

--- a/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonDialogBox.hpp
@@ -27,6 +27,8 @@ enum DBoxDraw
 class HexagonDialogBox
 {
 private:
+    using KKey = sf::Keyboard::Key;
+
     HGAssets& assets;
     ssvs::GameWindow& window;
     StyleData& styleData;
@@ -46,16 +48,26 @@ private:
     float xPos{0.f};
     float yPos{0.f};
 
+    KKey keyToClose{KKey::Unknown};
+
 public:
     HexagonDialogBox(
         HGAssets& mAssets, ssvs::GameWindow& window, StyleData& styleData);
 
     void createDialogBox(const std::string& output, const int charSize,
-        const float frameSize, const int mDrawMode, const float xPos = 0.f, const float yPos = 0.f);
+        const float mFrameSize, const int mDrawMode,
+        const float xPos = 0.f, const float yPos = 0.f);
+    void createDialogBox(const std::string& output, const int charSize,
+        const float mFrameSize, const int mDrawMode,
+        const KKey mKeyToClose, const float mXPos = 0.f, const float mYPos = 0.f);
     void drawDialogBox();
     void drawDialogBoxCentered();
     void clearDialogBox();
 
+    [[nodiscard]] KKey getKeyToClose() const noexcept
+    {
+        return keyToClose;
+    }
     [[nodiscard]] bool empty() const noexcept
     {
         return dialogText.empty();

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -266,11 +266,6 @@ private:
     void setIgnoreInputs(const int keyPresses);
     int ignoreInputs{0};
 
-    // Specific keys to close the dialog box
-    int dBoxCloseKey{-1};
-    int dBoxCloseMouse{-1};
-    int dBoxCloseJoystick{-1};
-
 public:
     MenuGame(Steam::steam_manager& mSteamManager,
         Discord::discord_manager& mDiscordManager, HGAssets& mAssets,

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -262,7 +262,8 @@ private:
     }
 
     void reloadLevelAssets();
-    int noActions{0};
+    void setIgnoreInputs(const int keyPresses);
+    int ignoreInputs{0};
 
 public:
     MenuGame(Steam::steam_manager& mSteamManager,

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -262,8 +262,14 @@ private:
     }
 
     void reloadLevelAssets();
+
     void setIgnoreInputs(const int keyPresses);
     int ignoreInputs{0};
+
+    // Specific keys to close the dialog box
+    int dBoxCloseKey{-1};
+    int dBoxCloseMouse{-1};
+    int dBoxCloseJoystick{-1};
 
 public:
     MenuGame(Steam::steam_manager& mSteamManager,

--- a/include/SSVOpenHexagon/Global/Config.hpp
+++ b/include/SSVOpenHexagon/Global/Config.hpp
@@ -209,17 +209,17 @@ void joystickBindsSanityCheck();
 [[nodiscard]] unsigned int getJoystickChangePack();
 [[nodiscard]] unsigned int getJoystickCreateProfile();
 
-[[nodiscard]] int reassignToJoystickSelect(unsigned int button);
-[[nodiscard]] int reassignToJoystickExit(unsigned int button);
-[[nodiscard]] int reassignToJoystickFocus(unsigned int button);
-[[nodiscard]] int reassignToJoystickSwap(unsigned int button);
-[[nodiscard]] int reassignToJoystickForceRestart(unsigned int button);
-[[nodiscard]] int reassignToJoystickRestart(unsigned int button);
-[[nodiscard]] int reassignToJoystickReplay(unsigned int button);
-[[nodiscard]] int reassignToJoystickScreenshot(unsigned int button);
-[[nodiscard]] int reassignToJoystickOptionMenu(unsigned int button);
-[[nodiscard]] int reassignToJoystickChangePack(unsigned int button);
-[[nodiscard]] int reassignToJoystickCreateProfile(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickSelect(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickExit(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickFocus(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickSwap(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickForceRestart(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickRestart(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickReplay(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickScreenshot(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickOptionMenu(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickChangePack(unsigned int button);
+[[nodiscard]] unsigned int reassignToJoystickCreateProfile(unsigned int button);
 
 void setJoystickSelect(unsigned int button);
 void setJoystickExit(unsigned int button);

--- a/include/SSVOpenHexagon/Global/Config.hpp
+++ b/include/SSVOpenHexagon/Global/Config.hpp
@@ -209,17 +209,17 @@ void joystickBindsSanityCheck();
 [[nodiscard]] unsigned int getJoystickChangePack();
 [[nodiscard]] unsigned int getJoystickCreateProfile();
 
-[[nodiscard]] unsigned int reassignToJoystickSelect(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickExit(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickFocus(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickSwap(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickForceRestart(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickRestart(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickReplay(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickScreenshot(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickOptionMenu(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickChangePack(unsigned int button);
-[[nodiscard]] unsigned int reassignToJoystickCreateProfile(unsigned int button);
+[[nodiscard]] int reassignToJoystickSelect(unsigned int button);
+[[nodiscard]] int reassignToJoystickExit(unsigned int button);
+[[nodiscard]] int reassignToJoystickFocus(unsigned int button);
+[[nodiscard]] int reassignToJoystickSwap(unsigned int button);
+[[nodiscard]] int reassignToJoystickForceRestart(unsigned int button);
+[[nodiscard]] int reassignToJoystickRestart(unsigned int button);
+[[nodiscard]] int reassignToJoystickReplay(unsigned int button);
+[[nodiscard]] int reassignToJoystickScreenshot(unsigned int button);
+[[nodiscard]] int reassignToJoystickOptionMenu(unsigned int button);
+[[nodiscard]] int reassignToJoystickChangePack(unsigned int button);
+[[nodiscard]] int reassignToJoystickCreateProfile(unsigned int button);
 
 void setJoystickSelect(unsigned int button);
 void setJoystickExit(unsigned int button);

--- a/src/SSVOpenHexagon/Core/BindControl.cpp
+++ b/src/SSVOpenHexagon/Core/BindControl.cpp
@@ -193,7 +193,7 @@ void JoystickBindControl::exec()
     return true;
 }
 
-void JoystickBindControl::newJoystickBind(const int joy)
+void JoystickBindControl::newJoystickBind(const unsigned int joy)
 {
     // stop if the pressed button is already assigned to this bind
     if(joy == valueGetter())

--- a/src/SSVOpenHexagon/Core/HexagonDialogBox.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonDialogBox.cpp
@@ -50,6 +50,14 @@ void HexagonDialogBox::createDialogBox(const std::string& output, const int char
     yPos = mYPos;
 }
 
+void HexagonDialogBox::createDialogBox(const std::string& output, const int charSize,
+    const float mFrameSize, const int mDrawMode, const KKey mKeyToClose,
+    const float mXPos, const float mYPos)
+{
+    createDialogBox(output, charSize, mFrameSize, mDrawMode, mXPos, mYPos);
+    keyToClose = mKeyToClose;
+}
+
 void HexagonDialogBox::drawDialogBox()
 {
     if(drawMode)
@@ -178,6 +186,7 @@ void HexagonDialogBox::clearDialogBox()
     assets.playSound("select.ogg");
     dialogFrame.clear();
     dialogText.clear();
+    keyToClose = KKey::Unknown;
 }
 
 } // namespace hg

--- a/src/SSVOpenHexagon/Core/HexagonDialogBox.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonDialogBox.cpp
@@ -132,13 +132,8 @@ void HexagonDialogBox::drawDialogBoxCentered()
     const float leftBorder = (w - dialogWidth) / 2.f + xPos,
                 rightBorder = (w + dialogWidth) / 2.f;
 
-    float heightOffsetTop, heightOffsetBottom;
-    if(drawMode == 2)
-    {
-        heightOffsetTop = dialogHeight;
-        heightOffsetBottom = 0.f;
-    }
-    else
+    float heightOffsetTop = dialogHeight, heightOffsetBottom = 0.f;
+    if(drawMode == DBoxDraw::centered)
     {
         heightOffsetTop = heightOffsetBottom = dialogHeight / 2.f;
     }

--- a/src/SSVOpenHexagon/Core/HexagonDialogBox.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonDialogBox.cpp
@@ -18,7 +18,7 @@ HexagonDialogBox::HexagonDialogBox(
 }
 
 void HexagonDialogBox::create(const std::string& output, const int charSize,
-    const float mFrameSize, const int mDrawMode, const float mXPos, const float mYPos)
+    const float mFrameSize, const DBoxDraw mDrawMode, const float mXPos, const float mYPos)
 {
     txtDialog.setCharacterSize(charSize);
     txtDialog.setString(output);
@@ -31,26 +31,7 @@ void HexagonDialogBox::create(const std::string& output, const int charSize,
     frameSize = mFrameSize;
     doubleFrameSize = 2.f * frameSize;
 
-    switch(mDrawMode)
-    {
-    case DBoxDraw::topLeft:
-        drawFunc = [this](const Color& txtColor, const Color& backdropColor) {
-            drawTopLeft(txtColor, backdropColor);
-        };
-        break;
-
-    case DBoxDraw::center:
-        drawFunc = [this](const Color& txtColor, const Color& backdropColor) {
-            drawCenter(txtColor, backdropColor);
-        };
-        break;
-
-    case DBoxDraw::centerUpperHalf:
-        drawFunc = [this](const Color& txtColor, const Color& backdropColor) {
-          drawCenterUpperHalf(txtColor, backdropColor);
-        };
-        break;
-    }
+    drawFunc = drawModeToDrawFunc(mDrawMode);
 
     xPos = mXPos;
     yPos = mYPos;
@@ -71,11 +52,33 @@ void HexagonDialogBox::create(const std::string& output, const int charSize,
 }
 
 void HexagonDialogBox::create(const std::string& output, const int charSize,
-    const float mFrameSize, const int mDrawMode, const KKey mKeyToClose,
+    const float mFrameSize, const DBoxDraw mDrawMode, const KKey mKeyToClose,
     const float mXPos, const float mYPos)
 {
     create(output, charSize, mFrameSize, mDrawMode, mXPos, mYPos);
     keyToClose = mKeyToClose;
+}
+
+HexagonDialogBox::DrawFunc HexagonDialogBox::drawModeToDrawFunc(DBoxDraw drawMode)
+{
+    switch(drawMode)
+    {
+        case DBoxDraw::topLeft:
+            return [this](const Color& txtColor, const Color& backdropColor) {
+                drawTopLeft(txtColor, backdropColor);
+            };
+
+        case DBoxDraw::center:
+            return [this](const Color& txtColor, const Color& backdropColor) {
+                drawCenter(txtColor, backdropColor);
+            };
+
+        default:
+            assert(drawMode == DBoxDraw::centerUpperHalf);
+            return [this](const Color& txtColor, const Color& backdropColor) {
+                drawCenterUpperHalf(txtColor, backdropColor);
+            };
+    }
 }
 
 void HexagonDialogBox::draw(const Color& txtColor, const Color& backdropColor)
@@ -86,11 +89,12 @@ void HexagonDialogBox::draw(const Color& txtColor, const Color& backdropColor)
 void HexagonDialogBox::drawBox(const Color& frameColor, const float x1,
     const float x2, const float y1, const float y2)
 {
-    sf::Vector2f p1{x1, y1}; // top left
-    sf::Vector2f p2{x2, y1}; // top right
-    sf::Vector2f p3{x2, y2}; // bottom right
-    sf::Vector2f p4{x1, y2}; // bottom left
-    dialogFrame.batch_unsafe_emplace_back(frameColor, p1, p2, p3, p4);
+    sf::Vector2f topLeft{x1, y1};
+    sf::Vector2f topRight{x2, y1};
+    sf::Vector2f bottomRight{x2, y2};
+    sf::Vector2f bottomLeft{x1, y2};
+    dialogFrame.batch_unsafe_emplace_back(frameColor,
+        topLeft, topRight, bottomRight, bottomLeft);
 }
 
 void HexagonDialogBox::drawText(const Color& txtColor, const float xOffset, const float yOffset)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1059,7 +1059,8 @@ void MenuGame::reloadLevelAssets()
 
 	assets.playSound("select.ogg");
     setIgnoreInputs(2);
-    dialogBox.createDialogBox(reloadOutput, 26, 10.f, DBoxDraw::levelReload);
+    dialogBox.createDialogBox(reloadOutput, 26, 10.f,
+        DBoxDraw::centeredUpperHalf);
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)
@@ -1617,7 +1618,7 @@ void MenuGame::draw()
 
     if(!dialogBox.empty())
     {
-        dialogBox.drawDialogBox();
+        dialogBox.draw(styleData.getTextColor(), styleData.getColor(0));
     }
 }
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1059,7 +1059,7 @@ void MenuGame::reloadLevelAssets()
 
 	assets.playSound("select.ogg");
     setIgnoreInputs(2);
-    dialogBox.create(reloadOutput, 26, 10.f, DBoxDraw::topLeft);
+    dialogBox.create(reloadOutput, 26, 10.f, DBoxDraw::centerUpperHalf);
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1069,7 +1069,7 @@ void MenuGame::reloadLevelAssets()
 
 	assets.playSound("select.ogg");
     setIgnoreInputs(2);
-    dialogBox.createDialogBox(reloadOutput, 26, 10.f, DBoxDraw::centered);
+    dialogBox.createDialogBox(reloadOutput, 26, 10.f, DBoxDraw::levelReload);
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -91,12 +91,6 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
             dialogBox.clearDialogBox();
             game.ignoreAllInputs(false);
             hg::Joystick::ignoreAllPresses(false);
-
-            // Reset keys to the "no specific press required"
-            // state
-            dBoxCloseKey = -1;
-            dBoxCloseMouse = -1;
-            dBoxCloseJoystick = -1;
         }
     };
 
@@ -121,9 +115,8 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
             KKey key = mEvent.key.code;
             if(!dialogBox.empty())
             {
-                // no particular key has been picked to close the box
-                if((dBoxCloseKey == -1 && dBoxCloseMouse == -1 &&
-                    dBoxCloseJoystick == -1) || dBoxCloseKey == int(key))
+                if(dialogBox.getKeyToClose() == KKey::Unknown ||
+                    key == dialogBox.getKeyToClose())
                 {
                     ignoreInputs--;
                 }
@@ -185,14 +178,13 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 return;
             }
 
-            MBtn btn = mEvent.mouseButton.button;
             if(!dialogBox.empty())
             {
-                if((dBoxCloseKey == -1 && dBoxCloseMouse == -1 &&
-                    dBoxCloseJoystick == -1) || dBoxCloseMouse == int(btn))
+                if(dialogBox.getKeyToClose() != KKey::Unknown)
                 {
-                    ignoreInputs--;
+                    return;
                 }
+                ignoreInputs--;
                 checkCloseDialogBox();
                 return;
             }
@@ -215,7 +207,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                     return;
                 }
 
-                bc->newKeyboardBind(KKey::Unknown, btn);
+                bc->newKeyboardBind(KKey::Unknown, mEvent.mouseButton.button);
                 game.ignoreAllInputs(false);
                 hg::Joystick::ignoreAllPresses(false);
                 assets.playSound("beep.ogg");
@@ -237,19 +229,17 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 return;
             }
 
-            unsigned int joy = mEvent.joystickButton.button;
             if(!dialogBox.empty())
             {
-                if((dBoxCloseKey == -1 && dBoxCloseMouse == -1 &&
-                   dBoxCloseJoystick == -1) || dBoxCloseJoystick == int(joy))
+                if(dialogBox.getKeyToClose() != KKey::Unknown)
                 {
-                    ignoreInputs--;
+                    return;
                 }
+                ignoreInputs--;
                 checkCloseDialogBox();
                 return;
             }
 
-            // close dialogbox after the second key release
             if(!(--ignoreInputs))
             {
                 if(getCurrentMenu() == nullptr)
@@ -268,7 +258,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                     return;
                 }
 
-                bc->newJoystickBind(joy);
+                bc->newJoystickBind(mEvent.joystickButton.button);
                 game.ignoreAllInputs(false);
                 hg::Joystick::ignoreAllPresses(false);
                 assets.playSound("beep.ogg");

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1059,8 +1059,7 @@ void MenuGame::reloadLevelAssets()
 
 	assets.playSound("select.ogg");
     setIgnoreInputs(2);
-    dialogBox.createDialogBox(reloadOutput, 26, 10.f,
-        DBoxDraw::centeredUpperHalf);
+    dialogBox.create(reloadOutput, 26, 10.f, DBoxDraw::topLeft);
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -72,12 +72,10 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
 
     // To make the epilepsy warning go away with
     // any key press
-    noActions = 1;
-    game.ignoreAllInputs(true);
-    hg::Joystick::ignoreAllPresses(true);
+    setIgnoreInputs(1);
 
     const auto checkCloseEpilepsyWarning = [this]() {
-        if(!(--noActions))
+        if(!(--ignoreInputs))
         {
             // TODO: remove when welcome screen is implemented
             playLocally();
@@ -88,7 +86,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     };
 
     const auto checkCloseDialogBox = [this]() {
-        if(!(--noActions))
+        if(!(--ignoreInputs))
         {
             dialogBox.clearDialogBox();
             game.ignoreAllInputs(false);
@@ -100,7 +98,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
         [this, checkCloseEpilepsyWarning, checkCloseDialogBox](
             const Event& mEvent) {
             // don't do anything if inputs are being processed as usual
-            if(!noActions)
+            if(!ignoreInputs)
             {
                 return;
             }
@@ -128,11 +126,11 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 getCurrentMenu()->getItem().exec(); // turn off bind inputting
                 game.ignoreAllInputs(false);
                 hg::Joystick::ignoreAllPresses(false);
-                noActions = 0;
+                ignoreInputs = 0;
                 return;
             }
 
-            if(!(--noActions))
+            if(!(--ignoreInputs))
             {
                 dialogBox.clearDialogBox();
 
@@ -148,7 +146,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 if(bc == nullptr)
                 {
                     assets.playSound("error.ogg");
-                    noActions = 1;
+                    ignoreInputs = 1;
                     return;
                 }
 
@@ -164,7 +162,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     game.onEvent(Event::EventType::MouseButtonReleased) +=
         [this, checkCloseEpilepsyWarning, checkCloseDialogBox](
             const Event& mEvent) {
-            if(!noActions)
+            if(!ignoreInputs)
             {
                 return;
             }
@@ -181,7 +179,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 return;
             }
 
-            if(!(--noActions))
+            if(!(--ignoreInputs))
             {
                 if(getCurrentMenu() == nullptr)
                 {
@@ -195,7 +193,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 if(bc == nullptr)
                 {
                     assets.playSound("error.ogg");
-                    noActions = 1;
+                    ignoreInputs = 1;
                     return;
                 }
 
@@ -210,7 +208,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     game.onEvent(Event::EventType::JoystickButtonReleased) +=
         [this, checkCloseEpilepsyWarning, checkCloseDialogBox](
             const Event& mEvent) {
-            if(!noActions)
+            if(!ignoreInputs)
             {
                 return;
             }
@@ -228,7 +226,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
             }
 
             // close dialogbox after the second key release
-            if(!(--noActions))
+            if(!(--ignoreInputs))
             {
                 if(getCurrentMenu() == nullptr)
                 {
@@ -242,7 +240,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 if(bc == nullptr)
                 {
                     assets.playSound("error.ogg");
-                    noActions = 1;
+                    ignoreInputs = 1;
                     return;
                 }
 
@@ -262,6 +260,13 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
     levelDataIds =
         assets.getLevelIdsByPack(assets.getPackInfos().at(packIdx).id);
     setIndex(0);
+}
+
+void MenuGame::setIgnoreInputs(const int keyPresses)
+{
+    ignoreInputs = keyPresses;
+    game.ignoreAllInputs(true);
+    hg::Joystick::ignoreAllPresses(true);
 }
 
 bool MenuGame::loadCommandLineLevel(
@@ -782,9 +787,7 @@ void MenuGame::okAction()
             return;
         }
 
-        noActions = 2;
-        game.ignoreAllInputs(true);
-        hg::Joystick::ignoreAllPresses(true);
+        setIgnoreInputs(2);
         touchDelay = 10.f;
     }
     else if(state == States::ETLPNew)
@@ -1011,12 +1014,6 @@ void MenuGame::reloadLevelAssets()
         return;
     }
 
-    // needs to be two because the dialog box reacts to key releases.
-    // First key release is the one of the key press that made the dialog
-    // box pop up, the second one belongs to the key press that closes it
-    noActions = 2;
-    assets.playSound("beep.ogg");
-
     auto [success, reloadOutput] = assets.reloadLevelData(
         levelData->packId, levelData->packPath, levelData->id);
 
@@ -1046,9 +1043,9 @@ void MenuGame::reloadLevelAssets()
     reloadOutput += "\npress any key to close this message\n";
     Utils::uppercasify(reloadOutput);
 
-    dialogBox.createDialogBox(reloadOutput, 26);
-    game.ignoreAllInputs(true);
-    hg::Joystick::ignoreAllPresses(true);
+	assets.playSound("select.ogg");
+    setIgnoreInputs(2);
+    dialogBox.createDialogBox(reloadOutput, 26, 10.f, DBoxDraw::centered);
 }
 
 void MenuGame::initLua(Lua::LuaContext& mLua)

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -1285,77 +1285,77 @@ using JoystickBindsConfigs = std::pair<SetFuncJoy, unsigned int>;
     return -1;
 }
 
-unsigned int reassignToJoystickSelect(unsigned int button)
+int reassignToJoystickSelect(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickSelect() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickExit(unsigned int button)
+int reassignToJoystickExit(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickExit() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickFocus(unsigned int button)
+int reassignToJoystickFocus(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickFocus() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickSwap(unsigned int button)
+int reassignToJoystickSwap(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickSwap() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickForceRestart(unsigned int button)
+int reassignToJoystickForceRestart(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickForceRestart() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickRestart(unsigned int button)
+int reassignToJoystickRestart(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickRestart() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickReplay(unsigned int button)
+int reassignToJoystickReplay(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickReplay() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickScreenshot(unsigned int button)
+int reassignToJoystickScreenshot(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickScreenshot() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickOptionMenu(unsigned int button)
+int reassignToJoystickOptionMenu(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickOptionMenu() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickChangePack(unsigned int button)
+int reassignToJoystickChangePack(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickChangePack() = button;
     return unboundID;
 }
 
-unsigned int reassignToJoystickCreateProfile(unsigned int button)
+int reassignToJoystickCreateProfile(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickCreateProfile() = button;

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -867,6 +867,19 @@ void setSaveLocalBestReplayToFile(bool mX)
 {
     std::vector<Combo>& combos = trig.getCombos();
 
+    // Remove empty slots to agglomerate all binds
+    // close to each other
+    for(auto it = combos.begin(); it != combos.end();)
+    {
+        if(it->isUnbound())
+        {
+            combos.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
     while(combos.size() >
           MAX_BINDS) // if the config has more binds than are supported
     {
@@ -876,28 +889,6 @@ void setSaveLocalBestReplayToFile(bool mX)
                                      // spots with unbound combos
     {
         combos.emplace_back(Combo({KKey::Unknown}));
-    }
-
-    // Agglomerate binds close to each other, leave empty
-    // spots at the end
-    for(auto it1 = combos.begin(), it2 = it1 + 1; it1 != combos.end() - 1;
-        ++it1, it2 = it1 + 1)
-    {
-        if(!it1->isUnbound())
-        {
-            continue;
-        }
-
-        while(it2->isUnbound() && it2++ != combos.end())
-            ;
-
-        if(it2 == combos.end())
-        {
-            break;
-        }
-
-        *it1 = *it2;
-        it2->clearBind();
     }
 
     return trig;
@@ -1294,77 +1285,77 @@ using JoystickBindsConfigs = std::pair<SetFuncJoy, unsigned int>;
     return -1;
 }
 
-int reassignToJoystickSelect(unsigned int button)
+unsigned int reassignToJoystickSelect(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickSelect() = button;
     return unboundID;
 }
 
-int reassignToJoystickExit(unsigned int button)
+unsigned int reassignToJoystickExit(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickExit() = button;
     return unboundID;
 }
 
-int reassignToJoystickFocus(unsigned int button)
+unsigned int reassignToJoystickFocus(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickFocus() = button;
     return unboundID;
 }
 
-int reassignToJoystickSwap(unsigned int button)
+unsigned int reassignToJoystickSwap(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickSwap() = button;
     return unboundID;
 }
 
-int reassignToJoystickForceRestart(unsigned int button)
+unsigned int reassignToJoystickForceRestart(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickForceRestart() = button;
     return unboundID;
 }
 
-int reassignToJoystickRestart(unsigned int button)
+unsigned int reassignToJoystickRestart(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickRestart() = button;
     return unboundID;
 }
 
-int reassignToJoystickReplay(unsigned int button)
+unsigned int reassignToJoystickReplay(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickReplay() = button;
     return unboundID;
 }
 
-int reassignToJoystickScreenshot(unsigned int button)
+unsigned int reassignToJoystickScreenshot(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickScreenshot() = button;
     return unboundID;
 }
 
-int reassignToJoystickOptionMenu(unsigned int button)
+unsigned int reassignToJoystickOptionMenu(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickOptionMenu() = button;
     return unboundID;
 }
 
-int reassignToJoystickChangePack(unsigned int button)
+unsigned int reassignToJoystickChangePack(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickChangePack() = button;
     return unboundID;
 }
 
-int reassignToJoystickCreateProfile(unsigned int button)
+unsigned int reassignToJoystickCreateProfile(unsigned int button)
 {
     const int unboundID = checkButtonReassignment(button);
     joystickCreateProfile() = button;


### PR DESCRIPTION
```
void create(const std::string& output, const int charSize, const float mFrameSize, const int mDrawMode,
        const float mXPos = 0.f, const float mYPos = 0.f);
void create(const std::string& output, const int charSize, const float mFrameSize, const int mDrawMode,
        const KKey mKeyToClose, const float mXPos = 0.f, const float mYPos = 0.f);
void draw(const Color& txtColor, const Color& backdropColor);
```
- mDrawMode 1 (DBoxDraw::topLeft) will place the box at {xPos, yPos} from the top left corner;
- mDrawMode 2 (DBoxDraw::center) will place the box at {xPos, yPos} from the screen center;
- mDrawMode 3 (DBoxDraw::centerUpperHalf) is a specialized version for the level reload function.
NOTE: xPos positive values shift the box to the right, yPos positive values shift it toward the bottom.

Also:
- added customization for the thickness of the frame surrounding the box and the color of both text and backdrop;
- condensed the functions to block the menu input processing into a single one, and renamed variable "noActions" to a more clear "ignoreInputs".

DrawMode 1 with a small x and y offset.
![Capture](https://user-images.githubusercontent.com/55557854/93810427-ef42c300-fc4e-11ea-9e30-edb9a509659e.PNG)

DrawMode 2 perfectly centered
![Capture2](https://user-images.githubusercontent.com/55557854/93810473-0386c000-fc4f-11ea-8c87-2590f2de06c8.PNG)