### PR TITLE
Include string explicitly so that the type is complete

### DIFF
--- a/include/SSVOpenHexagon/Core/Steam.hpp
+++ b/include/SSVOpenHexagon/Core/Steam.hpp
@@ -8,6 +8,7 @@
 #include "steam/steam_api.h"
 
 #include <functional>
+#include <string>
 #include <string_view>
 #include <unordered_set>
 


### PR DESCRIPTION
Before, was causing errors:
```
In file included from /usr/include/c++/10.2.0/unordered_map:42,
                 from /usr/include/c++/10.2.0/functional:61,
                 from /opt/SSVOpenHexagon/./include/SSVOpenHexagon/Core/Steam.hpp:10,
                 from /opt/SSVOpenHexagon/src/SSVOpenHexagon/Core/Steam.cpp:5:
/usr/include/c++/10.2.0/ext/aligned_buffer.h: In instantiation of ‘struct __gnu_cxx::__aligned_buffer<std::__cxx11::basic_string<char> >’:
/usr/include/c++/10.2.0/bits/hashtable_policy.h:233:43:   required from ‘struct std::__detail::_Hash_node_value_base<std::__cxx11::basic_string<char> >’
/usr/include/c++/10.2.0/bits/hashtable_policy.h:264:12:   required from ‘struct std::__detail::_Hash_node<std::__cxx11::basic_string<char>, true>’
/usr/include/c++/10.2.0/bits/hashtable_policy.h:1973:13:   required from ‘struct std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::__cxx11::basic_string<char>, true> > >’
/usr/include/c++/10.2.0/bits/hashtable.h:173:11:   required from ‘class std::_Hashtable<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::allocator<std::__cxx11::basic_string<char> >, std::__detail::_Identity, std::equal_to<std::__cxx11::basic_string<char> >, std::hash<std::__cxx11::basic_string<char> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >’
/usr/include/c++/10.2.0/bits/unordered_set.h:100:18:   required from ‘class std::unordered_set<std::__cxx11::basic_string<char> >’
/opt/SSVOpenHexagon/./include/SSVOpenHexagon/Core/Steam.hpp:23:37:   required from here
/usr/include/c++/10.2.0/ext/aligned_buffer.h:91:28: error: invalid application of ‘sizeof’ to incomplete type ‘std::__cxx11::basic_string<char>’
   91 |     : std::aligned_storage<sizeof(_Tp), __alignof__(_Tp)>

```

