### PR TITLE
Minor fixes/changes for 2.0.4

### DIFF
--- a/buildlx/cmake_gcc.sh
+++ b/buildlx/cmake_gcc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -g -fsanitize=undefined -Wall -Wextra -Wpedantic"
+cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -g -fsanitize=address -Wall -Wextra -Wpedantic"
 
 

--- a/include/SSVOpenHexagon/Components/CPlayer.hpp
+++ b/include/SSVOpenHexagon/Components/CPlayer.hpp
@@ -95,7 +95,11 @@ public:
     void kill(HexagonGame& mHexagonGame);
 
     void update(HexagonGame& mHexagonGame, const ssvu::FT mFT);
-    void updateInput(HexagonGame& mHexagonGame, const ssvu::FT mFT);
+
+    [[nodiscard]] bool updateInput(
+        HexagonGame& mHexagonGame, const ssvu::FT mFT);
+    // Returns `true` if the player swapped, `false` otherwise.
+
     void updatePosition(const HexagonGame& mHexagonGame, const ssvu::FT mFT);
 
     void draw(HexagonGame& mHexagonGame, const sf::Color& mCapColor);

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -138,6 +138,8 @@ private:
     random_number_generator rng;
     HexagonGameStatus status;
 
+    float deathInputIgnore{0.f};
+
     struct ActiveReplay
     {
         replay_file replayFile;
@@ -259,6 +261,16 @@ public:
                       << "\" with level \"" << levelData->name << "\": \n"
                       << ssvu::toStr(mError.what()) << "\n"
                       << std::endl;
+
+            if(!Config::getDebug())
+            {
+                goToMenu(false /* mSendScores */, true /* mError */);
+            }
+        }
+        catch(...)
+        {
+            std::cout << "[runLuaFunction] Unknown error on \"" << mName
+                      << "\" with level \"" << levelData->name << std::endl;
 
             if(!Config::getDebug())
             {

--- a/include/SSVOpenHexagon/Global/Assets.hpp
+++ b/include/SSVOpenHexagon/Global/Assets.hpp
@@ -158,7 +158,7 @@ public:
         return getLevelData(mPackId + "_" + mId);
     }
 
-    bool checkLevelIDValidity(const std::string& mAssetId)
+    [[nodiscard]] bool checkLevelIDValidity(const std::string& mAssetId)
     {
         return levelDatas.find(mAssetId) != levelDatas.end();
     }

--- a/include/SSVOpenHexagon/Global/Config.hpp
+++ b/include/SSVOpenHexagon/Global/Config.hpp
@@ -24,7 +24,7 @@ class Trigger;
 namespace hg::Config
 {
 
-inline constexpr GameVersion GAME_VERSION{2, 0, 3};
+inline constexpr GameVersion GAME_VERSION{2, 0, 4};
 
 void loadConfig(const std::vector<std::string>& mOverridesIds);
 void resetConfigToDefaults();

--- a/include/SSVOpenHexagon/Utils/LuaMetadataProxy.hpp
+++ b/include/SSVOpenHexagon/Utils/LuaMetadataProxy.hpp
@@ -13,9 +13,15 @@
 #include <vector>
 #include <utility>
 #include <type_traits>
+#include <tuple>
 
 namespace hg::Utils
 {
+
+template <typename>
+struct TypeWrapper
+{
+};
 
 class LuaMetadataProxy
 {
@@ -27,62 +33,70 @@ private:
     std::string docs;
     std::vector<std::string> argNames;
 
-    template <typename T>
-    [[nodiscard]] constexpr static const char* typeToStr() noexcept
+    template <typename... Ts>
+    [[nodiscard]] static std::string typeToStr(
+        TypeWrapper<std::tuple<Ts...>>) noexcept
     {
-        using Type = std::decay_t<T>;
+        std::string result;
 
-        if constexpr(std::is_same_v<Type, void>)
+        result += "tuple<";
+        ((result += typeToStr(TypeWrapper<Ts>{})), ...);
+        result += ">";
+
+        return result;
+    }
+
+    template <typename T>
+    [[nodiscard]] constexpr static const char* typeToStr(
+        TypeWrapper<T>) noexcept
+    {
+        if constexpr(std::is_same_v<T, void>)
         {
             return "void";
         }
-        else if constexpr(std::is_same_v<Type, bool>)
+        else if constexpr(std::is_same_v<T, bool>)
         {
             return "bool";
         }
-        else if constexpr(std::is_same_v<Type, int>)
+        else if constexpr(std::is_same_v<T, int>)
         {
             return "int";
         }
-        else if constexpr(std::is_same_v<Type, float>)
+        else if constexpr(std::is_same_v<T, float>)
         {
             return "float";
         }
-        else if constexpr(std::is_same_v<Type, double>)
+        else if constexpr(std::is_same_v<T, double>)
         {
             return "double";
         }
-        else if constexpr(std::is_same_v<Type, std::string>)
+        else if constexpr(std::is_same_v<T, std::string>)
         {
             return "string";
         }
-        else if constexpr(std::is_same_v<Type, unsigned int>)
+        else if constexpr(std::is_same_v<T, unsigned int>)
         {
             return "unsigned int";
         }
-        else if constexpr(std::is_same_v<Type, long>)
+        else if constexpr(std::is_same_v<T, long>)
         {
             return "long";
         }
-        else if constexpr(std::is_same_v<Type, unsigned long>)
+        else if constexpr(std::is_same_v<T, unsigned long>)
         {
             return "unsigned long";
         }
-        else if constexpr(std::is_same_v<Type, long long>)
+        else if constexpr(std::is_same_v<T, long long>)
         {
             return "long long";
         }
-        else if constexpr(std::is_same_v<Type, unsigned long long>)
+        else if constexpr(std::is_same_v<T, unsigned long long>)
         {
             return "unsigned long long";
         }
-        else if constexpr(std::is_same_v<Type, std::size_t>)
+        else if constexpr(std::is_same_v<T, std::size_t>)
         {
             return "size_t";
-        }
-        else if constexpr(std::is_same_v<Type, std::tuple<float, float>>)
-        {
-            return "tuple<float, float>";
         }
         else
         {
@@ -94,7 +108,7 @@ private:
     template <typename ArgT>
     static void addTypeToStr(std::vector<std::string>& types)
     {
-        types.emplace_back(typeToStr<ArgT>());
+        types.emplace_back(typeToStr(TypeWrapper<std::decay_t<ArgT>>{}));
     }
 
     template <typename F>
@@ -169,7 +183,8 @@ public:
               using AE =
                   Utils::ArgExtractor<decltype(&std::decay_t<F>::operator())>;
 
-              return typeToStr<typename AE::Return>();
+              return typeToStr(
+                  TypeWrapper<std::decay_t<typename AE::Return>>{});
           }},
           erasedArgs{[](LuaMetadataProxy* self) {
               return makeArgsString<std::decay_t<F>>(self);

--- a/include/SSVOpenHexagon/Utils/LuaWrapper.hpp
+++ b/include/SSVOpenHexagon/Utils/LuaWrapper.hpp
@@ -798,10 +798,19 @@ private:
             // pushed on the stack
             const std::string errorMsg =
                 _readTopAndPop(1, (std::string*)nullptr);
+
             if(pcallReturnValue == LUA_ERRMEM)
-                throw(std::bad_alloc());
+            {
+                throw std::bad_alloc();
+            }
             else if(pcallReturnValue == LUA_ERRRUN)
-                throw(ExecutionErrorException(errorMsg));
+            {
+                throw ExecutionErrorException(errorMsg);
+            }
+            else
+            {
+                throw std::runtime_error("UNKNOWN RC: " + errorMsg);
+            }
         }
 
         // pcall succeeded, we pop the returned values and return them

--- a/include/SSVOpenHexagon/Utils/Utils.hpp
+++ b/include/SSVOpenHexagon/Utils/Utils.hpp
@@ -108,6 +108,29 @@ void recursiveFillIncludedLuaFileNames(std::set<std::string>& mLuaScriptNames,
 
 [[gnu::pure]] sf::Color transformHue(const sf::Color& in, float H);
 
+inline void runLuaCode(Lua::LuaContext& mLua, const std::string& mCode)
+{
+    try
+    {
+        mLua.executeCode(mCode);
+    }
+    catch(std::runtime_error& mError)
+    {
+        ssvu::lo("hg::Utils::runLuaCode") << "Fatal lua error"
+                                          << "\n";
+        ssvu::lo("hg::Utils::runLuaCode") << "Code: " << mCode << "\n";
+        ssvu::lo("hg::Utils::runLuaCode") << "Error: " << mError.what() << "\n"
+                                          << std::endl;
+    }
+    catch(...)
+    {
+        ssvu::lo("hg::Utils::runLuaCode") << "Fatal unknown lua error"
+                                          << "\n";
+        ssvu::lo("hg::Utils::runLuaCode") << "Code: " << mCode << "\n";
+        ssvu::lo("hg::Utils::runLuaCode") << std::endl;
+    }
+}
+
 inline void runLuaFile(Lua::LuaContext& mLua, const std::string& mFileName)
 {
     std::ifstream s{mFileName};
@@ -123,6 +146,13 @@ inline void runLuaFile(Lua::LuaContext& mLua, const std::string& mFileName)
         ssvu::lo("hg::Utils::runLuaFile") << "Filename: " << mFileName << "\n";
         ssvu::lo("hg::Utils::runLuaFile") << "Error: " << mError.what() << "\n"
                                           << std::endl;
+    }
+    catch(...)
+    {
+        ssvu::lo("hg::Utils::runLuaFile") << "Fatal unknown lua error"
+                                          << "\n";
+        ssvu::lo("hg::Utils::runLuaFile") << "Filename: " << mFileName << "\n";
+        ssvu::lo("hg::Utils::runLuaFile") << std::endl;
     }
 }
 

--- a/src/SSVOpenHexagon/Components/CPlayer.cpp
+++ b/src/SSVOpenHexagon/Components/CPlayer.cpp
@@ -408,7 +408,8 @@ void CPlayer::update(HexagonGame& mHexagonGame, const ssvu::FT mFT)
     forcedMove = false;
 }
 
-void CPlayer::updateInput(HexagonGame& mHexagonGame, const ssvu::FT mFT)
+[[nodiscard]] bool CPlayer::updateInput(
+    HexagonGame& mHexagonGame, const ssvu::FT mFT)
 {
     const int movement{mHexagonGame.getInputMovement()};
     currentSpeed = mHexagonGame.getPlayerSpeedMult() *
@@ -421,12 +422,13 @@ void CPlayer::updateInput(HexagonGame& mHexagonGame, const ssvu::FT mFT)
         playerSwap(mHexagonGame, true /* mPlaySound */);
         swapTimer.restart(mHexagonGame.getSwapCooldown());
         swapBlinkTimer.restart(mHexagonGame.getSwapCooldown() / 6.f);
+
         justSwapped = true;
+        return true;
     }
-    else
-    {
-        justSwapped = false;
-    }
+
+    justSwapped = false;
+    return false;
 }
 
 void CPlayer::updatePosition(

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -321,7 +321,7 @@ void HexagonGame::initLua_MainTimeline()
 {
     addLuaFn("t_eval",
         [this](const std::string& mCode) {
-            timeline.append_do([=, this] { lua.executeCode(mCode); });
+            timeline.append_do([=, this] { Utils::runLuaCode(lua, mCode); });
         })
         .arg("code")
         .doc(
@@ -1182,6 +1182,12 @@ void HexagonGame::initLua_StyleControl()
         .doc(
             "Set the color of the center polygon to match the  style "
             "color with index `$0`.");
+
+    // TODO:
+    addLuaFn("s_getMainColor", [this]() -> std::tuple<int, int, int, int> {
+        const sf::Color& c = styleData.getMainColor();
+        return {c.r, c.g, c.b, c.a};
+    });
 }
 
 void HexagonGame::initLua_WallCreation()

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -79,6 +79,11 @@ void HexagonGame::update(ssvu::FT mFT)
 
     updateKeyIcons();
 
+    if(deathInputIgnore > 0.f)
+    {
+        deathInputIgnore -= mFT;
+    }
+
     if(status.started)
     {
         player.update(*this, mFT);
@@ -91,7 +96,12 @@ void HexagonGame::update(ssvu::FT mFT)
 
             if(!preventPlayerInput.has_value() || !(*preventPlayerInput))
             {
-                player.updateInput(*this, mFT);
+                if(player.updateInput(*this, mFT))
+                {
+                    // Player successfully swapped.
+                    // TODO: document and cleanup
+                    runLuaFunctionIfExists<void>("onSwap");
+                }
             }
 
             status.accumulateFrametime(mFT);

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -167,7 +167,7 @@ HexagonGame::HexagonGame(Steam::steam_manager& mSteamManager,
     game.addInput(
         Config::getTriggerRestart(),
         [this](ssvu::FT /*unused*/) {
-            if(status.hasDied)
+            if(deathInputIgnore <= 0.f && status.hasDied)
             {
                 status.mustStateChange = StateChange::MustRestart;
             }
@@ -177,7 +177,7 @@ HexagonGame::HexagonGame(Steam::steam_manager& mSteamManager,
     game.addInput(
         Config::getTriggerReplay(),
         [this](ssvu::FT /*unused*/) {
-            if(status.hasDied)
+            if(deathInputIgnore <= 0.f && status.hasDied)
             {
                 status.mustStateChange = StateChange::MustReplay;
             }
@@ -478,6 +478,8 @@ void HexagonGame::death(bool mForce)
     {
         return;
     }
+
+    deathInputIgnore = 10.f;
 
     fpsWatcher.disable();
     assets.playSound(levelStatus.deathSound, ssvs::SoundPlayer::Mode::Abort);

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -656,6 +656,8 @@ void MenuGame::initLua()
             "u_isFastSpinning", "u_setPlayerAngle", "u_forceIncrement",
             "u_haltTime", "u_timelineWait", "u_clearWalls",
 
+            "u_rndReal", "u_rndIntUpper", "u_rndInt", "u_rndSwitch",
+
             "a_setMusic", "a_setMusicSegment", "a_setMusicSeconds",
             "a_playSound", "a_playPackSound", "a_syncMusicToDM",
             "a_setMusicPitch", "a_overrideBeepSound",

--- a/src/SSVOpenHexagon/Global/Config.cpp
+++ b/src/SSVOpenHexagon/Global/Config.cpp
@@ -207,7 +207,7 @@ void loadConfig(const vector<string>& mOverridesIds)
 {
     lo("::loadConfig") << "loading config\n";
 
-    for(const auto p :
+    for(const ssvufs::Path& p :
         getScan<ssvufs::Mode::Single, ssvufs::Type::File, ssvufs::Pick::ByExt>(
             "ConfigOverrides/", ".json"))
     {


### PR DESCRIPTION
- Minor fixes and optimizations
- Added a few milliseconds of ignoring input after death to avoid accidental restarts
- Added a new built-in Lua function, 'onSwap', called when the player successfully swaps
- Fixed 't_eval' crashing on Lua error
- Added 's_getMainColor' which returns a RGBA tuple of the current main color