### PR TITLE
[Incompatibility] Move message functions to Event Timeline Prefix. Create New Prefix a_ for Audio Handling.

### DIFF
--- a/_RELEASE/Packs/cube/Scripts/Levels/apeirogon.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/apeirogon.lua
@@ -61,7 +61,7 @@ end
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
 	if (u_getDifficultyMult() >= 1.25) then
-		m_messageAdd("Difficulty >= 1.25\nPentagon removed!", 120)
+		e_messageAdd("Difficulty >= 1.25\nPentagon removed!", 120)
 		l_setSidesMin(6)
 	end
 end
@@ -82,7 +82,7 @@ end
 function onIncrement()
 	enableSwapIfSpeedGEThan(4);
 	if (u_getSpeedMultDM() >= 4.5 and l_getSidesMin() == 5) then
-		m_messageAddImportant("Speed >= 4.5\nPentagon removed!", 120)
+		e_messageAddImportant("Speed >= 4.5\nPentagon removed!", 120)
 		if (l_getSides() == 5) then
 			l_setSides(6)
 		end

--- a/_RELEASE/Packs/cube/Scripts/Levels/babysteps.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/babysteps.lua
@@ -38,21 +38,21 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAddImportant("welcome to open hexagon 2", 130)
-	m_messageAddImportant("use left/right to rotate", 130)
-	m_messageAddImportant("avoid the walls!", 130)
+	e_messageAddImportant("welcome to open hexagon 2", 130)
+	e_messageAddImportant("use left/right to rotate", 130)
+	e_messageAddImportant("avoid the walls!", 130)
 	e_eventStopTimeS(6)
 	e_eventWaitS(6)
 
 	e_eventWaitUntilS(10)
 	e_eventStopTimeS(5)
-	m_messageAddImportant("great job!", 130)
-	m_messageAddImportant("after a while, things get harder", 130)
-	m_messageAddImportant("get to 45 seconds to win!", 130)
+	e_messageAddImportant("great job!", 130)
+	e_messageAddImportant("after a while, things get harder", 130)
+	e_messageAddImportant("get to 45 seconds to win!", 130)
 
 	e_eventWaitUntilS(42)
-	m_messageAddImportant("well done!", 130)
-	m_messageAddImportant("now play some real levels!", 138)
+	e_messageAddImportant("well done!", 130)
+	e_messageAddImportant("now play some real levels!", 138)
 
 	e_eventWaitUntilS(44) -- not 45, to avoid level up
 	u_eventKill()

--- a/_RELEASE/Packs/cube/Scripts/Levels/commando.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/commando.lua
@@ -10,7 +10,7 @@ achievementUnlocked = false
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -50,8 +50,8 @@ end
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-	u_playSound("beep.ogg")
-	u_playSound("VeeEndurance_test.ogg")
+	a_playSound("beep.ogg")
+	a_playSound("VeeEndurance_test.ogg")
 
 	extra = extra + 1
 	level = extra + 1
@@ -65,7 +65,7 @@ function onIncrement()
 	l_setSides(l_getSides() + 2)
 	l_setIncTime(incrementTime)
 
-	m_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted

