### PR TITLE
Allow binary file reading using io.open(filename, "rb")

### DIFF
--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -130,8 +130,8 @@ static void redefineIoOpen(Lua::LuaContext& lua)
 try
 {
     lua.executeCode(
-        "local open = io.open; io.open = function(filename) return "
-        "open(filename, \"r\"); end");
+        "local open = io.open; io.open = function(filename, mode) return "
+        "open(filename, mode == \"rb\" and mode or \"r\"); end");
 }
 catch(...)
 {


### PR DESCRIPTION
On **some** platforms (including Windows), `io.open(filename, "r")` (currently the only supported mode) performs potentially unwanted newline conversion, forcing pack developers to work around this restriction using base64 or similar binary-to-text encoding formats. This PR allows pack developers to read files in binary mode using `io.open(filename, "rb")`.