### PR TITLE
Multiple newlines in description bugfixes

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -3296,13 +3296,13 @@ void MenuGame::formatLevelDescription()
     {
         if(desc[i] == '\n')
         {
-            words.emplace_back(desc.substr(j, ++i - j)); // include the newline.
-            j = i;
+            words.emplace_back(desc.substr(j, i - j + 1)); // include the newline.
+            j = i + 1;
         }
         else if(desc[i] == ' ')
         {
             words.emplace_back(desc.substr(j, i - j));
-            j = ++i; // skip the space.
+            j = i + 1; // skip the space.
         }
     }
 


### PR DESCRIPTION
Fixes a couple of issues in the way the level description was formatted when multiple consecutive newlines were written in the .json file.