--- a/_RELEASE/Packs/cube/Scripts/Levels/labyrinth.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/labyrinth.lua
@@ -10,7 +10,7 @@ achievementUnlocked = false
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAddImportant("level: "..(level + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(level + 1).." / time: "..incrementTime, 170)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -53,8 +53,8 @@ end
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-	u_playSound("beep.ogg")
-	u_playSound("VeeEndurance_test.ogg")
+	a_playSound("beep.ogg")
+	a_playSound("VeeEndurance_test.ogg")
 
 	level = level + 1
 	levelTracked = level + 1
@@ -68,7 +68,7 @@ function onIncrement()
 	l_setSides(l_getSides() + 1)
 	l_setIncTime(incrementTime)
 
-	m_messageAddImportant("level: "..(level + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(level + 1).." / time: "..incrementTime, 170)
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted

--- a/_RELEASE/Packs/cube/Scripts/Levels/pointless.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/pointless.lua
@@ -54,8 +54,8 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAdd("tutorials are over", 130)
-	m_messageAdd("good luck getting high scores!", 130)
+	e_messageAdd("tutorials are over", 130)
+	e_messageAdd("good luck getting high scores!", 130)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty

--- a/_RELEASE/Packs/cube/Scripts/Levels/seconddimension.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/seconddimension.lua
@@ -63,13 +63,13 @@ end
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
 	if (u_getDifficultyMult() >= 2.2) then
-		m_messageAdd("Difficulty >= 2.2\nPentagon removed!", 120)
+		e_messageAdd("Difficulty >= 2.2\nPentagon removed!", 120)
 		l_setSidesMin(6)
 	end
 	e_eventWaitS(16)
-	m_messageAdd("whoa!", 120)
+	e_messageAdd("whoa!", 120)
 	e_eventWaitS(45)
-	m_messageAddImportant("may the mayhem begin!", 130)
+	e_messageAddImportant("may the mayhem begin!", 130)
 	s_setPulseInc(0.15)
 end
 
@@ -89,7 +89,7 @@ end
 function onIncrement()
 	enableSwapIfSpeedGEThan(4);
 	if (u_getSpeedMultDM() >= 4.5 and l_getSidesMin() == 5) then
-		m_messageAddImportant("Speed >= 4.5\nPentagon removed!", 120)
+		e_messageAddImportant("Speed >= 4.5\nPentagon removed!", 120)
 		if (l_getSides() == 5) then
 			l_setSides(6)
 		end

--- a/_RELEASE/Packs/cube/Scripts/common.lua
+++ b/_RELEASE/Packs/cube/Scripts/common.lua
@@ -3,21 +3,21 @@ THICKNESS = 40.0;
 
 function enableSwapIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
 		l_setSwapEnabled(true)
 	end	
 end
 
 function enableSwapIfSpeedGEThan(mSpeed)
 	if (u_getSpeedMultDM() >= mSpeed and not l_getSwapEnabled()) then
-		m_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
+		e_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
 		l_setSwapEnabled(true)
 	end
 end
 
 function disableIncIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
 		l_setIncEnabled(false)
 	end	
 end

--- a/_RELEASE/Packs/experimental/Scripts/Levels/arcadia.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/arcadia.lua
@@ -388,7 +388,7 @@ end
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
     e_eventWaitUntilS(2)
-    -- m_messageAddImportant("test", 130)
+    -- e_messageAddImportant("test", 130)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty

--- a/_RELEASE/Packs/experimental/Scripts/Levels/curvetest2.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/curvetest2.lua
@@ -36,7 +36,7 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAdd("remember, swap with spacebar!", 120)
+	e_messageAdd("remember, swap with spacebar!", 120)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty

--- a/_RELEASE/Packs/experimental/Scripts/Levels/cw.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/cw.lua
@@ -86,7 +86,7 @@ end
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
 	e_eventWaitUntilS(2)
-	m_messageAddImportant("test", 130)
+	e_messageAddImportant("test", 130)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty

--- a/_RELEASE/Packs/experimental/Scripts/common.lua
+++ b/_RELEASE/Packs/experimental/Scripts/common.lua
@@ -3,21 +3,21 @@ THICKNESS = 40.0;
 
 function enableSwapIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
 		l_setSwapEnabled(true)
 	end	
 end
 
 function enableSwapIfSpeedGEThan(mSpeed)
 	if (u_getSpeedMultDM() >= mSpeed and not l_getSwapEnabled()) then
-		m_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
+		e_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
 		l_setSwapEnabled(true)
 	end
 end
 
 function disableIncIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
 		l_setIncEnabled(false)
 	end	
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/centrifugal.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/centrifugal.lua
@@ -54,7 +54,7 @@ end
 function onIncrement()
 	if curveSpeed < 3 then
 		curveSpeed = curveSpeed + 0.4
-		m_messageAddImportant("Curve speed: "..curveSpeed, 120)
+		e_messageAddImportant("Curve speed: "..curveSpeed, 120)
 	end
 end
 

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/disc-o.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/disc-o.lua
@@ -92,7 +92,7 @@ function onIncrement()
 
 	if special == "none" then
 		special = specials[1]
-		m_messageAddImportant("Special: "..special, 120)
+		e_messageAddImportant("Special: "..special, 120)
 	else
 		special = "none"
 	end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/evotutorial.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/evotutorial.lua
@@ -64,18 +64,18 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAddImportant("welcome to the evolution tutorial", 120)
-	m_messageAddImportant("today you'll be introduced to...", 120)
-	m_messageAddImportant("1. swapping!", 100)
-	m_messageAddImportant("2. curving walls!", 100)
-	m_messageAddImportant("", 120)
-	m_messageAddImportant("press space or middle mouse button\nto swap", 250)
-	m_messageAddImportant("it allows you to rotate 180 degrees!", 200)
-	m_messageAddImportant("", 120)
+	e_messageAddImportant("welcome to the evolution tutorial", 120)
+	e_messageAddImportant("today you'll be introduced to...", 120)
+	e_messageAddImportant("1. swapping!", 100)
+	e_messageAddImportant("2. curving walls!", 100)
+	e_messageAddImportant("", 120)
+	e_messageAddImportant("press space or middle mouse button\nto swap", 250)
+	e_messageAddImportant("it allows you to rotate 180 degrees!", 200)
+	e_messageAddImportant("", 120)
 
-	m_messageAddImportant("now: curving walls", 120)
-	m_messageAddImportant("they can be simple...", 120)
-	m_messageAddImportant("", 120 * 3 + 80)
+	e_messageAddImportant("now: curving walls", 120)
+	e_messageAddImportant("they can be simple...", 120)
+	e_messageAddImportant("", 120 * 3 + 80)
 
 	t_wait(135 * 8)
 	hmcSimpleBarrage(1)
@@ -91,16 +91,16 @@ function onLoad()
 	hmcSimpleBarrage(3)
 
 	t_wait(50)
-	m_messageAddImportant("...in various patterns...", 130)
-	m_messageAddImportant("", 120 * 5 + 80)
+	e_messageAddImportant("...in various patterns...", 130)
+	e_messageAddImportant("", 120 * 5 + 80)
 	t_wait(130)
 
 	hmcSimpleTwirl(5, 1, 0)
 	t_wait(50)
 	hmcSimpleTwirl(5, -2.5, 0.3)
 
-	m_messageAddImportant("...or can accellerate!", 130)
-	m_messageAddImportant("", 120 * 4 + 40)
+	e_messageAddImportant("...or can accellerate!", 130)
+	e_messageAddImportant("", 120 * 4 + 40)
 	t_wait(130)
 
 	hmcBarrage(0, 0.05, -1.5, 3, true)
@@ -112,8 +112,8 @@ function onLoad()
 	hmcBarrage(0, 0.1, -3, 3, true)
 	t_wait(200)
 
-	m_messageAddImportant("they can also do crazy stuff!", 130)
-	m_messageAddImportant("", 120 * 8 + 50)
+	e_messageAddImportant("they can also do crazy stuff!", 130)
+	e_messageAddImportant("", 120 * 8 + 50)
 
 	hmcSimpleCage(2.5, 1)
 	t_wait(80)
@@ -144,8 +144,8 @@ function onLoad()
 	hmcSimpleSpinner(-1.2)
 	t_wait(700)
 
-	m_messageAddImportant("well done!", 130)
-	m_messageAddImportant("now play some real levels!", 138)
+	e_messageAddImportant("well done!", 130)
+	e_messageAddImportant("now play some real levels!", 138)
 
 	u_kill()
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/g-force.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/g-force.lua
@@ -109,7 +109,7 @@ function onIncrement()
 
 	if special == "none" then
 		special = specials[1]
-		m_messageAddImportant("Special: "..special, 120)
+		e_messageAddImportant("Special: "..special, 120)
 	else
 		special = "none"
 	end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/incongruence.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/incongruence.lua
@@ -56,7 +56,7 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAddImportant("Sides ("..lowerBound.." / "..upperBound..")", 170)
+	e_messageAddImportant("Sides ("..lowerBound.." / "..upperBound..")", 170)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -76,7 +76,7 @@ end
 function onIncrement()
 	lowerBound = math.random(4, 6)
 	upperBound = lowerBound + math.random(1, 3)
-	m_messageAddImportant("Sides ("..lowerBound.." / "..upperBound..")", 170)
+	e_messageAddImportant("Sides ("..lowerBound.." / "..upperBound..")", 170)
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/massacre.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/massacre.lua
@@ -105,7 +105,7 @@ function onIncrement()
 
 	if special == "none" then
 		special = specials[1]
-		m_messageAddImportant("Special: "..special, 120)
+		e_messageAddImportant("Special: "..special, 120)
 	else
 		special = "none"
 	end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/polyhedrug.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/polyhedrug.lua
@@ -58,7 +58,7 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -80,7 +80,7 @@ function onIncrement()
 	incrementTime = incrementTime + 5
 	l_setSides(l_getSides() + 1)
 	l_setIncTime(incrementTime)
-	m_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/reppaws.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/reppaws.lua
@@ -69,7 +69,7 @@ end
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
 	syncCurveWithRotationSpeed(0, 0)
-	m_messageAdd("remember, swap with spacebar!", 120)
+	e_messageAdd("remember, swap with spacebar!", 120)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -90,7 +90,7 @@ end
 function onIncrement()
 	if gap > minGap then
 		gap = gap -1
-		m_messageAddImportant("Gap size: "..gap, 120)
+		e_messageAddImportant("Gap size: "..gap, 120)
 	end
 end
 

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/slither.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/slither.lua
@@ -79,7 +79,7 @@ end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-	m_messageAdd("remember, you can focus with lshift!", 150)
+	e_messageAdd("remember, you can focus with lshift!", 150)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -94,7 +94,7 @@ end
 function onIncrement()
 	level = level + 1
 	incrementTime = incrementTime + 5
-	m_messageAddImportant("level: "..(level).." / time: "..incrementTime, 150)
+	e_messageAddImportant("level: "..(level).." / time: "..incrementTime, 150)
 
 	if smax < 4 then
 		smax = smax + 1;
@@ -104,7 +104,7 @@ function onIncrement()
 	end
 
 	range = "("..(smin * 2).."/"..(smax * 2).."]"
-	m_messageAddImportant("Range: "..range, 100)
+	e_messageAddImportant("Range: "..range, 100)
 
 	l_setSides(l_getSides() + 2)
 	l_setIncTime(incrementTime)

--- a/_RELEASE/Packs/hypercube/Scripts/common.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/common.lua
@@ -3,21 +3,21 @@ THICKNESS = 40.0;
 
 function enableSwapIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
 		l_setSwapEnabled(true)
 	end	
 end
 
 function enableSwapIfSpeedGEThan(mSpeed)
 	if (u_getSpeedMultDM() >= mSpeed and not l_getSwapEnabled()) then
-		m_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
+		e_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
 		l_setSwapEnabled(true)
 	end
 end
 
 function disableIncIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
 		l_setIncEnabled(false)
 	end	
 end

--- a/_RELEASE/Packs/workshopexample/Scripts/Levels/examplelevel.lua
+++ b/_RELEASE/Packs/workshopexample/Scripts/Levels/examplelevel.lua
@@ -56,8 +56,8 @@ end
 -- `onLoad` is an hardcoded function that is called when the level is started
 -- or restarted.
 function onLoad()
-	m_messageAdd("welcome to the example level", 130)
-	m_messageAdd("look at the level's files and edit them!", 150)
+	e_messageAdd("welcome to the example level", 130)
+	e_messageAdd("look at the level's files and edit them!", 150)
 end
 
 -- `onStep` is an hardcoded function that is called when the level "timeline"

--- a/_RELEASE/Packs/workshopexample/Scripts/common.lua
+++ b/_RELEASE/Packs/workshopexample/Scripts/common.lua
@@ -3,14 +3,14 @@ THICKNESS = 40.0;
 
 function enableSwapIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
 		l_setSwapEnabled(true)
 	end	
 end
 
 function disableIncIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
 		l_setIncEnabled(false)
 	end	
 end

--- a/_RELEASE/Temp/example/Scripts/Levels/examplelevel.lua
+++ b/_RELEASE/Temp/example/Scripts/Levels/examplelevel.lua
@@ -56,8 +56,8 @@ end
 -- `onLoad` is an hardcoded function that is called when the level is started
 -- or restarted.
 function onLoad()
-	m_messageAdd("welcome to the example level", 130)
-	m_messageAdd("look at the level's files and edit them!", 150)
+	e_messageAdd("welcome to the example level", 130)
+	e_messageAdd("look at the level's files and edit them!", 150)
 end
 
 -- `onStep` is an hardcoded function that is called when the level "timeline"

--- a/_RELEASE/Temp/example/Scripts/common.lua
+++ b/_RELEASE/Temp/example/Scripts/common.lua
@@ -3,14 +3,14 @@ THICKNESS = 40.0;
 
 function enableSwapIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nswap enabled!", 65)
 		l_setSwapEnabled(true)
 	end	
 end
 
 function disableIncIfDMGreaterThan(mDM)
 	if(u_getDifficultyMult() > mDM) then
-		m_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
+		e_messageAdd(" difficulty > " ..mDM.. "\nincrement disabled!", 65)
 		l_setIncEnabled(false)
 	end	
 end

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -181,6 +181,7 @@ private:
     void initLua_WallCreation();
     void initLua_Steam();
     void initLua_CustomWalls();
+    void initLua_Deprecated();
 
     void initLua();
     void runLuaFile(const std::string& mFileName)

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -173,6 +173,7 @@ private:
     void redefineLuaFunctions();
     void destroyMaliciousFunctions();
     void initLua_Utils();
+    void initLua_MusicControl();
     void initLua_MainTimeline();
     void initLua_EventTimeline();
     void initLua_LevelControl();

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -173,7 +173,7 @@ private:
     void redefineLuaFunctions();
     void destroyMaliciousFunctions();
     void initLua_Utils();
-    void initLua_MusicControl();
+    void initLua_AudioControl();
     void initLua_MainTimeline();
     void initLua_EventTimeline();
     void initLua_LevelControl();

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -40,6 +40,7 @@
 #include <SFML/Window.hpp>
 
 #include <sstream>
+#include <set>
 #include <optional>
 
 namespace hg
@@ -81,6 +82,7 @@ private:
     const sf::Vector2f centerPos{ssvs::zeroVec2f};
 
     Lua::LuaContext lua;
+    std::set<std::string> calledDeprecatedFunctions;
 
     LevelStatus levelStatus;
     MusicData musicData;
@@ -248,6 +250,8 @@ public:
             Utils::runLuaFunctionIfExists<T, TArgs...>(lua, mName, mArgs...)){};
     }
 
