### PR TITLE
Fix Black and White showing color in level / menu

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -467,6 +467,8 @@ public:
     [[nodiscard]] sf::Color getColorMain() const;
     [[nodiscard]] sf::Color getColorPlayer() const;
     [[nodiscard]] sf::Color getColorText() const;
+    [[nodiscard]] sf::Color getColorCap() const;
+    [[nodiscard]] sf::Color getColorWall() const;
     [[nodiscard]] float getMusicDMSyncFactor() const;
     [[nodiscard]] float getOptionalMusicDMSyncFactor() const;
 

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -62,7 +62,7 @@ private:
 
     void drawBackgroundMenuHexagonImpl(Utils::FastVertexVectorTris& vertices,
         const sf::Vector2f& mCenterPos, const unsigned int sides,
-        const bool fourByThree) const;
+        const bool fourByThree, const bool blackAndWhite) const;
 
 public:
     std::string id{};

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -104,7 +104,7 @@ void HexagonGame::draw()
 
     for(CWall& w : walls)
     {
-        w.draw(styleData.getWallColor(), wallQuads);
+        w.draw(getColorWall(), wallQuads);
     }
 
     cwManager.draw(wallQuads);
@@ -112,7 +112,7 @@ void HexagonGame::draw()
     if(status.started)
     {
         player.draw(getSides(), getColorMain(), getColorPlayer(), pivotQuads,
-            capTris, playerTris, styleData.getCapColorResult());
+            capTris, playerTris, getColorCap());
     }
 
     if(Config::get3D())
@@ -165,8 +165,19 @@ void HexagonGame::draw()
 
             const sf::Vector2f newPos(offset * cosRot, offset * sinRot);
 
-            sf::Color overrideColor{Utils::getColorDarkened(
-                styleData.get3DOverrideColor(), styleData._3dDarkenMult)};
+            sf::Color overrideColor;
+
+            if(!Config::getBlackAndWhite())
+            {
+                overrideColor = Utils::getColorDarkened(
+                    styleData.get3DOverrideColor(), styleData._3dDarkenMult);
+            }
+            else
+            {
+                overrideColor = Utils::getColorDarkened(
+                    sf::Color(255, 255, 255, styleData.getMainColor().a),
+                    styleData._3dDarkenMult);
+            }
             adjustAlpha(overrideColor, i);
 
             // Draw pivot layers
@@ -180,7 +191,7 @@ void HexagonGame::draw()
             if(styleData.get3DOverrideColor() == styleData.getMainColor())
             {
                 overrideColor = Utils::getColorDarkened(
-                    styleData.getWallColor(), styleData._3dDarkenMult);
+                    getColorWall(), styleData._3dDarkenMult);
 
                 adjustAlpha(overrideColor, i);
             }
@@ -197,7 +208,7 @@ void HexagonGame::draw()
             if(styleData.get3DOverrideColor() == styleData.getMainColor())
             {
                 overrideColor = Utils::getColorDarkened(
-                    styleData.getPlayerColor(), styleData._3dDarkenMult);
+                    getColorPlayer(), styleData._3dDarkenMult);
 
                 adjustAlpha(overrideColor, i);
             }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -1388,6 +1388,26 @@ auto HexagonGame::getColorText() const -> sf::Color
     return styleData.getTextColor();
 }
 
+auto HexagonGame::getColorCap() const -> sf::Color
+{
+    if (Config::getBlackAndWhite()) 
+    {
+        return sf::Color::Black;
+    }
+
+    return styleData.getCapColorResult();
+}
+
+auto HexagonGame::getColorWall() const -> sf::Color
+{
+    if (Config::getBlackAndWhite()) 
+    {
+        return sf::Color(255, 255, 255, styleData.getWallColor().a);
+    }
+
+    return styleData.getWallColor();
+}
+
 [[nodiscard]] float HexagonGame::getMusicDMSyncFactor() const
 {
     return std::pow(difficultyMult, 0.12f);

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -2901,8 +2901,8 @@ void MenuGame::setIndex(const int mIdx)
 
     // Set the colors of the menus
     auto& colors{styleData.getColors()};
-    menuQuadColor = styleData.getTextColor();
-    if(ssvu::toInt(menuQuadColor.a) == 0)
+    menuQuadColor = Config::getBlackAndWhite() ? sf::Color(20, 20, 20, 255) : styleData.getTextColor();
+    if(ssvu::toInt(menuQuadColor.a) == 0 && !Config::getBlackAndWhite())
     {
         for(auto& c : colors)
         {
@@ -2913,7 +2913,7 @@ void MenuGame::setIndex(const int mIdx)
             }
         }
     }
