### PR TITLE
Fix focus resetting background animation in main menu

### DIFF
--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1949,6 +1949,39 @@ void MenuGame::update(ssvu::FT mFT)
 
     Joystick::update();
 
+    // Focus should have no effect if we are in the favorites menu
+    // or a pack change animation is in progress.
+    if(state == States::LevelSelection && !isFavoriteLevels() &&
+        packChangeState == PackChange::Rest)
+    {
+        if(!focusHeld)
+        {
+            focusHeld = Joystick::pressed(Joystick::Jid::Focus);
+        }
+
+        // If focus was not pressed it means we have initiated a quick
+        // pack switch.
+        if(focusHeld && !wasFocusHeld)
+        {
+            if(lvlDrawer->currentIndex != 0)
+            {
+                setIndex(0);
+            }
+            quickPackFoldStretch();
+        }
+        else if(!focusHeld && wasFocusHeld)
+        {
+            // focus is now released we have to stretch the level list of the
+            // current menu.
+            quickPackFoldStretch();
+        }
+        wasFocusHeld = focusHeld;
+    }
+    else
+    {
+        wasFocusHeld = focusHeld = false;
+    }
+
     if(Joystick::risingEdge(Joystick::Jid::NextPack))
     {
         changePackAction(1);
@@ -1967,32 +2000,6 @@ void MenuGame::update(ssvu::FT mFT)
     {
         switchToFromFavoriteLevels();
     }
-
-    // Focus should have no effect if we are in the favorites menu
-    // or a pack change animation is in progress.
-    if(!(!isFavoriteLevels() && packChangeState == PackChange::Rest))
-    {
-        focusHeld = false;
-    }
-    else if(!focusHeld)
-    {
-        focusHeld = Joystick::pressed(Joystick::Jid::Focus);
-    }
-
-    // If focus was not pressed it means we have initiated a quick
-    // pack switch.
-    if(focusHeld && !wasFocusHeld)
-    {
-        setIndex(0);
-        quickPackFoldStretch();
-    }
-    else if(!focusHeld && wasFocusHeld)
-    {
-        // focus is now released we have to stretch the level list of the
-        // current menu.
-        quickPackFoldStretch();
-    }
-    wasFocusHeld = focusHeld;
 
     if(Joystick::risingEdge(Joystick::Jdir::Left))
     {


### PR DESCRIPTION
As per title, now focus presses only effect the menu when in Level Selection.