### PR TITLE
Fix glitchy level selection after command line level load

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1219,6 +1219,11 @@ bool MenuGame::loadCommandLineLevel(
     assets.pSetCurrent(enteredStr);
     changeStateTo(States::SMain);
 
+    // Go to level selection
+    resetNamesScrolls();
+    firstLevelSelection = false;
+    changeStateTo(States::LevelSelection);
+
     // Start game
     window.setGameState(hexagonGame.getGame());
     hexagonGame.newGame(packID,


### PR DESCRIPTION
As per title.
A small fix to address wonky behavior in the level selection menu after using the command line level load.