+    void raiseWarning(const std::string& mFunctionName,
+        const std::string& additionalInfo = "");
     void setLastReplay(const replay_file& mReplayFile);
 
 private:

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -173,7 +173,6 @@ private:
     void redefineLuaFunctions();
     void destroyMaliciousFunctions();
     void initLua_Utils();
-    void initLua_Messages();
     void initLua_MainTimeline();
     void initLua_EventTimeline();
     void initLua_LevelControl();

--- a/include/SSVOpenHexagon/Data/ColorData.hpp
+++ b/include/SSVOpenHexagon/Data/ColorData.hpp
@@ -46,7 +46,7 @@ struct ColorData
               ssvuj::getExtr<float>(mRoot, "dynamic_darkness", 1.f)},
           hueShift{ssvuj::getExtr<float>(mRoot, "hue_shift", 0.f)},
           offset{ssvuj::getExtr<float>(mRoot, "offset", 0.f)},
-          color{ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::White)},
+          color{ssvuj::getExtr<sf::Color>(mRoot, "value", sf::Color::Black)},
           pulse{hg::pulse_from_json(mRoot)} {};
 
     ColorData(const bool mMain, const bool mDynamic, const bool mDynamicOffset,

--- a/include/SSVOpenHexagon/Utils/LuaMetadata.hpp
+++ b/include/SSVOpenHexagon/Utils/LuaMetadata.hpp
@@ -26,7 +26,7 @@ private:
     std::array<std::vector<FnEntry>, NUM_CATEGORIES> fnEntries;
     constexpr static std::array<std::string_view, NUM_CATEGORIES>
         prefixCategories = {
-            "u_", "m_", "t_", "e_", "l_", "s_", "w_", "cw_", "Miscellaneous"};
+            "u_", "a_", "t_", "e_", "l_", "s_", "w_", "cw_", "Miscellaneous"};
 
     [[nodiscard]] std::size_t getCategoryIndexFromName(
         const std::string_view fnName)