-    menuTextColor = colors[0];
+    menuTextColor = Config::getBlackAndWhite() ? sf::Color::White : colors[0];
 
     dialogBoxTextColor = menuQuadColor;
     dialogBoxTextColor.a = 255;
@@ -2933,7 +2933,7 @@ void MenuGame::setIndex(const int mIdx)
         {
             for(auto& c : colors)
             {
-                if(ssvu::toInt(c.a) != 0 && c != menuQuadColor)
+                if(ssvu::toInt(c.a) != 0 && c != menuQuadColor && !Config::getBlackAndWhite())
                 {
                     menuTextColor = c;
                     break;
@@ -2942,7 +2942,7 @@ void MenuGame::setIndex(const int mIdx)
         }
 
         // Same as above.
-        menuSelectionColor = colors[1];
+        menuSelectionColor = Config::getBlackAndWhite() ? sf::Color::White : colors[1];
         if(ssvu::toInt(menuSelectionColor.a) == 0 ||
             menuSelectionColor == menuQuadColor ||
             menuSelectionColor == menuTextColor)
@@ -2950,7 +2950,7 @@ void MenuGame::setIndex(const int mIdx)
             for(auto& c : colors)
             {
                 if(ssvu::toInt(c.a) != 0 && c != menuQuadColor &&
-                    c != menuTextColor)
+                    c != menuTextColor && !Config::getBlackAndWhite())
                 {
                     menuSelectionColor = c;
                     break;
@@ -2962,10 +2962,10 @@ void MenuGame::setIndex(const int mIdx)
 
     // Set color of the fonts.
     txtSelectionBig.font.setFillColor(menuQuadColor);
-    txtSelectionSmall.font.setFillColor(menuQuadColor);
-    txtSelectionRanked.font.setFillColor(menuQuadColor);
-    txtInstructionsSmall.font.setFillColor(menuQuadColor);
-    txtSelectionScore.font.setFillColor(menuQuadColor);
+    txtSelectionSmall.font.setFillColor(menuTextColor);
+    txtSelectionRanked.font.setFillColor(menuTextColor);
+    txtInstructionsSmall.font.setFillColor(menuTextColor);
+    txtSelectionScore.font.setFillColor(menuTextColor);
 
     // Set gameplay values
     diffMultIdx = 0;

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -235,14 +235,14 @@ void StyleData::drawBackgroundImpl(Utils::FastVertexVectorTris& vertices,
 
 void StyleData::drawBackgroundMenuHexagonImpl(
     Utils::FastVertexVectorTris& vertices, const sf::Vector2f& mCenterPos,
-    const unsigned int sides, const bool fourByThree) const
+    const unsigned int sides, const bool fourByThree, const bool blackAndWhite) const
 {
     const float div{ssvu::tau / sides * 1.0001f};
     const float halfDiv{div / 2.f};
     const float hexagonRadius{fourByThree ? 75.f : 100.f};
 
-    const sf::Color& colorMain{getMainColor()};
-    const sf::Color colorCap{getCapColorResult()};
+    const sf::Color& colorMain{blackAndWhite ? sf::Color::White : getMainColor()};
+    const sf::Color colorCap{blackAndWhite ? sf::Color::Black : getCapColorResult()};
 
     for(auto i(0u); i < sides; ++i)
     {
@@ -279,7 +279,7 @@ void StyleData::drawBackgroundMenu(Utils::FastVertexVectorTris& mTris,
 
     drawBackgroundImpl(
         mTris, mCenterPos, sides, darkenUnevenBackgroundChunk, blackAndWhite);
-    drawBackgroundMenuHexagonImpl(mTris, mCenterPos, sides, fourByThree);
+    drawBackgroundMenuHexagonImpl(mTris, mCenterPos, sides, fourByThree, blackAndWhite);
 }
 
 void StyleData::setCapColor(const CapColor& mCapColor)


### PR DESCRIPTION
I know that a lot of people don't pay attention to Black And White mode, but I wanted to enable it so I could have some pictures for some artwork, and noticed how Black And White hasn't adjusted to fit some of the new style changes that have been introduced. This pull request fixes those bugs and also tries its best to provide a convincing Black And White look to the level selection menu as well.

Still, a bug fix is a bug fix.