### PR TITLE
Expand the audio prefix (First Expansion)

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -474,8 +474,14 @@ public:
 
     [[nodiscard]] float getMusicDMSyncFactor() const
     {
-        return Config::getMusicSpeedDMSync() ? std::pow(difficultyMult, 0.12f)
-                                             : 1.f;
+        return levelStatus.syncMusicToDM ? std::pow(difficultyMult, 0.12f)
+                                         : 1.f;
+    }
+
+    void setMusicPitch(sf::Music* current)
+    {
+        current->setPitch((getMusicDMSyncFactor()) *
+                          Config::getMusicSpeedMult() * levelStatus.musicPitch);
     }
 
     // Input

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -478,7 +478,7 @@ public:
                                          : 1.f;
     }
 
-    void setMusicPitch(sf::Music* current)
+    void setMusicPitch(sf::Music& current)
     {
         current->setPitch((getMusicDMSyncFactor()) *
                           Config::getMusicSpeedMult() * levelStatus.musicPitch);

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -480,7 +480,7 @@ public:
 
     void setMusicPitch(sf::Music& current)
     {
-        current->setPitch((getMusicDMSyncFactor()) *
+        current.setPitch((getMusicDMSyncFactor()) *
                           Config::getMusicSpeedMult() * levelStatus.musicPitch);
     }
 

--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -6,6 +6,7 @@
 
 #include "SSVOpenHexagon/SSVUtilsJson/SSVUtilsJson.hpp"
 #include "SSVOpenHexagon/Data/TrackedVariable.hpp"
+#include "SSVOpenHexagon/Global/Config.hpp"
 
 #include <SSVUtils/Core/FileSystem/FileSystem.hpp>
 
@@ -62,6 +63,10 @@ struct LevelStatus
     // Allows alternative scoring to be possible
     bool scoreOverridden{false};
     std::string scoreOverride;
+
+    // Music and sound related attributes
+    bool syncMusicToDM = Config::getMusicSpeedDMSync();
+    float musicPitch{1.f};
 
     float speedMult{1.f};
     float playerSpeedMult{1.f};

--- a/include/SSVOpenHexagon/Data/LevelData.hpp
+++ b/include/SSVOpenHexagon/Data/LevelData.hpp
@@ -67,6 +67,10 @@ struct LevelStatus
     // Music and sound related attributes
     bool syncMusicToDM = Config::getMusicSpeedDMSync();
     float musicPitch{1.f};
+    std::string beepSound{"beep.ogg"};
+    std::string levelUpSound{"increment.ogg"};
+    std::string swapSound{"swap.ogg"};
+    std::string deathSound{"death.ogg"};
 
     float speedMult{1.f};
     float playerSpeedMult{1.f};

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -149,7 +149,7 @@ void CPlayer::playerSwap(HexagonGame& mHexagonGame, bool mPlaySound)
 
     if(mPlaySound)
     {
-        mHexagonGame.getAssets().playSound("swap.ogg");
+        mHexagonGame.getAssets().playSound(mHexagonGame.getLevelStatus().swapSound);
     }
 }
 

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -247,6 +247,32 @@ void HexagonGame::initLua_AudioControl()
         .doc(
             "Dives into the `Sounds` folder of the current level pack and "
             "plays the specified file `$0`.");
+
+    addLuaFn("a_syncMusicToDM", //
+        [this](bool value) {
+            levelStatus.syncMusicToDM = value;
+
+            auto* current(assets.getMusicPlayer().getCurrent());
+            setMusicPitch(current);
+        })
+        .arg("value")
+        .doc(
+            "This function, when called, overrides the user's preference of "
+            "adjusting the music's pitch to the difficulty multiplier. Useful "
+            "for levels that rely on the music to time events.");
+
+    addLuaFn("a_setMusicPitch", //
+        [this](float mPitch) {
+            levelStatus.musicPitch = mPitch;
+
+            auto* current(assets.getMusicPlayer().getCurrent());
+            setMusicPitch(current);
+        })
+        .arg("pitch")
+        .doc(
+            "Manually adjusts the pitch of the music by multiplying it by "
+            "`$0`. The amount the pitch shifts may change on DM multiplication "
+            "and user's preference of the music pitch.");
 }
 
 void HexagonGame::initLua_MainTimeline()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -272,39 +272,49 @@ void HexagonGame::initLua_AudioControl()
         .doc(
             "Manually adjusts the pitch of the music by multiplying it by "
             "`$0`. The amount the pitch shifts may change on DM multiplication "
-            "and user's preference of the music pitch.");
-    
+            "and user's preference of the music pitch. **Negative values will "
+            "not work!**");
+
     addLuaFn("a_overrideBeepSound", //
-		[this] (const std::string& mId) { levelStatus.beepSound = getPackId() + "_" + mId; })
-		.arg("fileName")
+        [this](const std::string& mId) {
+            levelStatus.beepSound = getPackId() + "_" + mId;
+        })
+        .arg("fileName")
         .doc(
             "Dives into the `Sounds` folder of the current level pack and "
             "sets the specified file `$0` to be the new beep sound. This only "
-			"applies to the particular level where this function is called.");
-			
-	addLuaFn("a_overrideIncrementSound", //
-		[this] (const std::string& mId) { levelStatus.levelUpSound = getPackId() + "_" + mId; })
-		.arg("fileName")
+            "applies to the particular level where this function is called.");
+
+    addLuaFn("a_overrideIncrementSound", //
+        [this](const std::string& mId) {
+            levelStatus.levelUpSound = getPackId() + "_" + mId;
+        })
+        .arg("fileName")
         .doc(
             "Dives into the `Sounds` folder of the current level pack and "
-            "sets the specified file `$0` to be the new increment sound. This only "
-			"applies to the particular level where this function is called.");
-	
-	addLuaFn("a_overrideSwapSound", //
-		[this] (const std::string& mId) { levelStatus.swapSound = getPackId() + "_" + mId; })
-		.arg("fileName")
+            "sets the specified file `$0` to be the new increment sound. This "
+            "only "
+            "applies to the particular level where this function is called.");
+
+    addLuaFn("a_overrideSwapSound", //
+        [this](const std::string& mId) {
+            levelStatus.swapSound = getPackId() + "_" + mId;
+        })
+        .arg("fileName")
         .doc(
             "Dives into the `Sounds` folder of the current level pack and "
             "sets the specified file `$0` to be the new swap sound. This only "
-			"applies to the particular level where this function is called.");
-	
-	addLuaFn("a_overrideDeathSound", //
-		[this] (const std::string& mId) { levelStatus.deathSound = getPackId() + "_" + mId; })
-		.arg("fileName")
+            "applies to the particular level where this function is called.");
+
+    addLuaFn("a_overrideDeathSound", //
+        [this](const std::string& mId) {
+            levelStatus.deathSound = getPackId() + "_" + mId;
+        })
+        .arg("fileName")
         .doc(
             "Dives into the `Sounds` folder of the current level pack and "
             "sets the specified file `$0` to be the new death sound. This only "
-			"applies to the particular level where this function is called.");
+            "applies to the particular level where this function is called.");
 }
 
 void HexagonGame::initLua_MainTimeline()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -273,6 +273,38 @@ void HexagonGame::initLua_AudioControl()
             "Manually adjusts the pitch of the music by multiplying it by "
             "`$0`. The amount the pitch shifts may change on DM multiplication "
             "and user's preference of the music pitch.");
