### PR TITLE
Add Music Timeline (Global Timeline) to Open Hexagon to enhance rhythm aspects

### DIFF
--- a/include/SSVOpenHexagon/Core/HGStatus.hpp
+++ b/include/SSVOpenHexagon/Core/HGStatus.hpp
@@ -31,6 +31,7 @@ private:
     double currentPause{0.1 * 60};       // Current pause time
     double currentIncrementTime{};       // Time since last increment
     float customScore{};                 // Value for alternative scoring
+    int32_t musicPointer{};              // Current time in level music
 
 public:
     float pulse{75};
@@ -83,6 +84,15 @@ public:
 
     // Accumulate the time spent in a frame into the total
     void accumulateFrametime(const double ft) noexcept;
+
+    // Get the current music time in milliseconds
+    [[nodiscard]] int32_t getMusicTime() noexcept;
+
+    // Get the current music time in seconds
+    [[nodiscard]] double getMusicTimeSeconds() noexcept;
+
+    // Update the music pointer with the new time
+    void updateMusicTime(int32_t newTime) noexcept;
 
     // Update the custom score
     void updateCustomScore(const float score) noexcept;

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -15,6 +15,7 @@
 #include "SSVOpenHexagon/Utils/LuaWrapper.hpp"
 #include "SSVOpenHexagon/Utils/FastVertexVector.hpp"
 #include "SSVOpenHexagon/Utils/Timeline2.hpp"
+#include "SSVOpenHexagon/Utils/TimelineGlobal.hpp"
 #include "SSVOpenHexagon/Components/CCustomWallManager.hpp"
 
 #include <SSVStart/GameSystem/GameSystem.hpp>
@@ -141,6 +142,9 @@ private:
 
     Utils::timeline2 eventTimeline;
     Utils::timeline2_runner eventTimelineRunner;
+
+    Utils::timelineGlobal musicTimeline;
+    Utils::timelineGlobal_runner musicTimelineRunner;
 
     Utils::timeline2 messageTimeline;
     Utils::timeline2_runner messageTimelineRunner;

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -89,6 +89,7 @@ private:
     sf::Font& font;
 
     Audio* audio;
+    MusicData::Segment segment;
 
     const LevelData* levelData;
 

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -303,6 +303,7 @@ private:
     void updateWalls(ssvu::FT mFT);
     void updateIncrement();
     void updateEvents(ssvu::FT mFT);
+    void updateMusic(ssvu::FT mFT);
     void updateLevel(ssvu::FT mFT);
     void updateCustomWalls(ssvu::FT mFT);
     void updatePulse(ssvu::FT mFT);

--- a/include/SSVOpenHexagon/Core/Replay.hpp
+++ b/include/SSVOpenHexagon/Core/Replay.hpp
@@ -120,6 +120,7 @@ struct replay_file
     replay_data _data;        // Input data.
     std::string _pack_id;     // Id of the selected pack.
     std::string _level_id;    // Id of the played level.
+    float _music_start_time;  // The music time the player was on.
     bool _first_play;         // If this was achieved on first level play.
     float _difficulty_mult;   // Played difficulty multiplier.
     double _played_score; // Played score (This can be an overridden score or

--- a/include/SSVOpenHexagon/Global/Audio.hpp
+++ b/include/SSVOpenHexagon/Global/Audio.hpp
@@ -38,6 +38,8 @@ public:
 
     ~Audio();
 
+    [[nodiscard]] int32_t getCurrentMusicTime();
+
     void setSoundVolume(const float volume);
     void setMusicVolume(const float volume);
 

--- a/include/SSVOpenHexagon/Utils/TimelineGlobal.hpp
+++ b/include/SSVOpenHexagon/Utils/TimelineGlobal.hpp
@@ -21,7 +21,6 @@ class timelineGlobal
 {
 public:
     using clock = std::chrono::high_resolution_clock;
-    using time_point = clock::time_point;
 
 
     // Variants don't need to be used here, because waiting functions aren't
@@ -31,37 +30,36 @@ public:
         std::function<void()> _func;
     };
 
-    using timeline_G = std::map<time_point, std::vector<action>>;
+    using timeline_G = std::map<int32_t, std::vector<action>>;
 
 private:
     timeline_G _actions;
 
 public:
-    [[nodiscard]] int hasTimepoint(time_point tp) const noexcept;
+    [[nodiscard]] int hasTimepoint(int32_t tp) const noexcept;
     [[nodiscard]] timeline_G::iterator begin() noexcept;
     [[nodiscard]] timeline_G::iterator end() noexcept;
     void clear();
