### PR TITLE
Fixed pack description in favorites

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1376,15 +1376,29 @@ void MenuGame::upAction()
             return;
         }
 
-        if(lvlDrawer->currentIndex - 1 < 0)
+        if(getPackInfosSize() == 1)
         {
-            // If just one pack, pack change
-            // should not be triggered.
-            if(getPackInfosSize() == 1)
+            setIndex(ssvu::getMod(lvlDrawer->currentIndex - 1, 0,
+                lvlDrawer->levelDataIds.size()));
+
+            if(isFavoriteLevels())
             {
-                return;
+                const auto& p{assets.getPackInfos()};
+
+                for(int i{0}; i < static_cast<int>(p.size()); ++i)
+                {
+                    if(levelData->packId == p.at(i).id)
+                    {
+                        lvlDrawer->packIdx = i;
+                        break;
+                    }
+                }
             }
 
+            calcLevelChangeScroll(-2);
+        }
+        else if(lvlDrawer->currentIndex - 1 < 0)
+        {
             // -2 means "go to previous pack and
             // skip to the last level of the list"
             changePackAction(-2);
@@ -1429,7 +1443,8 @@ void MenuGame::upAction()
     do
     {
         getCurrentMenu()->previous();
-    } while(!getCurrentMenu()->getItem().isEnabled());
+    }
+    while(!getCurrentMenu()->getItem().isEnabled());
 
     assets.playSound("beep.ogg");
     touchDelay = 50.f;
@@ -1452,13 +1467,30 @@ void MenuGame::downAction()
             return;
         }
 
-        if(lvlDrawer->currentIndex + 1 >
+        if(getPackInfosSize() == 1)
+        {
+            setIndex(ssvu::getMod(lvlDrawer->currentIndex + 1, 0,
+                lvlDrawer->levelDataIds.size()));
+
+            if(isFavoriteLevels())
+            {
+                const auto& p{assets.getPackInfos()};
+
+                for(int i{0}; i < static_cast<int>(p.size()); ++i)
+                {
+                    if(levelData->packId == p.at(i).id)
+                    {
+                        lvlDrawer->packIdx = i;
+                        break;
+                    }
+                }
+            }
+
+            calcLevelChangeScroll(2);
+        }
+        else if(lvlDrawer->currentIndex + 1 >
             ssvu::toInt(lvlDrawer->levelDataIds.size() - 1))
         {
-            if(getPackInfosSize() == 1)
-            {
-                return;
-            }
             changePackAction(1);
         }
         else
@@ -1503,7 +1535,8 @@ void MenuGame::downAction()
     do
     {
         getCurrentMenu()->next();
-    } while(!getCurrentMenu()->getItem().isEnabled());
+    }
+    while(!getCurrentMenu()->getItem().isEnabled());
 
     assets.playSound("beep.ogg");
     touchDelay = 50.f;
@@ -3725,7 +3758,7 @@ void MenuGame::drawLevelSelectionRightSide(
     Color alphaTextColor{
         menuTextColor.r, menuTextColor.g, menuTextColor.b, 150};
     txtSelectionMedium.font.setFillColor(menuTextColor);
-    height = packLabelHeight * (drawer.packIdx + 1) + slctFrameSize -
+    height = packLabelHeight * (isFavoriteLevels() ? 1 : drawer.packIdx + 1) + slctFrameSize -
              packChangeOffset + drawer.YOffset;
 
     for(i = 0; i < levelsSize; ++i)
@@ -3823,8 +3856,6 @@ void MenuGame::drawLevelSelectionRightSide(
     {
         height = drawer.YOffset;
     }
-    
-    
 
     //----------------------------------------
     // PACKS LABELS
@@ -3944,7 +3975,8 @@ void MenuGame::drawLevelSelectionRightSide(
         {
             height = drawer.YOffset;
         }
-    } while(i != ssvu::getMod(drawer.packIdx + 1, packsSize));
+    }
+    while(i != ssvu::getMod(drawer.packIdx + 1, packsSize));
 }
 
 void MenuGame::drawLevelSelectionLeftSide(

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1380,21 +1380,6 @@ void MenuGame::upAction()
         {
             setIndex(ssvu::getMod(lvlDrawer->currentIndex - 1, 0,
                 lvlDrawer->levelDataIds.size()));
-
-            if(isFavoriteLevels())
-            {
-                const auto& p{assets.getPackInfos()};
-
-                for(int i{0}; i < static_cast<int>(p.size()); ++i)
-                {
-                    if(levelData->packId == p.at(i).id)
-                    {
-                        lvlDrawer->packIdx = i;
-                        break;
-                    }
-                }
-            }
-
             calcLevelChangeScroll(-2);
         }
         else if(lvlDrawer->currentIndex - 1 < 0)
@@ -1471,21 +1456,6 @@ void MenuGame::downAction()
         {
             setIndex(ssvu::getMod(lvlDrawer->currentIndex + 1, 0,
                 lvlDrawer->levelDataIds.size()));
-
-            if(isFavoriteLevels())
-            {
-                const auto& p{assets.getPackInfos()};
-
-                for(int i{0}; i < static_cast<int>(p.size()); ++i)
-                {
-                    if(levelData->packId == p.at(i).id)
-                    {
-                        lvlDrawer->packIdx = i;
-                        break;
-                    }
-                }
-            }
-
             calcLevelChangeScroll(2);
         }
         else if(lvlDrawer->currentIndex + 1 >
@@ -2151,6 +2121,20 @@ void MenuGame::setIndex(const int mIdx)
 
     styleData = assets.getStyleData(levelData->packId, levelData->styleId);
     styleData.computeColors(levelStatus);
+
+    if(isFavoriteLevels())
+    {
+        const auto& p{assets.getPackInfos()};
+
+        for(int i{0}; i < static_cast<int>(p.size()); ++i)
+        {
+            if(levelData->packId == p.at(i).id)
+            {
+                lvlDrawer->packIdx = i;
+                break;
+            }
+        }
+    }
 
     // Set the colors of the menus
     auto& colors{styleData.getColors()};


### PR DESCRIPTION
Changing level in the favorite levels submenu was not updating the pack id, and therefore the level description always defaulted to the pack at index 0.