+    
+    addLuaFn("a_overrideBeepSound", //
+		[this] (const std::string& mId) { levelStatus.beepSound = getPackId() + "_" + mId; })
+		.arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "sets the specified file `$0` to be the new beep sound. This only "
+			"applies to the particular level where this function is called.");
+			
+	addLuaFn("a_overrideIncrementSound", //
+		[this] (const std::string& mId) { levelStatus.levelUpSound = getPackId() + "_" + mId; })
+		.arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "sets the specified file `$0` to be the new increment sound. This only "
+			"applies to the particular level where this function is called.");
+	
+	addLuaFn("a_overrideSwapSound", //
+		[this] (const std::string& mId) { levelStatus.swapSound = getPackId() + "_" + mId; })
+		.arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "sets the specified file `$0` to be the new swap sound. This only "
+			"applies to the particular level where this function is called.");
+	
+	addLuaFn("a_overrideDeathSound", //
+		[this] (const std::string& mId) { levelStatus.deathSound = getPackId() + "_" + mId; })
+		.arg("fileName")
+        .doc(
+            "Dives into the `Sounds` folder of the current level pack and "
+            "sets the specified file `$0` to be the new death sound. This only "
+			"applies to the particular level where this function is called.");
 }
 
 void HexagonGame::initLua_MainTimeline()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -255,7 +255,7 @@ void HexagonGame::initLua_AudioControl()
             sf::Music* current(assets.getMusicPlayer().getCurrent());
             if (current == nullptr)
             {
-                return:
+                return;
             }
             
             setMusicPitch(*current);