-    void clearTimepoint(time_point tp);
+    void clearTimepoint(int32_t tp);
 
-    void append_to(time_point tp, const std::function<void()>& func);
+    void append_to(int32_t tp, const std::function<void()>& func);
 
     [[nodiscard]] std::size_t size() const noexcept;
-    [[nodiscard]] std::vector<action>& actions_at(const time_point tp);
+    [[nodiscard]] std::vector<action>& actions_at(const int32_t tp);
 };
 
 class timelineGlobal_runner
 {
 public:
-    using time_point = timelineGlobal::time_point;
     using action = timelineGlobal::action;
 
 private:
-    std::optional<time_point> prev_tp;
+    std::optional<int32_t> prev_tp;
 
 public:
-    [[nodiscard]] std::vector<time_point> getRunnableTimepoints(
-        timelineGlobal& timeline, const time_point tp);
-    void update(timelineGlobal& timeline, const time_point tp);
+    [[nodiscard]] std::vector<int32_t> getRunnableTimepoints(
+        timelineGlobal& timeline, const int32_t tp);
+    void update(timelineGlobal& timeline, const int32_t tp);
     void clearLastTp();
 };
 

--- a/include/SSVOpenHexagon/Utils/TimelineGlobal.hpp
+++ b/include/SSVOpenHexagon/Utils/TimelineGlobal.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2013-2020 Vittorio Romeo
+// License: Academic Free License ("AFL") v. 3.0
+// AFL License page: https://opensource.org/licenses/AFL-3.0
+
+// This file, unlike Timeline2.hpp, is built for a global timeline instead of a
+// relative timeline.
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <cstddef>
+#include <optional>
+
+#include <map>
+#include <vector> // We won't use the vector for the timeline itself, but a container
+
+namespace hg::Utils {
+
+class timelineGlobal
+{
+public:
+    using clock = std::chrono::high_resolution_clock;
+    using time_point = clock::time_point;
+
+
+    // Variants don't need to be used here, because waiting functions aren't
+    // needed in a global timeline
+    struct action
+    {
+        std::function<void()> _func;
+    };
+
+    using timeline_G = std::map<time_point, std::vector<action>>;
+
+private:
+    timeline_G _actions;
+
+public:
+    [[nodiscard]] int hasTimepoint(time_point tp) const noexcept;
+    [[nodiscard]] timeline_G::iterator begin() noexcept;
+    [[nodiscard]] timeline_G::iterator end() noexcept;
+    void clear();
+    void clearTimepoint(time_point tp);
+
+    void append_to(time_point tp, const std::function<void()>& func);
+
+    [[nodiscard]] std::size_t size() const noexcept;
+    [[nodiscard]] std::vector<action>& actions_at(const time_point tp);
+};
+
+class timelineGlobal_runner
+{
+public:
+    using time_point = timelineGlobal::time_point;
+    using action = timelineGlobal::action;
+
+private:
+    std::optional<time_point> prev_tp;
+
+public:
+    [[nodiscard]] std::vector<time_point> getRunnableTimepoints(
+        timelineGlobal& timeline, const time_point tp);
+    void update(timelineGlobal& timeline, const time_point tp);
+    void clearLastTp();
+};
+
+} // namespace hg::Utils

--- a/include/SSVOpenHexagon/Utils/TimelineGlobal.hpp
+++ b/include/SSVOpenHexagon/Utils/TimelineGlobal.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <cstddef>
 #include <optional>
+#include <string>
 
 #include <map>
 #include <vector> // We won't use the vector for the timeline itself, but a container
@@ -46,6 +47,7 @@ public:
 
     [[nodiscard]] std::size_t size() const noexcept;
     [[nodiscard]] std::vector<action>& actions_at(const int32_t tp);
+    [[nodiscard]] std::string to_string() noexcept;
 };
 
 class timelineGlobal_runner

--- a/src/SSVOpenHexagon/Core/Audio.cpp
+++ b/src/SSVOpenHexagon/Core/Audio.cpp
@@ -59,6 +59,10 @@ public:
         SSVOH_ASSERT(static_cast<bool>(_soundBufferGetter));
     }
 
