### PR TITLE
Customizable Quick Pack Switch key

### DIFF
--- a/src/SSVOpenHexagon/Core/Joystick.cpp
+++ b/src/SSVOpenHexagon/Core/Joystick.cpp
@@ -134,6 +134,11 @@ enum class AxisDir : int
     Right = 1
 };
 
+inline AxisDir operator-(AxisDir dir)
+{
+    return static_cast<AxisDir>(- static_cast<int>(dir));
+}
+
 [[nodiscard]] static AxisDir axisPressed(
     const unsigned int joyId, const sf::Joystick::Axis axis)
 {
@@ -187,13 +192,13 @@ void update()
     };
 
     const auto yIs = [&](const AxisDir axisDir) {
-        return dpadYIs(axisDir) || leftStickYIs(axisDir);
+        return dpadYIs(axisDir) || leftStickYIs(- axisDir);
     };
 
     s.leftWasPressed = std::exchange(s.leftPressed, xIs(AxisDir::Left));
     s.rightWasPressed = std::exchange(s.rightPressed, xIs(AxisDir::Right));
-    s.upWasPressed = std::exchange(s.upPressed, yIs(AxisDir::Left));
-    s.downWasPressed = std::exchange(s.downPressed, yIs(AxisDir::Right));
+    s.upWasPressed = std::exchange(s.upPressed, yIs(AxisDir::Right));
+    s.downWasPressed = std::exchange(s.downPressed, yIs(AxisDir::Left));
 
     s.selectWasPressed = std::exchange(s.selectPressed,
         sf::Joystick::isButtonPressed(joyId, s.joystickInputs[Jid::Select]));

--- a/src/SSVOpenHexagon/Core/Joystick.cpp
+++ b/src/SSVOpenHexagon/Core/Joystick.cpp
@@ -134,7 +134,7 @@ enum class AxisDir : int
     Right = 1
 };
 
-inline AxisDir operator-(AxisDir dir)
+[[nodiscard]] AxisDir operator-(AxisDir dir)
 {
     return static_cast<AxisDir>(- static_cast<int>(dir));
 }

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1696,6 +1696,7 @@ void MenuGame::update(ssvu::FT mFT)
     {
         changePackAction(-1);
     }
+    
     focusHeld = hg::Joystick::focusPressed();
 
     if(hg::Joystick::leftRisingEdge())

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1688,6 +1688,16 @@ void MenuGame::update(ssvu::FT mFT)
 
     hg::Joystick::update();
 
+    if(hg::Joystick::nextPackRisingEdge())
+    {
+        changePackAction(1);
+    }
+    else if(hg::Joystick::previousPackRisingEdge())
+    {
+        changePackAction(-1);
+    }
+    focusHeld = hg::Joystick::focusPressed();
+
     if(hg::Joystick::leftRisingEdge())
     {
         leftAction();
@@ -1712,15 +1722,6 @@ void MenuGame::update(ssvu::FT mFT)
     else if(hg::Joystick::exitRisingEdge())
     {
         exitAction();
-    }
-
-    if(hg::Joystick::nextPackRisingEdge())
-    {
-        changePackAction(1);
-    }
-    else if(hg::Joystick::previousPackRisingEdge())
-    {
-        changePackAction(-1);
     }
 
     if(hg::Joystick::screenshotRisingEdge())

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -921,7 +921,7 @@ void setSaveLocalBestReplayToFile(bool mX)
 //**************************************************
 // Game start check
 
-#define MAX_BINDS 4
+constexpr int maxBinds = 4;
 
 [[nodiscard]] Trigger resizeTrigger(Trigger trig) noexcept
 {
@@ -941,13 +941,13 @@ void setSaveLocalBestReplayToFile(bool mX)
         }
     }
     // if the config has more binds than are supported
-    while(combos.size() > MAX_BINDS)
+    while(combos.size() > maxBinds)
     {
         combos.pop_back();
     }
     // if the config has less binds fill the
     // spots with unbound combos
-    while(combos.size() < MAX_BINDS)
+    while(combos.size() < maxBinds)
     {
         combos.emplace_back(Combo({KKey::Unknown}));
     }
@@ -1079,7 +1079,7 @@ const triggerGetter keyboardGetterFuncs[] = {
     Trigger trig, int key, int btn, int index) noexcept
 {
     // if both slots are taken replace the first one
-    if(index >= MAX_BINDS)
+    if(index >= maxBinds)
     {
         index = 0;
         trig.getCombos()[index].clearBind();


### PR DESCRIPTION
Assigned Focus bind to control the quick switch function when in menu (its in game behavior is unchanged).
Also:
- replaced a #define in Config.cpp with a constexpr;
- added pack change keys to RefreshBinds();
- small tweak in formatLevelDescription().

A new custom bind can be made but that would make the bind customization menu go out of bounds and would require a bigger amount of effort.