### PR TITLE
Only call initLua() at boot

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -97,7 +97,8 @@ private:
 
     void initAssets();
     void initInput();
-    void initLua(Lua::LuaContext& mLua);
+    Lua::LuaContext lua;
+    void initLua();
     void initMenus();
     void playLocally();
     std::pair<const unsigned int, const unsigned int>


### PR DESCRIPTION
Recently I noticed how sometimes the game stutters when changing selected level in the menu.
I suspect the culprit is the function initLua() which does a pretty significant amount of work and is called every time the index of the level selection is changed.
I have slightly reworked it to only be called on menu initialization. There seem to be no drawbacks from this new approach.

P.S: I have also renamed a variable with a misleading name and re-added the "DIFFICULTY: " string that had been removed by accident (at least I think, sorry if that was intentional and I could not figure out the reason).