+    [[nodiscard]] int32_t getCurrentMusicTime() {
+        return _music->getPlayingOffset().asMilliseconds();
+    }
+
     void setSoundVolume(const float volume)
     {
         SSVOH_ASSERT(volume >= 0.f && volume <= 100.f);
@@ -195,6 +199,10 @@ Audio::Audio(const SoundBufferGetter& soundBufferGetter,
 {}
 
 Audio::~Audio() = default;
+
+[[nodiscard]] int32_t Audio::getCurrentMusicTime() {
+    return impl().getCurrentMusicTime();
+}
 
 void Audio::setSoundVolume(const float volume)
 {

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -186,6 +186,32 @@ void HexagonGame::initLua_AudioControl()
             "Unlike `a_getMusicSeconds`, this will return an integer. Useful "
             "for avoiding floating point error.");
 
+    addLuaFn(lua, "a_evalTo", //
+        [this](double mTime, const std::string& mCode)
+        {
+            musicTimeline.append_to((int32_t)(mTime * 1000),
+                [=, this] { Utils::runLuaCode(lua, mCode); });
+            ssvu::lo("lua") << "Music timeline is now:\n" << musicTimeline.to_string() << '\n';
+        })
+        .arg("time")
+        .arg("code")
+        .doc(
+            "*Add to the music timeline*: evaluate the Lua code specified in "
+            "`$1` at `$0` seconds in the music timeline.");
+    
+    addLuaFn(lua, "a_evalToMs", //
+        [this](int32_t mTime, const std::string& mCode)
+        {
+            musicTimeline.append_to(mTime,
+                [=, this] { Utils::runLuaCode(lua, mCode); });
+            ssvu::lo("lua") << "Music timeline is now:\n" << musicTimeline.to_string() << '\n';
+        })
+        .arg("time")
+        .arg("code")
+        .doc(
+            "*Add to the music timeline*: evaluate the Lua code specified in "
+            "`$1` at `$0` milliseconds in the music timeline.");
+
     addLuaFn(lua, "a_setMusic", //
         [this](const std::string& mId)
         {

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -175,6 +175,17 @@ void HexagonGame::initLua_Utils()
 
 void HexagonGame::initLua_AudioControl()
 {
+    addLuaFn(lua, "a_getMusicSeconds", //
+        [this] { return status.getMusicTimeSeconds(); })
+        .doc("Return the music pointer's current position in seconds.");
+
+    addLuaFn(lua, "a_getMusicMilliseconds", //
+        [this] { return status.getMusicTime(); })
+        .doc(
+            "Return the music pointer's current position in milliseconds. "
+            "Unlike `a_getMusicSeconds`, this will return an integer. Useful "
+            "for avoiding floating point error.");
+
     addLuaFn(lua, "a_setMusic", //
         [this](const std::string& mId)
         {

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -191,26 +191,43 @@ void HexagonGame::initLua_AudioControl()
         {
             musicTimeline.append_to((int32_t)(mTime * 1000),
                 [=, this] { Utils::runLuaCode(lua, mCode); });
-            ssvu::lo("lua") << "Music timeline is now:\n" << musicTimeline.to_string() << '\n';
         })
         .arg("time")
         .arg("code")
         .doc(
             "*Add to the music timeline*: evaluate the Lua code specified in "
             "`$1` at `$0` seconds in the music timeline.");
-    
+
     addLuaFn(lua, "a_evalToMs", //
         [this](int32_t mTime, const std::string& mCode)
         {
-            musicTimeline.append_to(mTime,
-                [=, this] { Utils::runLuaCode(lua, mCode); });
-            ssvu::lo("lua") << "Music timeline is now:\n" << musicTimeline.to_string() << '\n';
+            musicTimeline.append_to(
+                mTime, [=, this] { Utils::runLuaCode(lua, mCode); });
         })
         .arg("time")
         .arg("code")
         .doc(
             "*Add to the music timeline*: evaluate the Lua code specified in "
             "`$1` at `$0` milliseconds in the music timeline.");
+
+    addLuaFn(lua, "a_clearTimepoint", //
+        [this](double mTime)
+        { musicTimeline.clearTimepoint((int32_t)(mTime * 1000)); })
+        .arg("time")
+        .doc(
+            "Removes all events that occur at specific time `$0` seconds in "
+            "the music timeline.");
+
+    addLuaFn(lua, "a_clearTimepointMs", //
+        [this](int32_t mTime) { musicTimeline.clearTimepoint(mTime); })
+        .arg("time")
+        .doc(
+            "Removes all events that occur at specific time `$0` milliseconds "
+            "in the music timeline.");
+
+    addLuaFn(lua, "a_clear", //
+        [this] { musicTimeline.clear(); })
+        .doc("Removes all events from the music timeline.");
 
     addLuaFn(lua, "a_setMusic", //
         [this](const std::string& mId)

--- a/src/SSVOpenHexagon/Core/HGStatus.cpp
+++ b/src/SSVOpenHexagon/Core/HGStatus.cpp
@@ -97,6 +97,21 @@ void HexagonGameStatus::accumulateFrametime(const double ft) noexcept
     }
 }
 
+[[nodiscard]] int32_t HexagonGameStatus::getMusicTime() noexcept
+{
+    return musicPointer;
+}
+
+[[nodiscard]] double HexagonGameStatus::getMusicTimeSeconds() noexcept
+{
+    return (musicPointer / 1000.0);
+}
+
+void HexagonGameStatus::updateMusicTime(int32_t newTime) noexcept
+{
+    musicPointer = newTime;
+}
+
 void HexagonGameStatus::updateCustomScore(const float score) noexcept
 {
     customScore = score;

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -631,6 +631,7 @@ void HexagonGame::updateLevel(ssvu::FT mFT)
         return;
     }
 
+    status.updateMusicTime(audio->getCurrentMusicTime());
     runLuaFunctionIfExists<float>("onUpdate", mFT);
 
     const auto o = timelineRunner.update(timeline, status.getTimeTP());

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -228,6 +228,7 @@ void HexagonGame::update(ssvu::FT mFT, const float timescale)
                         levelStatus.sidesMin, levelStatus.sidesMax));
                 }
 
+                updateMusic(mFT);
                 updateLevel(mFT);
 
                 if(Config::getBeatPulse())
@@ -606,6 +607,12 @@ void HexagonGame::updateEvents(ssvu::FT)
     }
 }
 
