### PR TITLE
Hardcoded keys reference message

### DIFF
--- a/include/SSVOpenHexagon/Core/BindControl.hpp
+++ b/include/SSVOpenHexagon/Core/BindControl.hpp
@@ -26,7 +26,7 @@ public:
         const std::string& mName, const int mID);
 
     [[nodiscard]] virtual bool erase();
-    [[nodiscard]] virtual bool isWaitingForBind();
+    [[nodiscard]] virtual bool isWaitingForBind() const;
 };
 
 class KeyboardBindControl final : public BindControlBase
@@ -86,7 +86,7 @@ public:
 
     void exec() override;
 
-    [[nodiscard]] bool isWaitingForBind() override;
+    [[nodiscard]] bool isWaitingForBind() const override;
     [[nodiscard]] bool erase() override;
 
     bool newKeyboardBind(const ssvs::KKey key);
@@ -118,7 +118,7 @@ public:
 
     void exec() override;
 
-    [[nodiscard]] bool isWaitingForBind() override;
+    [[nodiscard]] bool isWaitingForBind() const override;
     [[nodiscard]] bool erase() override;
 
     void newJoystickBind(const unsigned int joy);

--- a/src/SSVOpenHexagon/Core/BindControl.cpp
+++ b/src/SSVOpenHexagon/Core/BindControl.cpp
@@ -28,7 +28,7 @@ BindControlBase::BindControlBase(ssvms::Menu& mMenu, ssvms::Category& mCategory,
     return false;
 }
 
-[[nodiscard]] bool BindControlBase::isWaitingForBind()
+[[nodiscard]] bool BindControlBase::isWaitingForBind() const
 {
     return false;
 }
@@ -56,7 +56,7 @@ void KeyboardBindControl::exec()
     waitingForBind = !waitingForBind;
 }
 
-[[nodiscard]] bool KeyboardBindControl::isWaitingForBind()
+[[nodiscard]] bool KeyboardBindControl::isWaitingForBind() const
 {
     return waitingForBind;
 }
@@ -145,7 +145,7 @@ void JoystickBindControl::exec()
     waitingForBind = !waitingForBind;
 }
 
