### PR TITLE
Add Wall Color Override to style JSONs

### DIFF
--- a/_RELEASE/Packs/experimental/Levels/wall_color_test.json
+++ b/_RELEASE/Packs/experimental/Levels/wall_color_test.json
@@ -1,0 +1,12 @@
+{
+    "id": "wall_color_test",
+    "name": "Wall Color Test",
+    "description": "Another style test yay",
+    "author": "Morxemplum",
+    "menuPriority": 31,
+    "selectable": true,
+    "styleId": "construct",
+    "musicId": "jackRussel",
+    "luaFile": "Scripts/Levels/negative_pulse.lua",
+    "difficultyMults": []
+}

--- a/_RELEASE/Packs/experimental/Styles/construct.json
+++ b/_RELEASE/Packs/experimental/Styles/construct.json
@@ -1,0 +1,37 @@
+{
+    // Style data id
+    "id": "construct",
+
+    // Hue options
+    "hue_min": 0,
+    "hue_max": 360,
+    "hue_ping_pong": true,
+    "hue_increment": 1.0,
+
+    // Pulse options
+    "pulse_min": 0.0,
+    "pulse_max": 1,
+    "pulse_increment": 0.025,
+
+    // 3D options
+    "3D_depth": 7,
+    "3D_skew": 0.15,
+    "3D_spacing": 1.5,
+    "3D_darken_multiplier": 1.5,
+    "3D_alpha_multiplier": 0.5,
+    "3D_alpha_falloff": 19.0,
+
+    // Main color
+    "main": { "main": true, "dynamic": false, "value": [0, 0, 0, 255], "pulse": [0, 0, 0, 0] },
+    "cap_color": {"legacy": false, "value": [255, 255, 255, 255], "pulse": [0, 0, 0, 0] },
+    "player_color": {"dynamic": false, "value": [0, 255, 0, 255], "pulse": [0, 0, 0, 0] },
+    "text_color": {"dynamic": false, "value": [255, 255, 255, 255], "pulse": [0, 0, 0, 0] },
+	"wall_color": {"dynamic": false, "value": [0, 198, 254, 255], "pulse": [0, 0, 0, 0] },
+
+    // Background colors
+    "colors":
+    [
+        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [255, 145, 0, 255], "pulse": [0, 0, 0, 0]},
+        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [219, 124, 0, 255], "pulse": [0, 0, 0, 0]}
+    ]
+}

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -371,9 +371,11 @@ private:
 
     Utils::FastVertexVectorTris backgroundTris;
     Utils::FastVertexVectorQuads wallQuads;
+    Utils::FastVertexVectorQuads pivotQuads;
     Utils::FastVertexVectorTris playerTris;
     Utils::FastVertexVectorTris capTris;
     Utils::FastVertexVectorQuads wallQuads3D;
+    Utils::FastVertexVectorQuads pivotQuads3D;
     Utils::FastVertexVectorTris playerTris3D;
 
 public:

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -45,6 +45,7 @@ private:
     sf::Color currentMainColor{sf::Color::Black};
     sf::Color currentPlayerColor{sf::Color::Black};
     sf::Color currentTextColor{sf::Color::Black};
+    sf::Color currentWallColor{sf::Color::White};
     sf::Color current3DOverrideColor{sf::Color::Black};
     std::vector<sf::Color> currentColors;
 
@@ -95,6 +96,7 @@ private:
     ColorData mainColorData;
     ColorData playerColor;
     ColorData textColor;
+    ColorData wallColor;
 
     CapColor capColor;
 
@@ -122,6 +124,7 @@ public:
     [[nodiscard]] const sf::Color& getMainColor() const noexcept;
     [[nodiscard]] const sf::Color& getPlayerColor() const noexcept;
     [[nodiscard]] const sf::Color& getTextColor() const noexcept;
+    [[nodiscard]] const sf::Color& getWallColor() const noexcept;
     [[nodiscard]] const std::vector<sf::Color>& getColors() const noexcept;
     [[nodiscard]] const sf::Color& getColor(
         const std::size_t mIdx) const noexcept;

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -61,6 +61,7 @@ StyleData::StyleData(const ssvuj::Obj& mRoot)
           colorDataFromObjOrDefault(mRoot, "player_color", mainColorData)}, //
       textColor{
           colorDataFromObjOrDefault(mRoot, "text_color", mainColorData)}, //
+      wallColor{colorDataFromObjOrDefault(mRoot, "wall_color", mainColorData)},
       capColor{parseCapColor(ssvuj::getObj(mRoot, "cap_color"))}
 {
     currentHue = hueMin;
@@ -173,6 +174,7 @@ void StyleData::computeColors()
     currentMainColor = calculateColor(currentHue, pulseFactor, mainColorData);
     currentPlayerColor = calculateColor(currentHue, pulseFactor, playerColor);
     currentTextColor = calculateColor(currentHue, pulseFactor, textColor);
+    currentWallColor = calculateColor(currentHue, pulseFactor, wallColor);
 
     current3DOverrideColor =
         _3dOverrideColor.a != 0 ? _3dOverrideColor : getMainColor();
@@ -298,6 +300,11 @@ void StyleData::setCapColor(const CapColor& mCapColor)
 [[nodiscard]] const sf::Color& StyleData::getTextColor() const noexcept
 {
     return currentTextColor;
+}
+
+[[nodiscard]] const sf::Color& StyleData::getWallColor() const noexcept
+{  
+    return currentWallColor;
 }
 
 [[nodiscard]] const std::vector<sf::Color>&


### PR DESCRIPTION
Another little pull request that I want to add to the game. This one adds a wall color override, which I should've done back in 2.0.3. I've even made a nice little experimental level with a style that I created using the wall color override, and it shows how you can make some nice stuff. I think it's nice you can have some wall color customization without the need to use custom walls.

I'm coming back to source code development with small little pull requests like these before I have to start working on my bigger changes.