### PR TITLE
Favorite levels visual cue

### DIFF
--- a/include/SSVOpenHexagon/Core/MenuGame.hpp
+++ b/include/SSVOpenHexagon/Core/MenuGame.hpp
@@ -249,6 +249,7 @@ private:
     sf::Color menuTextColor;
     sf::Color menuQuadColor;
     sf::Color menuSelectionColor;
+    sf::Color dialogBoxTextColor;
     Utils::FastVertexVector<sf::PrimitiveType::Quads> menuQuads;
 
     void draw();

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -2135,6 +2135,9 @@ void MenuGame::setIndex(const int mIdx)
     }
     menuTextColor = colors[0];
 
+    dialogBoxTextColor = menuQuadColor;
+    dialogBoxTextColor.a = 255;
+
     if(colors.size() == 1)
     {
         menuTextColor.a = 255;
@@ -3682,9 +3685,9 @@ void MenuGame::drawLevelSelectionRightSide(
     LevelDrawer& drawer, const bool revertOffset)
 {
     const float outerFrame{textToQuadBorder + slctFrameSize},
-        sidepanelIndent{w * 0.33f}, quadsIndent{w - sidepanelIndent},
+        sidepanelIndent{w * 0.33f - outerFrame}, quadsIndent{w - sidepanelIndent},
         txtIndent{w - sidepanelIndent / 2.f},
-        levelIndent{quadsIndent + textToQuadBorder},
+        levelIndent{quadsIndent + outerFrame},
         rightSideOffset{
             calcMenuOffset(drawer.XOffset, w - quadsIndent, revertOffset)};
     const auto& infos{assets.getPackInfos()};
@@ -3820,6 +3823,8 @@ void MenuGame::drawLevelSelectionRightSide(
     {
         height = drawer.YOffset;
     }
+    
+    
 
     //----------------------------------------
     // PACKS LABELS
@@ -4396,7 +4401,7 @@ void MenuGame::draw()
 
     if(!dialogBox.empty())
     {
-        dialogBox.draw(styleData.getTextColor(), styleData.getColor(0));
+        dialogBox.draw(dialogBoxTextColor, styleData.getColor(0));
     }
 }
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1533,7 +1533,29 @@ void MenuGame::changePackQuick(const int direction)
     assets.playSound("beep.ogg");
     changePack();
     adjustLevelsOffset();
-    lvlDrawer->YOffset = -packLabelHeight * lvlDrawer->packIdx;
+
+    // YOffset is 0 when the first pack is shown and gets lower
+    // the further down we have to scroll.
+
+    // Height of the top of the pack label that is one index before the current one.
+    float scroll{packLabelHeight * (lvlDrawer->packIdx - 1) + lvlDrawer->YOffset};
+
+    // If the height is lower than the offset of the level selection we must change to
+    // that to show the labels before the current one.
+    if(scroll < 0.f)
+    {
+        lvlDrawer->YOffset = std::min(lvlDrawer->YOffset - scroll, 0.f);
+        return;
+    }
+
+    // Height of the bottom of the pack label that is one index after the current one.
+    scroll = packLabelHeight * (lvlDrawer->packIdx + 2) + levelLabelHeight + 3.f * slctFrameSize + lvlDrawer->YOffset;
+
+    // If the height is outside the boundaries of the screen adjust offset to show it.
+    if(scroll > h)
+    {
+        lvlDrawer->YOffset += h - scroll;
+    }
 }
 
 void MenuGame::changePackAction(const int direction)
@@ -2037,7 +2059,7 @@ void MenuGame::update(ssvu::FT mFT)
                     break;
             }
 
-            const float levelSelectionTotalHeight = getLevelSelectionHeight();
+            const float levelSelectionTotalHeight{getLevelSelectionHeight()};
 
             // If the height of the list is smaller than the window
             // height the offset of the list is always 0.
@@ -2074,7 +2096,7 @@ void MenuGame::update(ssvu::FT mFT)
             // If the list is higher than the screen make sure
             // there is no empty space between the bottom of
             // the list and the bottom of the window.
-            const float temp = h - levelSelectionTotalHeight;
+            const float temp{h - levelSelectionTotalHeight};
             if(lvlDrawer->YOffset <= temp)
             {
                 lvlDrawer->YOffset = temp;
@@ -3688,6 +3710,11 @@ void MenuGame::drawLevelSelectionRightSide(
     // Therefore pack labels must be drawn above everything else (aka must
     // be drawn last).
 
+    renderTextCentered(
+        isFavoriteLevels() ? "PRESS F2 TO SHOW ALL LEVELS" :
+                             "PRESS F2 TO SHOW FAVORITE LEVELS",
+        txtSelectionSmall.font, {w / 2.f, 5.f});
+
     //----------------------------------------
     // LEVELS LIST
 
@@ -4107,7 +4134,7 @@ void MenuGame::drawLevelSelectionLeftSide(
     menuQuads.clear();
 
     renderTextCenteredOffset(
-        levelData.favorite ? "UNFAVORITE" : "FAVORITE",
+        levelData.favorite ? "UNFAVORITE - F1" : "FAVORITE - F1",
         txtSelectionMedium.font, {sidepanelIndent / 2.f, height},
         -leftSideOffset, menuQuadColor);
 


### PR DESCRIPTION
Also improved the quick switch list scrolling (now it shows one label ahead/behind depending on the height of the labels).
NOTE: the tip can never be covered by a level label thanks to the look-ahead level scrolling system.

![Capture](https://user-images.githubusercontent.com/55557854/106364432-3ba1bc00-632f-11eb-807d-24d625378fa7.PNG)

