### PR TITLE
Further menu improvements

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -313,6 +313,7 @@ private:
     bool firstLevelSelection{true};
     PackChange packChangeState{PackChange::Rest};
     float namesScroll[static_cast<int>(Label::ScrollsSize)]{0};
+    std::vector<std::string> levelDescription;
     float levelSelectionTotalHeight{0.f};
     float levelSelectionXOffset{0.f}; // to make the menu slide in/out
     float levelSelectionYOffset{0.f}; // to scroll up and down the menu
@@ -325,6 +326,7 @@ private:
     float getLevelLabelHeight();
     float getQuadBorder();
     float getFrameSize();
+    float getMaximumTextWidth();
     float getLevelListHeight();
     void calcLevelChangeScroll();
     void calcPackChangeScroll();
@@ -334,6 +336,7 @@ private:
     void scrollNameRightBorder(
         std::string& text, sf::Text& font, float& scroller, float border);
     void resetNamesScrolls();
+    void formatLevelDescription();
     void drawLevelSelection(
         const unsigned int charSize, const bool revertOffset);
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -2151,11 +2151,12 @@ void MenuGame::reloadAssets(const bool reloadEntirePack)
     }
 
     setIndex(currentIndex); // loads the new levelData
+    formatLevelDescription();
 
     reloadOutput += "\npress any key to close this message\n";
     uppercasify(reloadOutput);
 
-    // needs to be two because the dialog box reacts to key releases.
+    // Needs to be two because the dialog box reacts to key releases.
     // First key release is the one of the key press that made the dialog
     // box pop up, the second one belongs to the key press that closes it
     setIgnoreAllInputs(2);


### PR DESCRIPTION
- Fixed pack switch still getting stuck in some circumstances I cannot figure out (assignement is now constantly updated instead of being bound to key press/release events);

- Added wrapping to the level description. It would be better if pack makers updated their jsons with newlines to fit the space available as they see fit, but since it is possible some packs may never be updated I enforce a formatting when the level is changed.
It should be noted that I have noticed some weird glitches in the formatted text rendering in certain packs (particularly Babagon). Best I can tell it's due to the editor used to make the jsons since if I retype the description as in the original in my text editors the issue is fixed.