### PR TITLE
Fixed death effect being FPS dependent

### DIFF
--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -121,11 +121,6 @@ void CPlayer::drawDeathEffect(HexagonGame& mHexagonGame)
     const sf::Color colorMain{
         ssvs::getColorFromHSV((360.f - hue) / 360.f, 1.f, 1.f)};
 
-    if(++hue > 360.f)
-    {
-        hue = 0.f;
-    }
-
     for(auto i(0u); i < mHexagonGame.getSides(); ++i)
     {
         const float sAngle{div * 2.f * i};
@@ -259,19 +254,25 @@ void CPlayer::kill(HexagonGame& mHexagonGame)
 
 void CPlayer::update(HexagonGame& mHexagonGame, ssvu::FT mFT)
 {
-    swapBlinkTimer.update(mFT);
-
-    if(deadEffectTimer.update(mFT) && !dead)
+    if(deadEffectTimer.isRunning())
     {
-        deadEffectTimer.stop();
+        deadEffectTimer.update(mFT);
+
+        if(++hue > 360.f)
+        {
+            hue = 0.f;
+        }
+        if(dead)
+        {
+            return;
+        }
     }
 
-    if(mHexagonGame.getLevelStatus().swapEnabled)
+    swapBlinkTimer.update(mFT);
+
+    if(mHexagonGame.getLevelStatus().swapEnabled && swapTimer.update(mFT))
     {
-        if(swapTimer.update(mFT))
-        {
-            swapTimer.stop();
-        }
+        swapTimer.stop();
     }
 
     lastPos = pos;

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -80,10 +80,10 @@ void HexagonGame::update(ssvu::FT mFT)
 
     if(status.started)
     {
+        player.update(*this, mFT);
+
         if(!status.hasDied)
         {
-            player.update(*this, mFT);
-
             const std::optional<bool> preventPlayerInput =
                 runLuaFunctionIfExists<bool, float, int, bool, bool>("onInput",
                     mFT, getInputMovement(), getInputFocused(), getInputSwap());


### PR DESCRIPTION
Fixes #312

"hue" parameter update has been moved from drawDeathEffect() to update(), fixing the frame dependency.
Furthermore, to make it work CPlayer::update() is now executed even when player is dead, except that when it is dead, after the death effect Ticker and hue have been updated the function is terminated.

From my testing it works as expected when Invincible is on and when it is off.