+void HexagonGame::updateMusic(ssvu::FT)
+{
+    status.updateMusicTime(audio->getCurrentMusicTime());
+    musicTimelineRunner.update(musicTimeline, status.getMusicTime());
+}
+
 void HexagonGame::updateIncrement()
 {
     if(!levelStatus.incEnabled)
@@ -630,8 +637,6 @@ void HexagonGame::updateLevel(ssvu::FT mFT)
     {
         return;
     }
-
-    status.updateMusicTime(audio->getCurrentMusicTime());
     runLuaFunctionIfExists<float>("onUpdate", mFT);
 
     const auto o = timelineRunner.update(timeline, status.getTimeTP());

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -583,6 +583,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
                 ._data{lastReplayData},
                 ._pack_id{mPackId},
                 ._level_id{mId},
+                ._music_start_time{segment.time},
                 ._first_play{lastFirstPlay},
                 ._difficulty_mult{mDifficultyMult},
                 ._played_score{lastPlayedScore},
@@ -603,6 +604,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
         rng = random_number_generator{activeReplay->replayFile._seed};
         firstPlay = activeReplay->replayFile._first_play;
+        
     }
 
     // Audio cleanup
@@ -613,7 +615,14 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
         if(!Config::getNoMusic())
         {
-            playLevelMusic();
+            if(!executeLastReplay)
+            {
+                playLevelMusic();
+            } 
+            else 
+            {
+                playLevelMusicAtTime(activeReplay->replayFile._music_start_time);
+            }
             audio->pauseMusic();
             refreshMusicPitch();
         }