@@ -273,7 +273,7 @@ void HexagonGame::initLua_AudioControl()
             sf::Music* current(assets.getMusicPlayer().getCurrent());
             if (current == nullptr)
             {
-                return:
+                return;
             }
         })
         .arg("pitch")

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -270,8 +270,11 @@ void HexagonGame::initLua_AudioControl()
         [this](float mPitch) {
             levelStatus.musicPitch = mPitch;
 
-            auto* current(assets.getMusicPlayer().getCurrent());
-            setMusicPitch(current);
+            sf::Music* current(assets.getMusicPlayer().getCurrent());
+            if (current == nullptr)
+            {
+                return:
+            }
         })
         .arg("pitch")
         .doc(

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -252,8 +252,13 @@ void HexagonGame::initLua_AudioControl()
         [this](bool value) {
             levelStatus.syncMusicToDM = value;
 
-            auto* current(assets.getMusicPlayer().getCurrent());
-            setMusicPitch(current);
+            sf::Music* current(assets.getMusicPlayer().getCurrent());
+            if (current == nullptr)
+            {
+                return:
+            }
+            
+            setMusicPitch(*current);
         })
         .arg("value")
         .doc(

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -319,10 +319,10 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
         playLevelMusic();
         assets.musicPlayer.pause();
 
-        auto* current(assets.getMusicPlayer().getCurrent());
+        sf::Music* current(assets.getMusicPlayer().getCurrent());
         if(current != nullptr)
         {
-            setMusicPitch(current);
+            setMusicPitch(*current);
         }
     }
     else

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -463,7 +463,7 @@ void HexagonGame::death(bool mForce)
     }
 
     fpsWatcher.disable();
-    assets.playSound("death.ogg", ssvs::SoundPlayer::Mode::Abort);
+    assets.playSound(levelStatus.deathSound, ssvs::SoundPlayer::Mode::Abort);
 
     if(!mForce && (Config::getInvincible() || levelStatus.tutorialMode))
     {
@@ -565,7 +565,7 @@ void HexagonGame::sideChange(unsigned int mSideNumber)
 
     mustChangeSides = false;
 
-    assets.playSound("increment.ogg");
+    assets.playSound(levelStatus.levelUpSound);
     runLuaFunction<void>("onIncrement");
 }
 
@@ -665,7 +665,7 @@ void HexagonGame::addMessage(
     messageTimeline.append_do([this, mSoundToggle, mMessage] {
         if(mSoundToggle)
         {
-            assets.playSound("beep.ogg");
+            assets.playSound(levelStatus.beepSound);
         }
         messageText.setString(mMessage);
     });
@@ -785,7 +785,7 @@ auto HexagonGame::getColorText() const -> sf::Color
 
 void HexagonGame::setSides(unsigned int mSides)
 {
-    assets.playSound("beep.ogg");
+    assets.playSound(levelStatus.beepSound);
 
     if(mSides < 3)
     {

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -322,10 +322,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
         auto* current(assets.getMusicPlayer().getCurrent());
         if(current != nullptr)
         {
-            current->setPitch(
-                (Config::getMusicSpeedDMSync() ? pow(difficultyMult, 0.12f)
-                                               : 1.f) *
-                Config::getMusicSpeedMult());
+            setMusicPitch(current);
         }
     }
     else

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -567,7 +567,9 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
 
             "a_setMusic", "a_setMusicSegment", "a_setMusicSeconds",
             "a_playSound", "a_playPackSound", "a_syncMusicToDM",
-            "a_setMusicPitch",
+            "a_setMusicPitch", "a_overrideBeepSound",
+            "a_overrideIncrementSound", "a_overrideSwapSound",
+            "a_overrideDeathSound",
 
             "t_eval", "t_wait", "t_waitS", "t_waitUntilS",
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -566,7 +566,8 @@ void MenuGame::initLua(Lua::LuaContext& mLua)
             "u_haltTime", "u_timelineWait", "u_clearWalls",
 
             "a_setMusic", "a_setMusicSegment", "a_setMusicSeconds",
-            "a_playSound", "a_playPackSound",
+            "a_playSound", "a_playPackSound", "a_syncMusicToDM",
+            "a_setMusicPitch",
 
             "t_eval", "t_wait", "t_waitS", "t_waitUntilS",
 
@@ -1696,7 +1697,7 @@ void MenuGame::update(ssvu::FT mFT)
     {
         changePackAction(-1);
     }
-    
+
     focusHeld = hg::Joystick::focusPressed();
 
     if(hg::Joystick::leftRisingEdge())


### PR DESCRIPTION
This PR introduces 6 new Lua functions that all expand the new **a_** prefix that was introduced.

Two of these functions are dedicated to the pitch of the music

1. **a_syncMusicToDM**: Allows pack developers to override the user's preference of whether the music's pitch is synced with the difficulty multiplier. By default, the value is based on the user's preference.

2. **a_setMusicPitch**: Allows pack developers to manually adjust the pitch of the music playing. Due to SFML limitations, this function does not accept negative values.

The other four are asset overriding functions, which allow pack developers to override some of the default sounds with their own custom ones.

1. **a_overrideBeepSound**: Overrides beep.ogg with a level pack sound to the developer's liking.
2. **a_overrideIncrementSound**: Overrides increment.ogg with a level pack sound to the developer's liking.
3. **a_overrideSwapSound**: Overrides swap.ogg with a level pack sound to the developer's liking. Closes #277.
4. **a_overrideDeathSound**: Overrides death.ogg with a level pack sound to the developer's liking.

I'm aware several more audio-related functions can be added later down the line, but these are a few starters.