### PR TITLE
fix collision on levels with a really high amount of sides

### DIFF
--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -174,12 +174,12 @@ void CPlayer::kill(HexagonGame& mHexagonGame)
         return false;
     }
 
-    constexpr float padding{0.025f};
     int movement{mHexagonGame.getInputMovement()};
 
     // First of all, if it's a rotating wall push player in the direction the
     // wall is rotating by the appropriate amount, but only if the direction
     // of the rotation is different from the direction player is moving.
+    constexpr float padding{0.025f};
     const SpeedData& curveData{wall.getCurve()};
     const int speedSign{ssvu::getSign(curveData.speed)};
 
@@ -204,13 +204,14 @@ void CPlayer::kill(HexagonGame& mHexagonGame)
         mHexagonGame.getPlayerSpeedMult() *
         (mHexagonGame.getInputFocused() ? focusSpeed : speed)};
 
-    lastAngle =
-        angle + ssvu::toRad(currentSpeed * movement * mFT) + movement * padding;
-    lastPos = ssvs::getOrbitRad(startPos, lastAngle, mHexagonGame.getRadius());
+    const float testAngle{
+        angle + ssvu::toRad(currentSpeed * movement * mFT) + movement * padding};
+    const sf::Vector2f testPos{
+        ssvs::getOrbitRad(startPos, testAngle, mHexagonGame.getRadius())};
 
     // If there is overlap even after compensation kill without updating
     // position, as there is no benefit in doing it.
-    if(wall.isOverlapping(lastPos))
+    if(wall.isOverlapping(testPos))
     {
         return true;
     }
@@ -222,12 +223,10 @@ void CPlayer::kill(HexagonGame& mHexagonGame)
     const std::array<sf::Vector2f, 4>& wVertexes{wall.getVertexes()};
     const float radZero{ssvs::getRad(wVertexes[0])},
         radOne{ssvs::getRad(wVertexes[1])};
-
-    angle = ssvu::getDistRad(angle, radOne) > ssvu::getDistRad(angle, radZero)
+    angle = ssvu::getDistRad(lastAngle, radOne) > ssvu::getDistRad(lastAngle, radZero)
                 ? radZero
                 : radOne;
     angle += movement * padding;
-
     updatePosition(mHexagonGame, mFT);
     return false;
 }


### PR DESCRIPTION
The fix: in CPlayer::push() I was reusing lastAngle and lastPos to store the position to be tested for overlap.
Problem is, to then figure put where the player should have been repositioned we need to use the actual position in the previous frame, not the test position i stored in the variables a few lines before.
This was an issue on levels with an outrageous amount of sides (more than 50) where pinpoint accuracy was essential.

Instead of reusing lastPos I added a dedicated variable in the function (testPos) to store the position to be tested after the movement compensation.