-[[nodiscard]] bool JoystickBindControl::isWaitingForBind()
+[[nodiscard]] bool JoystickBindControl::isWaitingForBind() const
 {
     return waitingForBind;
 }

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -77,7 +77,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
         // Disable scroll while assigning a bind
         if(state == States::MOpts)
         {
-            auto* bc{
+            const auto* const bc{
                 dynamic_cast<BindControlBase*>(&getCurrentMenu()->getItem())};
             if(bc != nullptr && bc->isWaitingForBind())
             {
@@ -191,7 +191,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                 return;
             }
 
-            auto* bc{dynamic_cast<KeyboardBindControl*>(
+            auto* const bc{dynamic_cast<KeyboardBindControl*>(
                 &getCurrentMenu()->getItem())};
 
             // don't try assigning a keyboard key to a controller bind
@@ -262,7 +262,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                     return;
                 }
 
-                auto* bc{dynamic_cast<KeyboardBindControl*>(
+                auto* const bc{dynamic_cast<KeyboardBindControl*>(
                     &getCurrentMenu()->getItem())};
 
                 // don't try assigning a keyboard key to a controller bind
@@ -319,7 +319,7 @@ MenuGame::MenuGame(Steam::steam_manager& mSteamManager,
                     return;
                 }
 
-                auto* bc{dynamic_cast<JoystickBindControl*>(
+                auto* const bc{dynamic_cast<JoystickBindControl*>(
                     &getCurrentMenu()->getItem())};
 
                 // don't try assigning a controller button to a keyboard bind
@@ -598,20 +598,20 @@ void MenuGame::initInput()
         t::Once);
 
     game.addInput( // hardcoded
-        {{k::F5}}, [this](ssvu::FT /*unused*/) { reloadAssets(false); },
+        {{k::F1}}, [this](ssvu::FT /*unused*/) { changeLevelFavoriteFlag(); },
         t::Once);
 
     game.addInput( // hardcoded
-        {{k::F6}}, [this](ssvu::FT /*unused*/) { reloadAssets(true); },
-        t::Once);
-
-    game.addInput( // hardcoded
-        {{k::F7}}, [this](ssvu::FT /*unused*/) { changeLevelFavoriteFlag(); },
-        t::Once);
-
-    game.addInput( // hardcoded
-        {{k::F8}},
+        {{k::F2}},
         [this](ssvu::FT /*unused*/) { switchToFromFavoriteLevels(); }, t::Once);
+
+    game.addInput( // hardcoded
+        {{k::F3}}, [this](ssvu::FT /*unused*/) { reloadAssets(false); },
+        t::Once);
+
+    game.addInput( // hardcoded
+        {{k::F4}}, [this](ssvu::FT /*unused*/) { reloadAssets(true); },
+        t::Once);
 }
 
 void MenuGame::initLua()
@@ -835,6 +835,20 @@ void MenuGame::initMenus()
     controls.create<i::Single>("reset binds", [this] {
         Config::resetBindsToDefaults();
         refreshBinds();
+    });
+    controls.create<i::Single>("hardcoded keys reference", [this] {
+        dialogBox.create(
+            "UP ARROW - UP\n"
+            "DOWN ARROW - DOWN\n"
+            "RETURN - ENTER\n"
+            "BACKSPACE - REMOVE BIND\n"
+            "F1 - ADD LEVEL TO FAVORITES\n"
+            "F2 - SWITCH TO/FROM FAVORITE LEVELS\n"
+            "F3 - RELOAD LEVEL ASSETS (DEBUG MODE ONLY)\n"
+            "F4 - RELOAD PACK ASSETS (DEBUG MODE ONLY)\n\n"
+            "PRESS ANY KEY OR BUTTON TO CLOSE THIS MESSAGE\n",
+            26, 10.f, DBoxDraw::center);
+        setIgnoreAllInputs(2);
     });
     controls.create<i::GoBack>("back");
 
@@ -1635,7 +1649,7 @@ void MenuGame::okAction()
             // There are two Bind controllers: KeyboardBindControl and
             // JoystickBindControl. So we cast to the common base class to not
             // check for one and the other.
-            auto* bc{
+            const auto* const bc{
                 dynamic_cast<BindControlBase*>(&getCurrentMenu()->getItem())};
             if(bc != nullptr && bc->isWaitingForBind())
             {
@@ -1726,8 +1740,8 @@ void MenuGame::eraseAction()
     {
         std::string name{
             profileSelectionMenu.getCategory().getItem().getName()};
-        // There must be at least one profile. don't erase currently profile in
-        // use
+        // There must be at least one profile, don't erase profile
+        // currently in use.
         if(profileSelectionMenu.getCategory().getItems().size() <= 1)
         {
             assets.playSound("error.ogg");
@@ -1764,7 +1778,7 @@ void MenuGame::eraseAction()
     }
     else if(state == States::MOpts && isInMenu())
     {
-        auto* bc{dynamic_cast<BindControlBase*>(&getCurrentMenu()->getItem())};
+        auto* const bc{dynamic_cast<BindControlBase*>(&getCurrentMenu()->getItem())};
         if(bc == nullptr)
         {
             return;
@@ -4093,7 +4107,7 @@ void MenuGame::drawLevelSelectionLeftSide(
     menuQuads.clear();
 
     renderTextCenteredOffset(
-        levelData.favorite ? "UNFAVORITE - F7" : "FAVORITE - F7",
+        levelData.favorite ? "UNFAVORITE" : "FAVORITE",
         txtSelectionMedium.font, {sidepanelIndent / 2.f, height},
         -leftSideOffset, menuQuadColor);
 


### PR DESCRIPTION
Added a little menu option to display a message showing all the hardcoded controls.
I originally wanted to show the controls somewhere in the menu themselves but could not find a suitable spot where to place them without causing overlaps or making the screen too busy.
While a bit old school I think this is a simple and elegant solution.

Also, since F1 to F4 are no longer used I have reassigned the currently in use FX keys as shown in the picture.

![capture](https://user-images.githubusercontent.com/55557854/106359297-12266780-6312-11eb-99a5-e795c24752d8.PNG)