@@ -62,24 +62,21 @@ public:
             "beneficial to pack developers, or help simplify complex "
             "calculations.",
 
-            "## Message Functions (m_)\n\n"
+            "## Audio Functions (a_)\n\n"
 
-            "Below are the message functions, which can be identified with the "
-            "\"m_\" prefix. These functions are capable "
-            "of displaying custom messages on the screen which can help pack "
-            "developers communicate additional info or "
-            "anything else useful (e.g Song Lyrics) to the players. For "
-            "keeping track of statistics, please look at "
-            "`l_addTracked`.",
+            "Below are the audio functions, which can be identified with the "
+            "\"a_\" prefix. This library is capable of controlling everything "
+            "audio with the game, including the level music and sounds. Set "
+            "the music, play a specific sound, all of this is in the domain of "
+            "this prefix.",
 
             "## Main Timeline Functions (t_)\n\n"
 
             "Below are the main timeline functions, which can be identified "
-            "with the \"t_\" prefix. These are functions "
-            "that have effects on the main timeline itself, but they mainly "
-            "consist of waiting functions. Using these "
-            "functions helps time out your patterns and space them in the "
-            "first place.",
+            "with the \"t_\" prefix. These are functions that have effects on "
+            "the main timeline itself, but they mainly consist of waiting "
+            "functions. Using these functions helps time out your patterns and "
+            "space them in the first place.",
 
             "## Event Timeline Functions (e_)\n\n"
 
@@ -88,8 +85,8 @@ public:
             "that are similar to the Main Timeline functions, but they instead "
             "are for the event timeline as opposed to "
             "the main timeline. Use these functions to help set up basic "
-            "events for the game. More advanced events must "
-            "be done with pure Lua.",
+            "events for the game, such as handling messages. Use ``e_eval`` to "
+            "do more advanced events.",
 
             "## Level Functions (l_)\n\n"
 

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -262,6 +262,16 @@ void HexagonGame::updateText()
             os << "PRESS Y TO VIEW REPLAY\n";
         }
 
