### PR TITLE
Moved initLua before newGame() function

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -97,11 +97,11 @@ private:
 
     void initAssets();
     void initInput();
-    void initLua(Lua::LuaContext& mLua);
+    void initLua();
     void initMenus();
     void playLocally();
     std::pair<const unsigned int, const unsigned int>
-    pickRandomMainMenuBackgroundStyle();
+        pickRandomMainMenuBackgroundStyle();
 
     //---------------------------------------
     // Assets
@@ -255,6 +255,8 @@ private:
     {
         window.draw(mDrawable);
     }
+
+    void readLuaVariablesForMenu();
 
     // Helper functions
     float getFPSMult() const;

--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -256,8 +256,6 @@ private:
         window.draw(mDrawable);
     }
 
-    void readLuaVariablesForMenu();
-
     // Helper functions
     float getFPSMult() const;
     void drawGraphics();

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -17,6 +17,7 @@ namespace hg
 {
 
 struct LevelStatus;
+struct LevelData;
 
 class StyleData
 {
@@ -130,7 +131,7 @@ public:
     void update(ssvu::FT mFT, float mMult = 1.f);
     void computeColors(const LevelStatus& levelStatus);
     void drawBackgroundMenu(sf::RenderTarget& mRenderTarget,
-        const sf::Vector2f& mCenterPos, const LevelStatus& levelStatus,
+        const sf::Vector2f& mCenterPos, const LevelData& levelData,
         const bool fourByThree) const;
     void drawBackground(sf::RenderTarget& mRenderTarget,
         const sf::Vector2f& mCenterPos, const LevelStatus& levelStatus) const;

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -159,7 +159,6 @@ void StyleData::drawBackground(sf::RenderTarget& mRenderTarget,
 
     const auto& colors(getColors());
     const sf::Color colorMain{getMainColor()};
-    const sf::Color colorCap{getCapColorResult()};
 
     for(auto i(0u); i < sides; ++i)
     {
@@ -190,10 +189,10 @@ void StyleData::drawBackground(sf::RenderTarget& mRenderTarget,
 }
 
 void StyleData::drawBackgroundMenu(sf::RenderTarget& mRenderTarget,
-    const sf::Vector2f& mCenterPos, const LevelStatus& levelStatus,
+    const sf::Vector2f& mCenterPos, const LevelData& levelData,
     const bool fourByThree) const
 {
-    const auto sides = levelStatus.sides;
+    const unsigned int sides = levelData.menuSides;
 
     const float div{ssvu::tau / sides * 1.0001f}, halfDiv{div / 2.f},
         distance{bgTileRadius}, hexagonRadius{fourByThree ? 75.f : 100.f};
@@ -218,7 +217,7 @@ void StyleData::drawBackgroundMenu(sf::RenderTarget& mRenderTarget,
         const bool darkenUnevenBackgroundChunk =
             (i % 2 == 0 && i == sides - 1) &&
             Config::getDarkenUnevenBackgroundChunk() &&
-            levelStatus.darkenUnevenBackgroundChunk;
+                levelData.menuDarkenUnevenBackgroundChunk;
 
         if(Config::getBlackAndWhite())
         {

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -456,7 +456,7 @@ std::string HGAssets::reloadPack(
 {
     std::string temp, output;
 
-    // Levels, if there is not folder cancel everything
+    // Levels, if there is no folder cancel everything
     temp = mPath + "Levels/";
     if(!ssvufs::Path{temp}.exists<ssvufs::Type::Folder>())
     {


### PR DESCRIPTION
Recently I noticed how sometimes the game stutters when changing selected level in the menu.
I suspect the culprit is the function initLua() which does a pretty significant amount of work and is called every time the index of the level selection is changed.
I have repositioned the lua initialization to just before a new level is initialized.

setIndex() now has a new function that goes through the lua script file to find the only two pieces of info necessary to properly draw the menu background: l_setSides and l_setRotationSpeed.
Upon applying this solution I do not notice any more stuttering in the level changes.
The function is just a file reader that looks for the onInit function and reads the two required lines. If there is a better way to handle it please let me know.

P.S: I have also renamed a variable with a misleading name and re-added the "DIFFICULTY: " string that had been removed by accident (at least I think, sorry if that was intentional and I could not figure out the reason).