@@ -1324,8 +1333,7 @@ void HexagonGame::playLevelMusic()
 {
     if(shouldPlayMusic())
     {
-        const MusicData::Segment segment =
-            musicData.playRandomSegment(getPackId(), *audio);
+        segment = musicData.playRandomSegment(getPackId(), *audio);
         musicTimelineRunner.clearLastTp();
         // TODO (P1): problems with addHash in headless mode:
         status.beatPulseDelay += segment.beatPulseDelayOffset;

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -633,6 +633,10 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     eventTimeline.clear();
     eventTimelineRunner = {};
 
+    // Music timeline cleanup
+    musicTimeline.clear();
+    musicTimelineRunner = {};
+
     // Message timeline cleanup
     messageTimeline.clear();
     messageTimelineRunner = {};
@@ -1322,7 +1326,6 @@ void HexagonGame::playLevelMusic()
     {
         const MusicData::Segment segment =
             musicData.playRandomSegment(getPackId(), *audio);
-
         // TODO (P1): problems with addHash in headless mode:
         status.beatPulseDelay += segment.beatPulseDelayOffset;
     }

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -1326,6 +1326,7 @@ void HexagonGame::playLevelMusic()
     {
         const MusicData::Segment segment =
             musicData.playRandomSegment(getPackId(), *audio);
+        musicTimelineRunner.clearLastTp();
         // TODO (P1): problems with addHash in headless mode:
         status.beatPulseDelay += segment.beatPulseDelayOffset;
     }
@@ -1336,6 +1337,7 @@ void HexagonGame::playLevelMusicAtTime(float mSeconds)
     if(shouldPlayMusic())
     {
         musicData.playSeconds(getPackId(), *audio, mSeconds);
+        musicTimelineRunner.clearLastTp();
     }
 }
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1079,9 +1079,10 @@ void MenuGame::initLua()
             "u_haltTime", "u_timelineWait", "u_clearWalls", "u_setFlashEffect",
 
             "a_getMusicSeconds", "a_getMusicMilliseconds", "a_evalTo",
-            "a_evalToMs", "a_setMusic", "a_setMusicSegment",
-            "a_setMusicSeconds", "a_playSound", "a_playPackSound",
-            "a_syncMusicToDM", "a_setMusicPitch", "a_overrideBeepSound",
+            "a_evalToMs", "a_clearTimepoint", "a_clearTimepointMs", "a_clear",
+            "a_setMusic", "a_setMusicSegment", "a_setMusicSeconds",
+            "a_playSound", "a_playPackSound", "a_syncMusicToDM",
+            "a_setMusicPitch", "a_overrideBeepSound",
             "a_overrideIncrementSound", "a_overrideSwapSound",
             "a_overrideDeathSound",
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1078,11 +1078,11 @@ void MenuGame::initLua()
             "u_isFastSpinning", "u_setPlayerAngle", "u_forceIncrement",
             "u_haltTime", "u_timelineWait", "u_clearWalls", "u_setFlashEffect",
 
-            "a_setMusic", "a_setMusicSegment", "a_setMusicSeconds",
-            "a_playSound", "a_playPackSound", "a_syncMusicToDM",
-            "a_setMusicPitch", "a_overrideBeepSound",
-            "a_overrideIncrementSound", "a_overrideSwapSound",
-            "a_overrideDeathSound",
+            "a_getMusicSeconds", "a_getMusicMilliseconds", "a_setMusic",
+            "a_setMusicSegment", "a_setMusicSeconds", "a_playSound",
+            "a_playPackSound", "a_syncMusicToDM", "a_setMusicPitch",
+            "a_overrideBeepSound", "a_overrideIncrementSound",
+            "a_overrideSwapSound", "a_overrideDeathSound",
 
             "t_eval", "t_kill", "t_clear", "t_wait", "t_waitS", "t_waitUntilS",
 

--- a/src/SSVOpenHexagon/Core/MenuGame.cpp
+++ b/src/SSVOpenHexagon/Core/MenuGame.cpp
@@ -1078,11 +1078,12 @@ void MenuGame::initLua()
             "u_isFastSpinning", "u_setPlayerAngle", "u_forceIncrement",
             "u_haltTime", "u_timelineWait", "u_clearWalls", "u_setFlashEffect",
 
-            "a_getMusicSeconds", "a_getMusicMilliseconds", "a_setMusic",
-            "a_setMusicSegment", "a_setMusicSeconds", "a_playSound",
-            "a_playPackSound", "a_syncMusicToDM", "a_setMusicPitch",
-            "a_overrideBeepSound", "a_overrideIncrementSound",
-            "a_overrideSwapSound", "a_overrideDeathSound",
+            "a_getMusicSeconds", "a_getMusicMilliseconds", "a_evalTo",
+            "a_evalToMs", "a_setMusic", "a_setMusicSegment",
+            "a_setMusicSeconds", "a_playSound", "a_playPackSound",
+            "a_syncMusicToDM", "a_setMusicPitch", "a_overrideBeepSound",
+            "a_overrideIncrementSound", "a_overrideSwapSound",
+            "a_overrideDeathSound",
 
             "t_eval", "t_kill", "t_clear", "t_wait", "t_waitS", "t_waitUntilS",
 

--- a/src/SSVOpenHexagon/Core/Replay.cpp
+++ b/src/SSVOpenHexagon/Core/Replay.cpp
@@ -195,14 +195,15 @@ void replay_player::reset() noexcept
 [[nodiscard]] bool replay_file::operator==(
     const replay_file& rhs) const noexcept
 {
-    return _version == rhs._version &&                 //
-           _player_name == rhs._player_name &&         //
-           _seed == rhs._seed &&                       //
-           _data == rhs._data &&                       //
-           _pack_id == rhs._pack_id &&                 //
-           _level_id == rhs._level_id &&               //
-           _first_play == rhs._first_play &&           //
-           _difficulty_mult == rhs._difficulty_mult && //
+    return _version == rhs._version &&                   //
+           _player_name == rhs._player_name &&           //
+           _seed == rhs._seed &&                         //
+           _data == rhs._data &&                         //
+           _pack_id == rhs._pack_id &&                   //
+           _level_id == rhs._level_id &&                 //
+           _music_start_time == rhs._music_start_time && //
+           _first_play == rhs._first_play &&             //
+           _difficulty_mult == rhs._difficulty_mult &&   //
            _played_score == rhs._played_score;
 }
 
@@ -260,6 +261,7 @@ void replay_player::reset() noexcept
 
     SSVOH_TRY(write_str(_pack_id));
     SSVOH_TRY(write_str(_level_id));
+    SSVOH_TRY(write(_music_start_time));
     SSVOH_TRY(write(_first_play));
     SSVOH_TRY(write(_difficulty_mult));
     SSVOH_TRY(write(_played_score));
@@ -316,6 +318,7 @@ void replay_player::reset() noexcept
 
     SSVOH_TRY(read_str(_pack_id));
     SSVOH_TRY(read_str(_level_id));
+    SSVOH_TRY(read(_music_start_time));
     SSVOH_TRY(read(_first_play));
     SSVOH_TRY(read(_difficulty_mult));
     SSVOH_TRY(read(_played_score));
@@ -416,8 +419,8 @@ static constexpr std::size_t buf_size{2097152}; // 2MB
 
 [[nodiscard]] std::string replay_file::create_filename() const
 {
-    return Utils::concat(_version, '_', _player_name, '_', _pack_id, '_',
-        _level_id, '_', _difficulty_mult, '_', _played_score, ".ohreplay");
+    return Utils::concat(_version, '_', _player_name, '_', _level_id, '_',
+        _difficulty_mult, '_', _played_score, ".ohreplay");
 }
 
 [[nodiscard]] bool compressed_replay_file::serialize_to_file(

--- a/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
+++ b/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
@@ -4,10 +4,7 @@
 
 #include "SSVOpenHexagon/Utils/TimelineGlobal.hpp"
 
-#include "SSVOpenHexagon/Global/Assert.hpp"
-
 #include <type_traits>
-#include <variant>
 #include <utility>
 #include <chrono>
 #include <optional>

--- a/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
+++ b/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <chrono>
 #include <optional>
+#include <string>
 #include <functional>
 
 namespace hg::Utils {
@@ -66,8 +67,18 @@ void timelineGlobal::append_to(int32_t tp, const std::function<void()>& func)
     return _actions[tp];
 }
 
-[[nodiscard]] std::vector<int32_t>
-timelineGlobal_runner::getRunnableTimepoints(
+[[nodiscard]] std::string timelineGlobal::to_string() noexcept
+{
+    std::string result = "CURRENT MUSIC TIMELINE MAP:\n";
+    for(timelineGlobal::timeline_G::iterator it = begin(); it != end(); it++)
+    {
+        std::string keyString = std::to_string(it->first);
+        result.append("\t[" + keyString + "]\n");
+    }
+    return result;
+}
+
+[[nodiscard]] std::vector<int32_t> timelineGlobal_runner::getRunnableTimepoints(
     timelineGlobal& timeline, const int32_t tp)
 {
     std::vector<int32_t> result{};
@@ -86,22 +97,20 @@ void timelineGlobal_runner::update(timelineGlobal& timeline, int32_t tp)
     if(!prev_tp.has_value())
     {
         // Just simply grab the time point
-        if(!timeline.hasTimepoint(tp))
+        if(timeline.hasTimepoint(tp))
         {
-            return;
-        }
-        std::vector<action> actions = timeline.actions_at(tp);
-        for(std::size_t i = 0; i < actions.size(); i++)
-        {
-            actions[i]._func();
+            std::vector<action> actions = timeline.actions_at(tp);
+            for(std::size_t i = 0; i < actions.size(); i++)
+            {
+                actions[i]._func();
+            }
         }
     }
     else
     {
         // Grab all timepoints in between the previous and current timepoint and
         // run all of the functions contained.
-        std::vector<int32_t> timepoints =
-            getRunnableTimepoints(timeline, tp);
+        std::vector<int32_t> timepoints = getRunnableTimepoints(timeline, tp);
         for(std::size_t t = 0; t < timepoints.size(); t++)
         {
             std::vector<timelineGlobal::action> actions =

--- a/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
+++ b/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
@@ -15,7 +15,7 @@
 
 namespace hg::Utils {
 
-[[nodiscard]] int timelineGlobal::hasTimepoint(time_point tp) const noexcept
+[[nodiscard]] int timelineGlobal::hasTimepoint(int32_t tp) const noexcept
 {
     return _actions.contains(tp);
 }
@@ -37,7 +37,7 @@ void timelineGlobal::clear()
     _actions.clear();
 }
 
-void timelineGlobal::clearTimepoint(time_point tp)
+void timelineGlobal::clearTimepoint(int32_t tp)
 {
     if(!hasTimepoint(tp))
     {
@@ -46,7 +46,7 @@ void timelineGlobal::clearTimepoint(time_point tp)
     _actions[tp].clear();
 }
 
-void timelineGlobal::append_to(time_point tp, const std::function<void()>& func)
+void timelineGlobal::append_to(int32_t tp, const std::function<void()>& func)
 {
     if(!hasTimepoint(tp))
     {
@@ -61,28 +61,19 @@ void timelineGlobal::append_to(time_point tp, const std::function<void()>& func)
 }
 
 [[nodiscard]] std::vector<timelineGlobal::action>& timelineGlobal::actions_at(
-    const time_point tp)
+    const int32_t tp)
 {
     return _actions[tp];
 }
 
-[[nodiscard]] std::vector<timelineGlobal::time_point>
+[[nodiscard]] std::vector<int32_t>
 timelineGlobal_runner::getRunnableTimepoints(
-    timelineGlobal& timeline, const time_point tp)
+    timelineGlobal& timeline, const int32_t tp)
 {
-    std::vector<time_point> result{};
-    long prev_tp_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-        prev_tp.value().time_since_epoch())
-                            .count();
-    long tp_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-        tp.time_since_epoch())
-                       .count();
+    std::vector<int32_t> result{};
     for(auto iter = timeline.begin(); iter != timeline.end(); iter++)
     {
-        long iter_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-            iter->first.time_since_epoch())
-                             .count();
-        if(iter_time > prev_tp_time && iter_time <= tp_time)
+        if(iter->first > prev_tp.value() && iter->first <= tp)
         {
             result.emplace_back(iter->first);
         }
@@ -90,7 +81,7 @@ timelineGlobal_runner::getRunnableTimepoints(
     return result;
 }
 
-void timelineGlobal_runner::update(timelineGlobal& timeline, time_point tp)
+void timelineGlobal_runner::update(timelineGlobal& timeline, int32_t tp)
 {
     if(!prev_tp.has_value())
     {
@@ -109,7 +100,7 @@ void timelineGlobal_runner::update(timelineGlobal& timeline, time_point tp)
     {
         // Grab all timepoints in between the previous and current timepoint and
         // run all of the functions contained.
-        std::vector<time_point> timepoints =
+        std::vector<int32_t> timepoints =
             getRunnableTimepoints(timeline, tp);
         for(std::size_t t = 0; t < timepoints.size(); t++)
         {

--- a/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
+++ b/src/SSVOpenHexagon/Utils/TimelineGlobal.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2013-2020 Vittorio Romeo
+// License: Academic Free License ("AFL") v. 3.0
+// AFL License page: https://opensource.org/licenses/AFL-3.0
+
+#include "SSVOpenHexagon/Utils/TimelineGlobal.hpp"
+
+#include "SSVOpenHexagon/Global/Assert.hpp"
+
+#include <type_traits>
+#include <variant>
+#include <utility>
+#include <chrono>
+#include <optional>
+#include <functional>
+
+namespace hg::Utils {
+
+[[nodiscard]] int timelineGlobal::hasTimepoint(time_point tp) const noexcept
+{
+    return _actions.contains(tp);
+}
+
+[[nodiscard]] timelineGlobal::timeline_G::iterator
+timelineGlobal::begin() noexcept
+{
+    return _actions.begin();
+}
+
+[[nodiscard]] timelineGlobal::timeline_G::iterator
+timelineGlobal::end() noexcept
+{
+    return _actions.end();
+}
+
+void timelineGlobal::clear()
+{
+    _actions.clear();
+}
+
+void timelineGlobal::clearTimepoint(time_point tp)
+{
+    if(!hasTimepoint(tp))
+    {
+        return;
+    }
+    _actions[tp].clear();
+}
+
+void timelineGlobal::append_to(time_point tp, const std::function<void()>& func)
+{
+    if(!hasTimepoint(tp))
+    {
+        _actions[tp] = std::vector<action>{};
+    }
+    _actions[tp].emplace_back(action{func});
+}
+
+[[nodiscard]] std::size_t timelineGlobal::size() const noexcept
+{
+    return _actions.size();
+}
+
+[[nodiscard]] std::vector<timelineGlobal::action>& timelineGlobal::actions_at(
+    const time_point tp)
+{
+    return _actions[tp];
+}
+
+[[nodiscard]] std::vector<timelineGlobal::time_point>
+timelineGlobal_runner::getRunnableTimepoints(
+    timelineGlobal& timeline, const time_point tp)
+{
+    std::vector<time_point> result{};
+    long prev_tp_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        prev_tp.value().time_since_epoch())
+                            .count();
+    long tp_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        tp.time_since_epoch())
+                       .count();
+    for(auto iter = timeline.begin(); iter != timeline.end(); iter++)
+    {
+        long iter_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+            iter->first.time_since_epoch())
+                             .count();
+        if(iter_time > prev_tp_time && iter_time <= tp_time)
+        {
+            result.emplace_back(iter->first);
+        }
+    }
+    return result;
+}
+
+void timelineGlobal_runner::update(timelineGlobal& timeline, time_point tp)
+{
+    if(!prev_tp.has_value())
+    {
+        // Just simply grab the time point
+        if(!timeline.hasTimepoint(tp))
+        {
+            return;
+        }
+        std::vector<action> actions = timeline.actions_at(tp);
+        for(std::size_t i = 0; i < actions.size(); i++)
+        {
+            actions[i]._func();
+        }
+    }
+    else
+    {
+        // Grab all timepoints in between the previous and current timepoint and
+        // run all of the functions contained.
+        std::vector<time_point> timepoints =
+            getRunnableTimepoints(timeline, tp);
+        for(std::size_t t = 0; t < timepoints.size(); t++)
+        {
+            std::vector<timelineGlobal::action> actions =
+                timeline.actions_at(timepoints[t]);
+            for(std::size_t i = 0; i < actions.size(); i++)
+            {
+                actions[i]._func();
+            }
+        }
+    }
+    // Update the previous timepoint with the new timepoint.
+    prev_tp = tp;
+}
+
+void timelineGlobal_runner::clearLastTp()
+{
+    prev_tp.reset();
+}
+
+} // namespace hg::Utils


### PR DESCRIPTION
Closes #335.

I've managed to implement the music timeline. Turns out that the timeline class that the pattern, event, and custom timelines use are based on `timeline2`, which is built to function as a relative timeline. So I had to actually create a brand new class that represents a global timeline. This was the trickiest part because there are things that the global timeline class does differently from timeline2. The global timeline:
- Uses integers for timepoints instead of Chrono timepoints for simplicity.
- Doesn't have any waiting functions, because waiting functions don't serve a purpose in a global timeline.
- Uses a map to keep track of actions instead of a vector. The map contains vector values to allow for multiple events at the same time.
- Can account for any abrupt changes in the time by clearing the previous timepoint
- Doesn't remove events after executing them, allowing for repeated execution.

The global timeline is used to create the music timeline, and it functions almost like your typical timeline. The main difference comes in when you have to time your events. Instead of a wait function, you have to specify a specific time when the event will happen. If you want to use relative transformations, you can use simple math to recreate a waiting function. 

There is now a "music pointer", which relays the current time that the song is playing. The music pointer will follow along with the music pitch and music changes. The music pointer works off milliseconds, rather than frame time (to account for precision in music). Due to an OpenAL limitation, the music pointer updates every 20ms. If precision is really important, I will go back and try to redo this pointer to work off the game logic instead of the SFML logic. 

Speaking of Lua functions, here are all the new Lua functions that this pull request adds:
- `a_getMusicSeconds`: Grabs the value of the music pointer in seconds
- `a_getMusicMilliseconds`: Grabs the value of the music pointer in milliseconds. Unlike the previous function, this returns an integer in case you're worried about floating-point error.
- `a_evalTo`: Puts a Lua block of code onto the music timeline at a specific timestamp in seconds.
- `a_evalToMs`: Puts a Lua block of code onto the music timeline at a specific timestamp in milliseconds.
- `a_clearTimepoint`: Removes all events from that specific time point in the music timeline.
- `a_clearTimepointMs`: Millisecond variant.
- `a_clear`: Removes all events from the music timeline.

There were a few more that I added than originally intended. I wanted to add clearing specifically for a timepoint for quality of life, and I added millisecond variants to ensure precision.