+        if(calledDeprecatedFunctions.size() > 1)
+        {
+            os << calledDeprecatedFunctions.size()
+               << " WARNINGS RAISED (CHECK CONSOLE)\n";
+        }
+        else if(calledDeprecatedFunctions.size() > 0)
+        {
+            os << "1 WARNING RAISED (CHECK CONSOLE)\n";
+        }
+
 
         const auto& trackedVariables(levelStatus.trackedVariables);
         if(Config::getShowTrackedVariables() && !trackedVariables.empty())

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -1281,6 +1281,36 @@ void HexagonGame::initLua_CustomWalls()
 // to the new functions before they get removed permanently
 void HexagonGame::initLua_Deprecated()
 {
+    addLuaFn("u_playSound", //
+        [this](const std::string& mId) {
+            raiseWarning("u_playSound",
+                "This function will be removed in a future version of Open "
+                "Hexagon. Please replace all occurrences of this function with "
+                "\"a_playSound\" in your level files.");
+            assets.playSound(mId);
+        })
+        .arg("soundId")
+        .doc(
+            "Play the sound with id `$0`. The id must be registered in "
+            "`assets.json`, under `\"soundBuffers\"`. "
+            "**This function is deprecated and will be removed in a future "
+            "version. Please use a_playSound instead!**");
+
+    addLuaFn("u_playPackSound", //
+        [this](const std::string& fileName) {
+            raiseWarning("u_playPackSound",
+                "This function will be removed in a future version of Open "
+                "Hexagon. Please replace all occurrences of this function with "
+                "\"a_playPackSound\" in your level files.");
+            assets.playPackSound(getPackId(), fileName);
+        })
+        .arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "plays the specified file `$0`. "
+            "**This function is deprecated and will be removed in a future "
+            "version. Please use a_playPackSound instead!**");
+
     addLuaFn("m_messageAdd", //
         [this](const std::string& mMsg, double mDuration) {
             raiseWarning("m_messageAdd",

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -1276,13 +1276,17 @@ void HexagonGame::initLua_CustomWalls()
         .doc("Remove all existing custom walls.");
 }
 
-// These are all deprecated functions that are only being kept for the sake of lessening the impact
-// of incompatibility. Pack Developers have time to change to the new functions before they get
-// removed permanently
+// These are all deprecated functions that are only being kept for the sake of
+// lessening the impact of incompatibility. Pack Developers have time to change
+// to the new functions before they get removed permanently
 void HexagonGame::initLua_Deprecated()
 {
     addLuaFn("m_messageAdd", //
         [this](const std::string& mMsg, double mDuration) {
+            raiseWarning("m_messageAdd",
+                "This function will be removed in a future version of Open "
+                "Hexagon. Please replace all occurrences of this function with "
+                "\"e_messageAdd\" in your level files and common.lua.");
             eventTimeline.append_do([=, this] {
                 if(firstPlay && Config::getShowMessages())
                 {
@@ -1301,6 +1305,11 @@ void HexagonGame::initLua_Deprecated()
 
     addLuaFn("m_messageAddImportant", //
         [this](const std::string& mMsg, double mDuration) {
+            raiseWarning("m_messageAddImportant",
+                "This function will be removed in a future version of Open "
+                "Hexagon. Please replace all occurrences of this function with "
+                "\"e_messageAddImportant\" in your level files and "
+                "common.lua.");
             eventTimeline.append_do([=, this] {
                 if(Config::getShowMessages())
                 {
@@ -1319,6 +1328,10 @@ void HexagonGame::initLua_Deprecated()
 
     addLuaFn("m_messageAddImportantSilent",
         [this](const std::string& mMsg, double mDuration) {
+            raiseWarning("m_messageAddImportantSilent",
+                "This function will be removed in a future version of Open "
+                "Hexagon. Please replace all occurrences of this function with "
+                "\"e_messageAddImportantSilent\" in your level files.");
             eventTimeline.append_do([=, this] {
                 if(Config::getShowMessages())
                 {
@@ -1336,10 +1349,17 @@ void HexagonGame::initLua_Deprecated()
             "version. Please use e_messageAddImportantSilent instead!**");
 
     addLuaFn("m_clearMessages", //
-        [this] { clearMessages(); })
-        .doc("Remove all previously scheduled messages. "
-             "**This function is deprecated and will be removed in a future "
-             "version. Please use e_clearMessages instead!**");
+        [this] {
+            raiseWarning("m_clearMessages",
+                "This function will be removed in a future version of Open "
+                "Hexagon. Please replace all occurrences of this function with "
+                "\"e_clearMessages\" in your level files.");
+            clearMessages();
+        })
+        .doc(
+            "Remove all previously scheduled messages. "
+            "**This function is deprecated and will be removed in a future "
+            "version. Please use e_clearMessages instead!**");
 }
 
 void HexagonGame::initLua()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -101,13 +101,15 @@ void HexagonGame::initLua_Utils()
         .arg("duration")
         .doc("Pause the game timer for `$0` seconds.");
 
-    addLuaFn("u_timelineWait",
-        [this](
-            double mDuration) { timeline.append_wait_for_sixths(mDuration); })
-        .arg("duration")
-        .doc(
-            "*Add to the main timeline*: wait for `$0` frames (under the "
-            "assumption of a 60 FPS frame rate).");
+    // Redundant function. Refer to t_wait
+
+    // addLuaFn("u_timelineWait",
+    //     [this](
+    //         double mDuration) { timeline.append_wait_for_sixths(mDuration); })
+    //     .arg("duration")
+    //     .doc(
+    //         "*Add to the main timeline*: wait for `$0` frames (under the "
+    //         "assumption of a 60 FPS frame rate).");
 
     addLuaFn("u_clearWalls", //
         [this] { walls.clear(); })

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -227,63 +227,6 @@ void HexagonGame::initLua_Utils()
             "`true`, the swap sound will be played.");
 }
 
-void HexagonGame::initLua_Messages()
-{
-    addLuaFn("m_messageAdd", //
-        [this](const std::string& mMsg, double mDuration) {
-            eventTimeline.append_do([=, this] {
-                if(firstPlay && Config::getShowMessages())
-                {
-                    addMessage(mMsg, mDuration, /* mSoundToggle */ true);
-                }
-            });
-        })
-        .arg("message")
-        .arg("duration")
-        .doc(
-            "*Add to the event timeline*: print a message with text `$0` for "
-            "`$1` seconds. The message will only be printed during the first "
-            "run of the level.");
-
-    addLuaFn("m_messageAddImportant", //
-        [this](const std::string& mMsg, double mDuration) {
-            eventTimeline.append_do([=, this] {
-                if(Config::getShowMessages())
-                {
-                    addMessage(mMsg, mDuration, /* mSoundToggle */ true);
-                }
-            });
-        })
-        .arg("message")
-        .arg("duration")
-        .doc(
-            "*Add to the event timeline*: print a message with text `$0` for "
-            "`$1` seconds. The message will be printed during every run of the "
-            "level.");
-
-
-    addLuaFn("m_messageAddImportantSilent",
-        [this](const std::string& mMsg, double mDuration) {
-            eventTimeline.append_do([=, this] {
-                if(Config::getShowMessages())
-                {
-                    addMessage(mMsg, mDuration, /* mSoundToggle */ false);
-                }
-            });
-        })
-        .arg("message")
-        .arg("duration")
-        .doc(
-            "*Add to the event timeline*: print a message with text `$0` for "
-            "`$1` seconds. The message will only be printed during every "
-            "run of the level, and will not produce any sound.");
-
-
-    addLuaFn("m_clearMessages", //
-        [this] { clearMessages(); })
-        .doc("Remove all previously scheduled messages.");
-}
-
 void HexagonGame::initLua_MainTimeline()
 {
     addLuaFn("t_eval",
@@ -386,6 +329,58 @@ void HexagonGame::initLua_EventTimeline()
         .doc(
             "*Add to the event timeline*: wait until the timer reaches `$0` "
             "seconds.");
+    
+    addLuaFn("e_messageAdd", //
+        [this](const std::string& mMsg, double mDuration) {
+            eventTimeline.append_do([=, this] {
+                if(firstPlay && Config::getShowMessages())
+                {
+                    addMessage(mMsg, mDuration, /* mSoundToggle */ true);
+                }
+            });
+        })
+        .arg("message")
+        .arg("duration")
+        .doc(
+            "*Add to the event timeline*: print a message with text `$0` for "
+            "`$1` seconds. The message will only be printed during the first "
+            "run of the level.");
+
+    addLuaFn("e_messageAddImportant", //
+        [this](const std::string& mMsg, double mDuration) {
+            eventTimeline.append_do([=, this] {
+                if(Config::getShowMessages())
+                {
+                    addMessage(mMsg, mDuration, /* mSoundToggle */ true);
+                }
+            });
+        })
+        .arg("message")
+        .arg("duration")
+        .doc(
+            "*Add to the event timeline*: print a message with text `$0` for "
+            "`$1` seconds. The message will be printed during every run of the "
+            "level.");
+
+    addLuaFn("e_messageAddImportantSilent",
+        [this](const std::string& mMsg, double mDuration) {
+            eventTimeline.append_do([=, this] {
+                if(Config::getShowMessages())
+                {
+                    addMessage(mMsg, mDuration, /* mSoundToggle */ false);
+                }
+            });
+        })
+        .arg("message")
+        .arg("duration")
+        .doc(
+            "*Add to the event timeline*: print a message with text `$0` for "
+            "`$1` seconds. The message will only be printed during every "
+            "run of the level, and will not produce any sound.");
+
+    addLuaFn("e_clearMessages", //
+        [this] { clearMessages(); })
+        .doc("Remove all previously scheduled messages.");
 }
 
 void HexagonGame::initLua_LevelControl()
@@ -1372,7 +1367,6 @@ end
     destroyMaliciousFunctions();
 
     initLua_Utils();
-    initLua_Messages();
     initLua_MainTimeline();
     initLua_EventTimeline();
     initLua_LevelControl();

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -86,22 +86,6 @@ void HexagonGame::initLua_Utils()
         .arg("scriptFilename")
         .doc("Execute the script located at `<pack>/Scripts/$0`.");
 
-    addLuaFn("u_playSound", //
-        [this](const std::string& mId) { assets.playSound(mId); })
-        .arg("soundId")
-        .doc(
-            "Play the sound with id `$0`. The id must be registered in "
-            "`assets.json`, under `\"soundBuffers\"`.");
-
-    addLuaFn("u_playPackSound", //
-        [this](const std::string& fileName) {
-            assets.playPackSound(getPackId(), fileName);
-        })
-        .arg("fileName")
-        .doc(
-            "Dives into the `Sounds` folder of the current level pack and "
-            "plays the specified file `$0`.");
-
     addLuaFn("u_isKeyPressed",
         [this](int mKey) { return window.getInputState()[KKey(mKey)]; })
         .arg("keyCode")
@@ -190,9 +174,9 @@ void HexagonGame::initLua_Utils()
             "`true`, the swap sound will be played.");
 }
 
-void HexagonGame::initLua_MusicControl()
+void HexagonGame::initLua_AudioControl()
 {
-    addLuaFn("m_setMusic", //
+    addLuaFn("a_setMusic", //
         [this](const std::string& mId) {
             musicData = assets.getMusicData(levelData->packId, mId);
             musicData.firstPlay = true;
@@ -204,7 +188,7 @@ void HexagonGame::initLua_MusicControl()
             "Stop the current music and play the music with id `$0`. The id is "
             "defined in the music `.json` file, under `\"id\"`.");
 
-    addLuaFn("m_setMusicSegment", //
+    addLuaFn("a_setMusicSegment", //
         [this](const std::string& mId, int segment) {
             musicData = assets.getMusicData(levelData->packId, mId);
             stopLevelMusic();
@@ -217,7 +201,7 @@ void HexagonGame::initLua_MusicControl()
             "at segment `$1`. Segments are defined in the music `.json` file, "
             "under `\"segments\"`.");
 
-    addLuaFn("m_setMusicSeconds", //
+    addLuaFn("a_setMusicSeconds", //
         [this](const std::string& mId, float mTime) {
             musicData = assets.getMusicData(levelData->packId, mId);
             stopLevelMusic();
@@ -228,6 +212,22 @@ void HexagonGame::initLua_MusicControl()
         .doc(
             "Stop the current music and play the music with id `$0`, starting "
             "at time `$1` (in seconds).");
+    
+    addLuaFn("a_playSound", //
+        [this](const std::string& mId) { assets.playSound(mId); })
+        .arg("soundId")
+        .doc(
+            "Play the sound with id `$0`. The id must be registered in "
+            "`assets.json`, under `\"soundBuffers\"`.");
+
+    addLuaFn("a_playPackSound", //
+        [this](const std::string& fileName) {
+            assets.playPackSound(getPackId(), fileName);
+        })
+        .arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "plays the specified file `$0`.");
 }
 
 void HexagonGame::initLua_MainTimeline()
@@ -1370,7 +1370,7 @@ end
     destroyMaliciousFunctions();
 
     initLua_Utils();
-    initLua_MusicControl();
+    initLua_AudioControl();
     initLua_MainTimeline();
     initLua_EventTimeline();
     initLua_LevelControl();

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -102,43 +102,6 @@ void HexagonGame::initLua_Utils()
             "Dives into the `Sounds` folder of the current level pack and "
             "plays the specified file `$0`.");
 
-    addLuaFn("u_setMusic", //
-        [this](const std::string& mId) {
-            musicData = assets.getMusicData(levelData->packId, mId);
-            musicData.firstPlay = true;
-            stopLevelMusic();
-            playLevelMusic();
-        })
-        .arg("musicId")
-        .doc(
-            "Stop the current music and play the music with id `$0`. The id is "
-            "defined in the music `.json` file, under `\"id\"`.");
-
-    addLuaFn("u_setMusicSegment", //
-        [this](const std::string& mId, int segment) {
-            musicData = assets.getMusicData(levelData->packId, mId);
-            stopLevelMusic();
-            playLevelMusicAtTime(musicData.getSegment(segment).time);
-        })
-        .arg("musicId")
-        .arg("segment")
-        .doc(
-            "Stop the current music and play the music with id `$0`, starting "
-            "at segment `$1`. Segments are defined in the music `.json` file, "
-            "under `\"segments\"`.");
-
-    addLuaFn("u_setMusicSeconds", //
-        [this](const std::string& mId, float mTime) {
-            musicData = assets.getMusicData(levelData->packId, mId);
-            stopLevelMusic();
-            playLevelMusicAtTime(mTime);
-        })
-        .arg("musicId")
-        .arg("time")
-        .doc(
-            "Stop the current music and play the music with id `$0`, starting "
-            "at time `$1` (in seconds).");
-
     addLuaFn("u_isKeyPressed",
         [this](int mKey) { return window.getInputState()[KKey(mKey)]; })
         .arg("keyCode")
@@ -225,6 +188,46 @@ void HexagonGame::initLua_Utils()
         .doc(
             "Force-swaps (180 degrees) the player when invoked. If `$0` is "
             "`true`, the swap sound will be played.");
+}
+
+void HexagonGame::initLua_MusicControl()
+{
+    addLuaFn("m_setMusic", //
+        [this](const std::string& mId) {
+            musicData = assets.getMusicData(levelData->packId, mId);
+            musicData.firstPlay = true;
+            stopLevelMusic();
+            playLevelMusic();
+        })
+        .arg("musicId")
+        .doc(
+            "Stop the current music and play the music with id `$0`. The id is "
+            "defined in the music `.json` file, under `\"id\"`.");
+
+    addLuaFn("m_setMusicSegment", //
+        [this](const std::string& mId, int segment) {
+            musicData = assets.getMusicData(levelData->packId, mId);
+            stopLevelMusic();
+            playLevelMusicAtTime(musicData.getSegment(segment).time);
+        })
+        .arg("musicId")
+        .arg("segment")
+        .doc(
+            "Stop the current music and play the music with id `$0`, starting "
+            "at segment `$1`. Segments are defined in the music `.json` file, "
+            "under `\"segments\"`.");
+
+    addLuaFn("m_setMusicSeconds", //
+        [this](const std::string& mId, float mTime) {
+            musicData = assets.getMusicData(levelData->packId, mId);
+            stopLevelMusic();
+            playLevelMusicAtTime(mTime);
+        })
+        .arg("musicId")
+        .arg("time")
+        .doc(
+            "Stop the current music and play the music with id `$0`, starting "
+            "at time `$1` (in seconds).");
 }
 
 void HexagonGame::initLua_MainTimeline()
@@ -1367,6 +1370,7 @@ end
     destroyMaliciousFunctions();
 
     initLua_Utils();
+    initLua_MusicControl();
     initLua_MainTimeline();
     initLua_EventTimeline();
     initLua_LevelControl();

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -105,7 +105,8 @@ void HexagonGame::initLua_Utils()
 
     // addLuaFn("u_timelineWait",
     //     [this](
-    //         double mDuration) { timeline.append_wait_for_sixths(mDuration); })
+    //         double mDuration) { timeline.append_wait_for_sixths(mDuration);
+    //         })
     //     .arg("duration")
     //     .doc(
     //         "*Add to the main timeline*: wait for `$0` frames (under the "
@@ -214,7 +215,7 @@ void HexagonGame::initLua_AudioControl()
         .doc(
             "Stop the current music and play the music with id `$0`, starting "
             "at time `$1` (in seconds).");
-    
+
     addLuaFn("a_playSound", //
         [this](const std::string& mId) { assets.playSound(mId); })
         .arg("soundId")
@@ -334,7 +335,7 @@ void HexagonGame::initLua_EventTimeline()
         .doc(
             "*Add to the event timeline*: wait until the timer reaches `$0` "
             "seconds.");
-    
+
     addLuaFn("e_messageAdd", //
         [this](const std::string& mMsg, double mDuration) {
             eventTimeline.append_do([=, this] {
@@ -1275,6 +1276,72 @@ void HexagonGame::initLua_CustomWalls()
         .doc("Remove all existing custom walls.");
 }
 
+// These are all deprecated functions that are only being kept for the sake of lessening the impact
+// of incompatibility. Pack Developers have time to change to the new functions before they get
+// removed permanently
+void HexagonGame::initLua_Deprecated()
+{
+    addLuaFn("m_messageAdd", //
+        [this](const std::string& mMsg, double mDuration) {
+            eventTimeline.append_do([=, this] {
+                if(firstPlay && Config::getShowMessages())
+                {
+                    addMessage(mMsg, mDuration, /* mSoundToggle */ true);
+                }
+            });
+        })
+        .arg("message")
+        .arg("duration")
+        .doc(
+            "*Add to the event timeline*: print a message with text `$0` for "
+            "`$1` seconds. The message will only be printed during the first "
+            "run of the level. "
+            "**This function is deprecated and will be removed in a future "
+            "version. Please use e_messageAdd instead!**");
+
+    addLuaFn("m_messageAddImportant", //
+        [this](const std::string& mMsg, double mDuration) {
+            eventTimeline.append_do([=, this] {
+                if(Config::getShowMessages())
+                {
+                    addMessage(mMsg, mDuration, /* mSoundToggle */ true);
+                }
+            });
+        })
+        .arg("message")
+        .arg("duration")
+        .doc(
+            "*Add to the event timeline*: print a message with text `$0` for "
+            "`$1` seconds. The message will be printed during every run of the "
+            "level. "
+            "**This function is deprecated and will be removed in a future "
+            "version. Please use e_messageAddImportant instead!**");
+
+    addLuaFn("m_messageAddImportantSilent",
+        [this](const std::string& mMsg, double mDuration) {
+            eventTimeline.append_do([=, this] {
+                if(Config::getShowMessages())
+                {
+                    addMessage(mMsg, mDuration, /* mSoundToggle */ false);
+                }
+            });
+        })
+        .arg("message")
+        .arg("duration")
+        .doc(
+            "*Add to the event timeline*: print a message with text `$0` for "
+            "`$1` seconds. The message will only be printed during every "
+            "run of the level, and will not produce any sound. "
+            "**This function is deprecated and will be removed in a future "
+            "version. Please use e_messageAddImportantSilent instead!**");
+
+    addLuaFn("m_clearMessages", //
+        [this] { clearMessages(); })
+        .doc("Remove all previously scheduled messages. "
+             "**This function is deprecated and will be removed in a future "
+             "version. Please use e_clearMessages instead!**");
+}
+
 void HexagonGame::initLua()
 {
     // TODO: cleanup/refactor
@@ -1380,6 +1447,7 @@ end
     initLua_WallCreation();
     initLua_Steam();
     initLua_CustomWalls();
+    initLua_Deprecated();
 
     // TODO: refactor doc stuff and have a command line option to print this:
 #if 0

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -385,6 +385,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     inputImplCCW = inputImplCW = inputImplBothCWCCW = false;
 
     lua = Lua::LuaContext{};
+    calledDeprecatedFunctions = {};
     initLua();
     runLuaFile(levelData->luaScriptPath);
 
@@ -577,6 +578,7 @@ void HexagonGame::goToMenu(bool mSendScores, bool mError)
         assets.playSound("beep.ogg");
     }
 
+    calledDeprecatedFunctions.clear();
     fpsWatcher.disable();
 
     if(mSendScores && !status.hasDied && !mError)
@@ -593,6 +595,20 @@ void HexagonGame::goToMenu(bool mSendScores, bool mError)
 
     window.setGameState(mgPtr->getGame());
     mgPtr->init(mError);
+}
+
+void HexagonGame::raiseWarning(
+    const std::string& mFunctionName, const std::string& additionalInfo)
+{
+    // Only raise the warning once to avoid redundancy
+    if(!calledDeprecatedFunctions.contains(mFunctionName))
+    {
+        calledDeprecatedFunctions.emplace(mFunctionName);
+        // Raise warning to the console
+        std::cout << "[Lua] WARNING: The function \"" << mFunctionName
+                  << "\" (used in level \"" << levelData->name
+                  << "\") is deprecated. " << additionalInfo << std::endl;
+    }
 }
 
 void HexagonGame::addMessage(

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1144,12 +1144,13 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
         "s_getHueIncrement", [this] { return styleData.hueIncrement; });
 
     // Unused functions
-    for(const auto& un : {"u_playSound", "u_isKeyPressed",
-            "u_isMouseButtonPressed", "u_isFastSpinning", "u_setPlayerAngle",
-            "u_forceIncrement", "u_kill", "u_eventKill", "u_haltTime",
-            "u_timelineWait", "u_clearWalls",
+    for(const auto& un :
+        {"u_isKeyPressed", "u_isMouseButtonPressed", "u_isFastSpinning",
+            "u_setPlayerAngle", "u_forceIncrement", "u_kill", "u_eventKill",
+            "u_haltTime", "u_timelineWait", "u_clearWalls",
 
-            "m_setMusic", "m_setMusicSegment", "m_setMusicSeconds",
+            "a_setMusic", "a_setMusicSegment", "a_setMusicSeconds",
+            "a_playSound", "a_playPackSound",
 
             "t_eval", "t_wait", "t_waitS", "t_waitUntilS",
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1144,8 +1144,21 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
         "s_getHueIncrement", [this] { return styleData.hueIncrement; });
 
     // Unused functions
-    for(const auto& un :
-        {"l_setSpeedMult", "l_setPlayerSpeedMult", "l_setSpeedInc",
+    for(const auto& un : {"u_playSound", "u_isKeyPressed",
+            "u_isMouseButtonPressed", "u_isFastSpinning", "u_setPlayerAngle",
+            "u_forceIncrement", "u_kill", "u_eventKill", "u_haltTime",
+            "u_timelineWait", "u_clearWalls",
+
+            "m_setMusic", "m_setMusicSegment", "m_setMusicSeconds",
+
+            "t_eval", "t_wait", "t_waitS", "t_waitUntilS",
+
+            "e_eval", "e_eventStopTime", "e_eventStopTimeS", "e_eventWait",
+            "e_eventWaitS", "e_eventWaitUntilS", "e_messageAdd",
+            "e_messageAddImportant", "e_messageAddImportantSilent",
+            "e_clearMessages",
+
+            "l_setSpeedMult", "l_setPlayerSpeedMult", "l_setSpeedInc",
             "l_setSpeedMax", "l_getSpeedMax", "l_getDelayMin", "l_setDelayMin",
             "l_setDelayMax", "l_getDelayMax", "l_setRotationSpeedMax",
             "l_setRotationSpeedInc", "l_setDelayInc", "l_setFastSpin",
@@ -1166,23 +1179,6 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
 
             "l_getSwapCooldownMult", "l_setSwapCooldownMult",
 
-            "u_playSound", "u_isKeyPressed", "u_isMouseButtonPressed",
-            "u_isFastSpinning", "u_setPlayerAngle", "u_forceIncrement",
-            "u_kill", "u_eventKill", "u_haltTime", "u_timelineWait",
-            "u_clearWalls", "u_setMusic", "u_setMusicSegment",
-            "u_setMusicSeconds",
-
-            "m_messageAdd", "m_messageAddImportant",
-            "m_messageAddImportantSilent", "m_clearMessages",
-
-            "t_eval", "t_wait", "t_waitS", "t_waitUntilS",
-
-            "e_eval", "e_eventStopTime", "e_eventStopTimeS", "e_eventWait",
-            "e_eventWaitS", "e_eventWaitUntilS",
-
-            "w_wall", "w_wallAdj", "w_wallAcc", "w_wallHModSpeedData",
-            "w_wallHModCurveData",
-
             "s_getCameraShake", "s_setCameraShake", "s_setStyle", "s_getHueMin",
             "s_setHueMin", "s_getHueMax", "s_setHueMax", "s_getPulseMin",
             "s_setPulseMin", "s_getPulseMax", "s_setPulseMax", "s_getPulseInc",
@@ -1198,11 +1194,12 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "s_setCapColorMainDarkened", "s_setCapColorByIndex",
             "s_setBGColorOffset", "s_getBGColorOffset", "s_setBGTileRadius",
             "s_getBGTileRadius", "s_setBGRotOff", "s_getBGRotOff",
-            "steam_unlockAchievement",
+
+            "w_wall", "w_wallAdj", "w_wallAcc", "w_wallHModSpeedData",
+            "w_wallHModCurveData",
 
             "cw_create", "cw_destroy", "cw_setVertexPos", "cw_setVertexColor",
-
-            "cw_isOverlappingPlayer", "cw_clear"})
+            "cw_isOverlappingPlayer", "cw_clear", "steam_unlockAchievement"})
     {
         mLua.writeVariable(un, [] {});
     }

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1111,6 +1111,11 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
 
     mLua.writeVariable("u_getPlayerAngle", [] { return 0; });
 
+    mLua.writeVariable("l_getPulseMin", [] { return levelStatus.pulseMin; });
+    mLua.writeVariable("l_getPulseMax", [] { return levelStatus.pulseMax; });
+    mLua.writeVariable("l_getPulseSpeed", [] { return levelStatus.pulseSpeed; });
+    mLua.writeVariable("l_getPulseSpeedR", [] { return levelStatus.pulseSpeedR; });
+
     mLua.writeVariable("l_setRotationSpeed",
         [this](float mValue) { levelStatus.rotationSpeed = mValue; });
 
@@ -1200,7 +1205,10 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "w_wallHModCurveData",
 
             "cw_create", "cw_destroy", "cw_setVertexPos", "cw_setVertexColor",
-            "cw_isOverlappingPlayer", "cw_clear", "steam_unlockAchievement"})
+            "cw_isOverlappingPlayer", "cw_clear", "steam_unlockAchievement",
+
+            "m_messageAdd", "m_messageAddImportant",
+            "m_messageAddImportantSilent", "m_clearMessages"})
     {
         mLua.writeVariable(un, [] {});
     }

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1111,10 +1111,10 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
 
     mLua.writeVariable("u_getPlayerAngle", [] { return 0; });
 
-    mLua.writeVariable("l_getPulseMin", [] { return levelStatus.pulseMin; });
-    mLua.writeVariable("l_getPulseMax", [] { return levelStatus.pulseMax; });
-    mLua.writeVariable("l_getPulseSpeed", [] { return levelStatus.pulseSpeed; });
-    mLua.writeVariable("l_getPulseSpeedR", [] { return levelStatus.pulseSpeedR; });
+    mLua.writeVariable("l_getPulseMin", [this] { return levelStatus.pulseMin; });
+    mLua.writeVariable("l_getPulseMax", [this] { return levelStatus.pulseMax; });
+    mLua.writeVariable("l_getPulseSpeed", [this] { return levelStatus.pulseSpeed; });
+    mLua.writeVariable("l_getPulseSpeedR", [this] { return levelStatus.pulseSpeedR; });
 
     mLua.writeVariable("l_setRotationSpeed",
         [this](float mValue) { levelStatus.rotationSpeed = mValue; });


### PR DESCRIPTION
This is a PR that will introduce incompatibilities to the game, but it's best that we do this now rather than later where this can hurt us more down the line.

Essentially the message functions that we all know will be removed from the **m_** prefix and will merge with the **e_** prefix. It makes it more intuitive for new developers to understand that messages run on the event timeline.

In addition, I've also decided to move some of the utility functions that specifically control audio and I decided to move them to their own prefix, **a_**. This is being done to remove some of the bloating of the utilities prefix. This also introduces an incompatibility, but it shouldn't be as significant as the messages because the audio functions aren't used as frequently. The main functions that are being moved to **a_** are the music functions and the sound functions **u_playSound** and **u_playPackSound**. It's also a good idea to have a prefix dedicated to audio functions because I plan on adding several functions that would fit perfectly under this prefix.

I also made a few smaller changes in this PR as well:

- When the "color" attribute of a Style is not provided in the JSON, it will default to the color black instead of white. This technically introduces an incompatibility, but since every style explicitly defines the color and pulse attributes, this incompatibility shouldn't break anything and it is negligible. This change is mainly done to allow people to shortcut certain colors and panels.
- Slightly touched up the documentation for not only the new prefix, but to also update a few things due to new functions coming to 2.0.3