### PR TITLE
Implementing a new Hypercube

### DIFF
--- a/_RELEASE/Packs/base/Scripts/common.lua
+++ b/_RELEASE/Packs/base/Scripts/common.lua
@@ -141,3 +141,44 @@ function cAltBarrage(mSide, mStep)
         cWall(mSide + i)
     end
 end
+
+-- cSwapBarrageN: A barrage with mNeighbors to have an opening pocket, forcing the players to go into the pocket and swap.
+function cSwapBarrageN(mSide, mNeighbors, mDelayMult)
+	mDelayMult = mDelayMult or 1
+	local myThickness = getPerfectThickness(THICKNESS) * 2.5 * mDelayMult
+	local delay = getPerfectDelay(myThickness - THICKNESS) / u_getDelayMultDM()
+	cBarrageN(mSide, mNeighbors + 1) -- Create the initial barrage
+	w_wall(mSide + 1 + mNeighbors, myThickness)
+	w_wall(mSide + l_getSides() - 1 - mNeighbors, myThickness)
+	t_wait(delay)
+	for i = -mNeighbors, mNeighbors do
+		cWall(i + mSide)
+	end
+end
+
+-- cSwapBarrage: A barrage, but the opening is instead a pocket that is fully enclosed, forcing the player to swap to escape the pocket.
+function cSwapBarrage(mSide, mDelayMult)
+	mDelayMult = mDelayMult or 1
+	local myThickness = getPerfectThickness(THICKNESS) * 2.5 * mDelayMult
+	local delay = getPerfectDelay(myThickness - THICKNESS) / u_getDelayMultDM()
+	cBarrageN(mSide, 1)
+	w_wall(mSide + 1, myThickness)
+	w_wall(mSide + l_getSides() - 1, myThickness)
+	t_wait(delay)
+	cWall(mSide)
+end
+
+-- cSwapCorridor: A barrage, but the neighbors of the opening have elongated thicknesses
+function cSwapCorridor(mSide, mEnding)
+	mEnding = mEnding or false
+	local myThickness = getPerfectThickness(THICKNESS) * 4
+	local delay = getPerfectDelay(myThickness - THICKNESS) / u_getDelayMultDM()
+	cBarrageN(mSide, 1)
+	w_wall(mSide + 1, myThickness)
+	w_wall(mSide + l_getSides() - 1, myThickness)
+	t_wait(delay)
+	if (mEnding) then
+		cWall(mSide)
+	end
+	t_wait(getPerfectDelay(THICKNESS) / u_getDelayMultDM())
+end

--- a/_RELEASE/Packs/base/Scripts/common.lua
+++ b/_RELEASE/Packs/base/Scripts/common.lua
@@ -1,6 +1,9 @@
--- common variables
+-- COMMON GLOBAL VARIABLES
 THICKNESS = 40.0
 
+-- COMMON FUNCTIONS
+
+-- enableSwapIfDMGreaterThan: If the player chooses to play a level that exceeds the given difficulty, turn on swap.
 function enableSwapIfDMGreaterThan(mDM)
     if(u_getDifficultyMult() > mDM) then
         e_messageAdd("difficulty > " ..mDM.. "\nswap enabled!", 65)
@@ -8,6 +11,7 @@ function enableSwapIfDMGreaterThan(mDM)
     end
 end
 
+-- enableSwapIfSpeedGEThan: If the player reaches a given speed on a level, turn on swap.
 function enableSwapIfSpeedGEThan(mSpeed)
     if (u_getSpeedMultDM() >= mSpeed and not l_getSwapEnabled()) then
         e_messageAddImportant("Speed >= "..mSpeed.."\nswap enabled!", 120)
@@ -15,6 +19,7 @@ function enableSwapIfSpeedGEThan(mSpeed)
     end
 end
 
+-- disableIncIfDMGreaterThan: If the player chooses to play a level that exceeds the given difficulty, disable incrementing.
 function disableIncIfDMGreaterThan(mDM)
     if(u_getDifficultyMult() > mDM) then
         e_messageAdd("difficulty > " ..mDM.. "\nincrement disabled!", 65)
@@ -22,6 +27,7 @@ function disableIncIfDMGreaterThan(mDM)
     end
 end
 
+-- disableSpeedIncIfDMGreaterThan: If the player chooses to play a level that exceeds the given difficulty, make speed not increase upon incrementing.
 function disableSpeedIncIfDMGreaterThan(mDM)
     if(u_getDifficultyMult() > mDM) then
         e_messageAdd("difficulty > " ..mDM.. "\nspeed increment disabled!", 65)
@@ -53,32 +59,32 @@ end
 -- getPerfectDelay: returns time to wait for two walls to be next to each other
 function getPerfectDelay(mThickness) return mThickness / (5.02 * u_getSpeedMultDM()) * u_getDelayMultDM() end
 
--- getPerfectDelayDM: returns getPerfectDelay calculated with difficulty mutliplier
-function getPerfectDelayDM(mThickness) return mThickness / (5.02 * u_getSpeedMultDM()) * u_getDelayMultDM() end
+-- getPerfectDelayDM's implementation has now been implemented into getPerfectDelay. Keeping the name for compatibility reasons.
+getPerfectDelayDM = getPerfectDelay
 
 -- getPerfectThickness: returns a good THICKNESS value in relation to human reflexes
 function getPerfectThickness(mThickness) return mThickness * u_getSpeedMultDM() end
 
 -- getSideDistance: returns shortest distance from a side to another
 function getSideDistance(mSide1, mSide2)
-    start = mSide1
-    rightSteps = 0
-    while start ~= mSide2 do
-        rightSteps = rightSteps + 1
-        start = start + 1
-        if start > l_getSides() - 1 then start = 0 end
+    if (mSide1 == mSide2) then
+        return 0
     end
-
-    start = mSide1
-    leftSteps = 0
-    while start ~= mSide2 do
-        leftSteps = leftSteps + 1
-        start = start - 1
-        if start < 0 then start = l_getSides() - 1 end
+    -- Pick out the lower and higher side
+    local low = math.min(mSide1, mSide2)
+    local high = math.max(mSide1, mSide2)
+    -- We need to get both high and low positive for modulus to work properly
+    -- We only need to check the lower number for this.
+    if (low < 0) then
+        high = high - low
+        low = 0
     end
-
-    if rightSteps < leftSteps then return rightSteps end
-    return leftSteps
+    -- Calculate the difference and make any last minute adjustments accordingly
+    local diff = (high - low) % l_getSides()
+    if (diff > getHalfSides()) then
+        return l_getSides() - diff
+    end
+    return diff 
 end
 
 -- cWall: creates a wall with the common THICKNESS
@@ -131,7 +137,7 @@ end
 
 -- cAltBarrage: spawns a barrage of alternate walls
 function cAltBarrage(mSide, mStep)
-    for i = 0, l_getSides() / mStep, 1 do
-        cWall(mSide + i * mStep)
+    for i = 0, l_getSides(), mStep do
+        cWall(mSide + i)
     end
 end

--- a/_RELEASE/Packs/base/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/commonpatterns.lua
@@ -4,7 +4,7 @@ u_execScript("common.lua")
 function pBarrage(mSide, mNeighbors)
 	mSide = mSide or getRandomSide()
 	mNeighbors = mNeighbors or 0
-	local delay = getPerfectDelayDM(THICKNESS) * 6.5
+	local delay = getPerfectDelay(THICKNESS) * 6.5
 	
 	cBarrageN(mSide, mNeighbors)
 	t_wait(delay)
@@ -13,7 +13,7 @@ end
 -- pAltBarrage: spawns a series of cAltBarrage
 function pAltBarrage(mTimes, mStep, mDelayMult)
 	mDelayMult = mDelayMult or 1
-    local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
+    local delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
 
     for i = 1, mTimes do
         cAltBarrage(i, mStep)
@@ -41,7 +41,7 @@ function pSpiral(mTimes, mExtra, mDir)
 	
 	THICKNESS = oldThickness
 	
-	t_wait(getPerfectDelayDM(THICKNESS) * 6.5)
+	t_wait(getPerfectDelay(THICKNESS) * 6.5)
 end
 
 -- pMirrorSpiral: spawns a spiral of rWallEx
@@ -61,14 +61,14 @@ function pMirrorSpiral(mTimes, mExtra)
 
     THICKNESS = oldThickness
 
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.5)
+    t_wait(getPerfectDelay(THICKNESS) * 6.5)
 end
 
 -- pMirrorSpiralDouble: spawns a spiral of rWallEx where you need to change direction
 function pMirrorSpiralDouble(mTimes, mExtra)
     local oldThickness = THICKNESS
     THICKNESS = getPerfectThickness(THICKNESS) * l_getDelayMult()
-    local delay = getPerfectDelayDM(THICKNESS) / l_getDelayMult() * 0.9 -- overlap a bit to avoid going through gaps
+    local delay = getPerfectDelay(THICKNESS) / l_getDelayMult() * 0.9 -- overlap a bit to avoid going through gaps
     local startSide = getRandomSide()
     local loopDir = getRandomDir()
     local j = 0
@@ -89,7 +89,7 @@ function pMirrorSpiralDouble(mTimes, mExtra)
     end
 
     THICKNESS = oldThickness
-    t_wait(getPerfectDelayDM(THICKNESS) * 7.5)
+    t_wait(getPerfectDelay(THICKNESS) * 7.5)
 end
 
 -- pBarrageSpiral: spawns a spiral of cBarrage
@@ -97,7 +97,7 @@ function pBarrageSpiral(mTimes, mDelayMult, mStep)
 	mDelayMult = mDelayMult or 1
 	mStep = mStep or 1
 
-    local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
+    local delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
     local startSide = getRandomSide()
     local loopDir = mStep * getRandomDir()
     local j = 0
@@ -109,12 +109,12 @@ function pBarrageSpiral(mTimes, mDelayMult, mStep)
         if(l_getSides() < 6) then t_wait(delay * 0.6) end
     end
 
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+    t_wait(getPerfectDelay(THICKNESS) * 6.1)
 end
 
 -- pDMBarrageSpiral: spawns a spiral of cBarrage, with static delay
 function pDMBarrageSpiral(mTimes, mDelayMult, mStep)
-	local delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
+	local delay = (getPerfectDelay(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
 	local startSide = getRandomSide()
 	local loopDir = mStep * getRandomDir()	
 	local j = 0
@@ -126,12 +126,12 @@ function pDMBarrageSpiral(mTimes, mDelayMult, mStep)
 		if(l_getSides() < 6) then t_wait(delay * 0.49) end
 	end
 	
-	t_wait(getPerfectDelayDM(THICKNESS) * (6.7 * (u_getDifficultyMult() ^ 0.7)))
+	t_wait(getPerfectDelay(THICKNESS) * (6.7 * (u_getDifficultyMult() ^ 0.7)))
 end
 
 -- pWallExVortex: spawns left-left right-right spiral patters
 function pWallExVortex(mTimes, mStep, mExtraMult)
-	local delay = getPerfectDelayDM(THICKNESS) * 5.0 
+	local delay = getPerfectDelay(THICKNESS) * 5.0 
 	local startSide = getRandomSide()
 	local loopDir = getRandomDir()
 	local currentSide = startSide
@@ -152,12 +152,12 @@ function pWallExVortex(mTimes, mStep, mExtraMult)
 		end
 	end
 	
-	t_wait(getPerfectDelayDM(THICKNESS) * 5.5)
+	t_wait(getPerfectDelay(THICKNESS) * 5.5)
 end
 
 -- pInverseBarrage: spawns two barrages who force you to turn 180 degrees
 function pInverseBarrage(mTimes)
-	local delay = getPerfectDelayDM(THICKNESS) * 9.9
+	local delay = getPerfectDelay(THICKNESS) * 9.9
 	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
@@ -168,7 +168,7 @@ function pInverseBarrage(mTimes)
 		t_wait(delay)
 	end
 	
-	t_wait(getPerfectDelayDM(THICKNESS) * 2.5)
+	t_wait(getPerfectDelay(THICKNESS) * 2.5)
 end
 
 -- pRandomBarrage: spawns barrages with random side, and waits humanly-possible times depending on the sides distance
@@ -180,15 +180,15 @@ function pRandomBarrage(mTimes, mDelayMult)
 		cBarrage(side)
 		oldSide = side
 		side = getRandomSide()
-		t_wait(getPerfectDelayDM(THICKNESS) * (2 + (getSideDistance(side, oldSide)*mDelayMult)))
+		t_wait(getPerfectDelay(THICKNESS) * (2 + (getSideDistance(side, oldSide)*mDelayMult)))
 	end
 	
-	t_wait(getPerfectDelayDM(THICKNESS) * 5.6)
+	t_wait(getPerfectDelay(THICKNESS) * 5.6)
 end
 
 -- pMirrorWallStrip: spawns rWalls close to one another on the same side
 function pMirrorWallStrip(mTimes, mExtra)
-	local delay = getPerfectDelayDM(THICKNESS) * 3.65
+	local delay = getPerfectDelay(THICKNESS) * 3.65
 	local startSide = getRandomSide()
 	
 	for i = 0, mTimes do
@@ -196,7 +196,7 @@ function pMirrorWallStrip(mTimes, mExtra)
 		t_wait(delay)
 	end
 	
-	t_wait(getPerfectDelayDM(THICKNESS) * 5.00)
+	t_wait(getPerfectDelay(THICKNESS) * 5.00)
 end
 
 -- pTunnel: forces you to circle around a very thick wall
@@ -227,7 +227,7 @@ end
 function pSwapBarrage(mSide, mDelayMult)
 	mDelayMult = mDelayMult or 1
 	cSwapBarrage(mSide, mDelayMult)
-	t_wait(getPerfectDelayDM(THICKNESS) * 7.5)
+	t_wait(getPerfectDelay(THICKNESS) * 7.5)
 end
 
 -- pSwapCorridor: A series of cSwapCorridors, forcing you to swap and look around for new corridors going through. Has some similarity to pTunnel.
@@ -241,5 +241,5 @@ function pSwapCorridor(mTimes)
 		end
 		currentSide = math.random(currentSide + getHalfSides() - 1, currentSide + getHalfSides() + 1)
 	end
-	t_wait(getPerfectDelayDM(THICKNESS) * 7)
+	t_wait(getPerfectDelay(THICKNESS) * 7)
 end

--- a/_RELEASE/Packs/base/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/commonpatterns.lua
@@ -15,7 +15,6 @@ function pAltBarrage(mTimes, mStep, mDelayMult)
 	mDelayMult = mDelayMult or 1
     local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
 
-	-- TODO: Modify cube and ensure the amount of occurrences are still the same
     for i = 1, mTimes do
         cAltBarrage(i, mStep)
         t_wait(delay)

--- a/_RELEASE/Packs/base/Scripts/commonpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/commonpatterns.lua
@@ -1,10 +1,22 @@
 u_execScript("common.lua")
 
--- pAltBarrage: spawns a series of cAltBarrage
-function pAltBarrage(mTimes, mStep)
-    local delay = getPerfectDelayDM(THICKNESS) * 5.6
+-- pBarrage: spawns a patternized cBarrageN with a delay
+function pBarrage(mSide, mNeighbors)
+	mSide = mSide or getRandomSide()
+	mNeighbors = mNeighbors or 0
+	local delay = getPerfectDelayDM(THICKNESS) * 6.5
+	
+	cBarrageN(mSide, mNeighbors)
+	t_wait(delay)
+end
 
-    for i = 0, mTimes do
+-- pAltBarrage: spawns a series of cAltBarrage
+function pAltBarrage(mTimes, mStep, mDelayMult)
+	mDelayMult = mDelayMult or 1
+    local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
+
+	-- TODO: Modify cube and ensure the amount of occurrences are still the same
+    for i = 1, mTimes do
         cAltBarrage(i, mStep)
         t_wait(delay)
     end
@@ -12,29 +24,25 @@ function pAltBarrage(mTimes, mStep)
     t_wait(delay)
 end
 
--- pSpiralDir: spawns a spiral of cWallEx
-function pSpiralDir(mLoopDir, mTimes, mExtra)
-    local oldThickness = THICKNESS
-    THICKNESS = getPerfectThickness(THICKNESS) * l_getDelayMult()
-    local delay = getPerfectDelay(THICKNESS) / l_getDelayMult()  * 0.9 -- overlap a bit to avoid going through gaps
-    local startSide = getRandomSide()
-    local loopDir = mLoopDir
-    local j = 0
-
-    for i = 0, mTimes do
-        cWallEx(startSide + j, mExtra)
-        j = j + loopDir
-        t_wait(delay)
-    end
-
-    THICKNESS = oldThickness
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.5)
-end
-
 -- pSpiral: spawns a spiral of cWallEx
-function pSpiral(mTimes, mExtra)
-    pSpiralDir(getRandomDir(), mTimes, mExtra)
+function pSpiral(mTimes, mExtra, mDir)
+	mDir = mDir or getRandomDir()
+
+	local oldThickness = THICKNESS
+	THICKNESS = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(THICKNESS)
+	local startSide = getRandomSide()	
+	local j = 0
+	
+	for i = 0, mTimes do
+		cWallEx(startSide + j, mExtra)
+		j = j + mDir
+		t_wait(delay)
+	end
+	
+	THICKNESS = oldThickness
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * 6.5)
 end
 
 -- pMirrorSpiral: spawns a spiral of rWallEx
@@ -87,6 +95,9 @@ end
 
 -- pBarrageSpiral: spawns a spiral of cBarrage
 function pBarrageSpiral(mTimes, mDelayMult, mStep)
+	mDelayMult = mDelayMult or 1
+	mStep = mStep or 1
+
     local delay = getPerfectDelayDM(THICKNESS) * 5.6 * mDelayMult
     local startSide = getRandomSide()
     local loopDir = mStep * getRandomDir()
@@ -104,111 +115,132 @@ end
 
 -- pDMBarrageSpiral: spawns a spiral of cBarrage, with static delay
 function pDMBarrageSpiral(mTimes, mDelayMult, mStep)
-    local delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
-    local startSide = getRandomSide()
-    local loopDir = mStep * getRandomDir()
-    local j = 0
-
-    for i = 0, mTimes do
-        cBarrage(startSide + j)
-        j = j + loopDir
-        t_wait(delay)
-        if(l_getSides() < 6) then t_wait(delay * 0.49) end
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * (6.7 * (u_getDifficultyMult() ^ 0.7)))
+	local delay = (getPerfectDelayDM(THICKNESS) * 5.42) * (mDelayMult / (u_getDifficultyMult() ^ 0.4)) * (u_getSpeedMultDM() ^ 0.35)
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()	
+	local j = 0
+	
+	for i = 0, mTimes do
+		cBarrage(startSide + j)
+		j = j + loopDir
+		t_wait(delay)
+		if(l_getSides() < 6) then t_wait(delay * 0.49) end
+	end
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * (6.7 * (u_getDifficultyMult() ^ 0.7)))
 end
 
 -- pWallExVortex: spawns left-left right-right spiral patters
 function pWallExVortex(mTimes, mStep, mExtraMult)
-    local delay = getPerfectDelayDM(THICKNESS) * 5.0
-    local startSide = getRandomSide()
-    local loopDir = getRandomDir()
-    local currentSide = startSide
-
-    for j = 0, mTimes do
-        for i = 0, mStep do
-            currentSide = currentSide + loopDir
-            rWallEx(currentSide, loopDir * mExtraMult)
-            t_wait(delay)
-        end
-
-        loopDir = loopDir * -1
-
-        for i = 0, mStep + 1 do
-            currentSide = currentSide + loopDir
-            rWallEx(currentSide, loopDir * mExtraMult)
-            t_wait(delay)
-        end
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.5)
+	local delay = getPerfectDelayDM(THICKNESS) * 5.0 
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
+	local currentSide = startSide
+	
+	for j = 0, mTimes do
+		for i = 0, mStep do
+			currentSide = currentSide + loopDir
+			rWallEx(currentSide, loopDir * mExtraMult)
+			t_wait(delay)
+		end
+		
+		loopDir = loopDir * -1
+		
+		for i = 0, mStep + 1 do
+			currentSide = currentSide + loopDir
+			rWallEx(currentSide, loopDir * mExtraMult)
+			t_wait(delay)
+		end
+	end
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * 5.5)
 end
 
 -- pInverseBarrage: spawns two barrages who force you to turn 180 degrees
 function pInverseBarrage(mTimes)
-    local delay = getPerfectDelayDM(THICKNESS) * 9.9
-    local startSide = getRandomSide()
-
-    for i = 0, mTimes do
-        cBarrage(startSide)
-        t_wait(delay)
-        if(l_getSides() < 6) then t_wait(delay * 0.8) end
-        cBarrage(startSide + getHalfSides())
-        t_wait(delay)
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.5)
+	local delay = getPerfectDelayDM(THICKNESS) * 9.9
+	local startSide = getRandomSide()
+	
+	for i = 0, mTimes do
+		cBarrage(startSide)
+		t_wait(delay)
+		if(l_getSides() < 6) then t_wait(delay * 0.8) end
+		cBarrage(startSide + getHalfSides())
+		t_wait(delay)
+	end
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * 2.5)
 end
 
 -- pRandomBarrage: spawns barrages with random side, and waits humanly-possible times depending on the sides distance
 function pRandomBarrage(mTimes, mDelayMult)
-    local side = getRandomSide()
-    local oldSide = 0
-
-    for i = 0, mTimes do
-        cBarrage(side)
-        oldSide = side
-        side = getRandomSide()
-        t_wait(getPerfectDelayDM(THICKNESS) * (2 + (getSideDistance(side, oldSide)*mDelayMult)))
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.6)
+	local side = getRandomSide()
+	local oldSide = 0
+	
+	for i = 0, mTimes do	
+		cBarrage(side)
+		oldSide = side
+		side = getRandomSide()
+		t_wait(getPerfectDelayDM(THICKNESS) * (2 + (getSideDistance(side, oldSide)*mDelayMult)))
+	end
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * 5.6)
 end
 
 -- pMirrorWallStrip: spawns rWalls close to one another on the same side
 function pMirrorWallStrip(mTimes, mExtra)
-    local delay = getPerfectDelayDM(THICKNESS) * 3.65
-    local startSide = getRandomSide()
-
-    for i = 0, mTimes do
-        rWallEx(startSide, mExtra)
-        t_wait(delay)
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.00)
+	local delay = getPerfectDelayDM(THICKNESS) * 3.65
+	local startSide = getRandomSide()
+	
+	for i = 0, mTimes do
+		rWallEx(startSide, mExtra)
+		t_wait(delay)
+	end
+	
+	t_wait(getPerfectDelayDM(THICKNESS) * 5.00)
 end
 
 -- pTunnel: forces you to circle around a very thick wall
 function pTunnel(mTimes)
-    local oldThickness = THICKNESS
-    local myThickness = getPerfectThickness(THICKNESS)
-    local delay = getPerfectDelay(myThickness) * 5
-    local startSide = getRandomSide()
-    local loopDir = getRandomDir()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
+	
+	THICKNESS = myThickness
+	
+	for i = 0, mTimes do
+		if i < mTimes then
+			w_wall(startSide, myThickness + 5 * u_getSpeedMultDM() * delay)
+		end
+		
+		cBarrage(startSide + loopDir)
+		t_wait(delay)
+		
+		loopDir = loopDir * -1
+	end
+	
+	THICKNESS = oldThickness
+end
 
-    THICKNESS = myThickness
+-- pSwapBarrage: a cSwapBarrage with additional pattern delay
+function pSwapBarrage(mSide, mDelayMult)
+	mDelayMult = mDelayMult or 1
+	cSwapBarrage(mSide, mDelayMult)
+	t_wait(getPerfectDelayDM(THICKNESS) * 7.5)
+end
 
-    for i = 0, mTimes do
-        if i < mTimes then
-            w_wall(startSide, myThickness + 5 * u_getSpeedMultDM() * delay)
-        end
-
-        cBarrage(startSide + loopDir)
-        t_wait(delay)
-
-        loopDir = loopDir * -1
-    end
-
-    THICKNESS = oldThickness
+-- pSwapCorridor: A series of cSwapCorridors, forcing you to swap and look around for new corridors going through. Has some similarity to pTunnel.
+function pSwapCorridor(mTimes)
+	local currentSide = getRandomSide()
+	for i = 1, mTimes do
+		if (i == mTimes) then
+			cSwapCorridor(currentSide, true)
+		else
+			cSwapCorridor(currentSide)
+		end
+		currentSide = math.random(currentSide + getHalfSides() - 1, currentSide + getHalfSides() + 1)
+	end
+	t_wait(getPerfectDelayDM(THICKNESS) * 7)
 end

--- a/_RELEASE/Packs/base/Scripts/evolutionpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/evolutionpatterns.lua
@@ -4,298 +4,616 @@ u_execScript("utils.lua")
 u_execScript("alternativepatterns.lua")
 u_execScript("nextpatterns.lua")
 
-local hueModifier = 0.2
-local sync = false
-local syncRndMin = 0
-local syncRndMax = 0
+---------------
+-- CONSTANTS --
+---------------
 
-local curveMult = 1
+globalHueModifier = 0.2 -- Constant used to shift the color offset to work with the style's hue.
+local sync = false -- Constant used to sync curving walls with that rotation speed
+local syncRndMin = 0 -- Minimum random displacement from the synced speed
+local syncRndMax = 0 -- Maximum random displacement from the synced speed
 
-function syncCurveWithRotationSpeed(mRndMin, mRndMax)
-    sync = true
-    syncRndMin = mRndMin
-    syncRndMax = mRndMax
+local curveMult = 1 -- Constant used to multiply the global curve speed of curving walls
+
+---------------
+-- FUNCTIONS --
+---------------
+
+-- syncCurveToSideDistance: Returns an appropriate constant that, if applied to a curving wall travelling at constant speed, will cause it go one full side.
+function syncCurveToSideDistance()
+	return (.2 * u_getSpeedMultDM() + 0.005) * (6 / l_getSides()) * (u_getDifficultyMult() ^ -.25); 
 end
 
-function setCurveMult(mMult)
-    curveMult = mMult
+-- getPerfectCurveDecel: Returns a constant that, if applied to a curving wall, will make the wall stop accelerating on a side panel.
+function getPerfectCurveDecel()
+	-- Coordinates tested: (0, 0), (1, .134), (1.5, .295), (2, .52), (2.5, .81), (3, 1.162), (3.5, 1.579), (4, 2.06)
+	-- Cubic Formula (full accuracy): 0.000233918 x^3 + 0.125985 x^2 + 0.00730493 x + 0.0000701754
+	-- Current formula has ~100% accuracy
+	return (0.127378 * u_getSpeedMultDM() ^ 2 + 0.00526331 * u_getSpeedMultDM() + 0.000431373) * (6 / l_getSides());
 end
 
-function wallHMCurveAcc(mSide, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    if sync == true then
-        mCurve = l_getRotationSpeed() * 10.0
-        mCurve = mCurve + (u_rndInt(syncRndMin, syncRndMax) / 100.0)
-    end
-
-    w_wallHModCurveData(hueModifier, mSide, THICKNESS, mCurve * (u_getDifficultyMult() ^ 0.25) * curveMult, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-end
-
-function wallHMCurve(mSide, mCurve)
-    wallHMCurveAcc(mSide, mCurve, 0, 0, 0, false)
-end
-
-function hmcBarrageN(mSide, mNeighbors, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    for i = mNeighbors, l_getSides() - 2 - mNeighbors, 1 do
-        wallHMCurveAcc(mSide + i + 1, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    end
-end
-
-function hmcBarrageS(mSide, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    hmcBarrageN(mSide, 0, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-end
-
-function hmcBarrage(mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    hmcBarrageS(getRandomSide(), mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-end
-
-function hmcSimpleBarrage(mCurve)
-    hmcBarrageN(getRandomSide(), 0, mCurve, 0, 0, 0, false)
-end
-
-function hmcSimpleBarrageS(mSide, mCurve)
-    hmcBarrageN(mSide, 0, mCurve, 0, 0, 0, false)
-end
-
-function hmcSimpleBarrageSNeigh(mSide, mCurve, mNeighbors)
-    hmcBarrageN(mSide, mNeighbors, mCurve, 0, 0, 0, false)
-end
-
-
-function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
-    local startSide = getRandomSide()
-    local currentSide = startSide
-    local loopDir = getRandomDir()
-    local delay = getPerfectDelayDM(THICKNESS) * 5.7
-    local j = 0
-
-    local currentCurve = mCurve
-
-    for i = 0, mTimes do
-        hmcSimpleBarrageS(startSide + j, currentCurve)
-        j = j + loopDir
-        currentCurve = currentCurve + mCurveAdd
-        t_wait(delay)
-    end
-end
-
-function hmcSimpleCage(mCurve, mDir)
-    local side = getRandomSide()
-    local oppositeSide = side + getHalfSides()
-
-    wallHMCurve(side, mCurve)
-    wallHMCurve(oppositeSide, mCurve * mDir)
-end
-
-function hmcSimpleCageS(mCurve, mDir, mSide)
-    local oppositeSide = mSide + getHalfSides()
-
-    wallHMCurve(mSide, mCurve)
-    wallHMCurve(oppositeSide, mCurve * mDir)
-end
-
-function hmcSimpleSpinner(mCurve)
-    local side = getRandomSide()
-
-    for i = 0, l_getSides() / 2, 1 do
-        wallHMCurve(side + i * 2, mCurve)
-    end
-end
-
-function hmcSimpleSpinnerS(mSide, mCurve)
-    for i = 0, l_getSides() / 2, 1 do
-        wallHMCurve(mSide + i * 2, mCurve)
-    end
-end
-
-function hmcSimpleSpinnerSAcc(mSide, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    for i = 0, l_getSides() / 2, 1 do
-        wallHMCurveAcc(mSide + i * 2, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
-    end
-end
-
-function hmcDefSpinner()
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.2)
-    hmcSimpleSpinner(u_rndInt(10, 19) / 10.0 * getRandomDir())
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.9)
-end
-
-function hmcDefBarrage()
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
-    hmcSimpleBarrage(u_rndInt(10, 20) / 10.0 * getRandomDir())
-    t_wait(getPerfectDelayDM(THICKNESS) * 5)
-end
-
-function hmcDef2Cage()
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-    local side = getRandomSide()
-    local rndspd = u_rndInt(10, 20) / 10.0
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
-    hmcSimpleCageS(rndspd, -1, side)
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
-    hmcSimpleCageS(rndspd, -1, side)
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
-    hmcSimpleCageS(rndspd, -1, side)
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.3)
-end
-
-function hmcDef2CageD()
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-
-    local side = getRandomSide()
-    local oppositeSide = getHalfSides() + side
-    local rndspd = u_rndInt(10, 17) / 10.0
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
-    hmcSimpleCageS(rndspd, -1, side)
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
-    hmcSimpleCageS(rndspd, -1, side)
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
-    hmcSimpleCageS(rndspd, -1, side)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.0)
-    hmcSimpleCageS(rndspd, -1, oppositeSide)
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
-    hmcSimpleCageS(rndspd, -1, oppositeSide)
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
-    hmcSimpleCageS(rndspd, -1, oppositeSide)
-    t_wait(getPerfectDelayDM(THICKNESS) * 9.2)
-end
-
-function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
-    local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
-    local startSide = getRandomSide()
-    local loopDir = mStep * getRandomDir()
-    local j = 0
-
-    for i = 0, mTimes do
-        hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
-        j = j + loopDir
-        t_wait(delay)
-        if(l_getSides() < 6) then t_wait(delay * 0.7) end
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
-end
-
-function hmcSimpleBarrageSpiralRnd(mTimes, mDelayMult, mCurve, mNeighbors)
-    local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
-    local startSide = getRandomSide()
-
-    for i = 0, mTimes do
-        hmcSimpleBarrageSNeigh(getRandomSide(), mCurve, mNeighbors)
-        t_wait(delay)
-        if(l_getSides() < 6) then t_wait(delay * 0.7) end
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
-end
-
-function hmcSimpleBarrageSpiralStatic(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
-    local delay = getPerfectDelay(THICKNESS) * 5.6 * mDelayMult
-    local startSide = getRandomSide()
-    local loopDir = mStep * getRandomDir()
-    local j = 0
-
-    for i = 0, mTimes do
-        hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
-        j = j + loopDir
-        t_wait(delay)
-        if(l_getSides() < 6) then t_wait(delay * 0.6) end
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
-end
-
-function hmcDefBarrageSpiral()
-    hmcSimpleBarrageSpiral(u_rndInt(1, 3), 1, 1, u_rndInt(5, 15) / 10.0 * getRandomDir(), 0)
-end
-
-function hmcDefBarrageSpiralRnd()
-    hmcSimpleBarrageSpiralRnd(u_rndInt(1, 3), 1, u_rndInt(5, 15) / 10.0 * getRandomDir(), 0)
-end
-
-function hmcDefBarrageSpiralFast()
-    hmcSimpleBarrageSpiral(u_rndInt(1, 3), 0.8, 1, u_rndInt(5, 15) / 10.0 * getRandomDir(), 0)
-end
-
-function hmcDefBarrageSpiralSpin()
-    hmcSimpleBarrageSpiralStatic(u_rndInt(7, 14), 0.25, 1, u_rndInt(5, 18) / 10.0 * getRandomDir(), 2)
-end
-
-function hmcDefBarrageInv()
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.0)
-    local delay = getPerfectDelay(THICKNESS) * 5.6
-    local side = getRandomSide()
-    local rndspd = u_rndInt(10, 20) / 10.0
-    local oppositeSide = getRandomSide() + getHalfSides()
-
-    hmcSimpleBarrageSNeigh(side, rndspd * getRandomDir(), 0)
-    t_wait(delay)
-
-    hmcSimpleBarrageSNeigh(oppositeSide, rndspd * getRandomDir(), 0)
-    t_wait(delay)
-end
-
-function hmcDefAccelBarrage()
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-    local c = u_rndInt(50, 100) / 1000.0 * getRandomDir()
-    local minimum = u_rndInt(5, 35) / 10.0 * -1
-    local maximum = u_rndInt(5, 35) / 10.0
-    hmcBarrage(0, c, minimum, maximum, true)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
-end
-
-function hmcDefAccelBarrageDouble()
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-    local c = u_rndInt(50, 100) / 1000.0 * getRandomDir()
-    local minimum = u_rndInt(5, 35) / 10.0 * -1
-    local maximum = u_rndInt(5, 35) / 10.0
-    hmcBarrage(0, c, minimum, maximum, true)
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-    hmcBarrage(0, c, minimum, maximum, true)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
-end
-
-function hmcDefSpinnerSpiral()
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
-    local side = getRandomSide()
-    local c = u_rndInt(10, 20) / 10.0 * getRandomDir()
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
-
-    for i = 0, u_rndInt(4, 8) do
-        hmcSimpleSpinnerS(side, c)
-        t_wait(getPerfectDelayDM(THICKNESS) * 1.15)
-    end
-
-    t_wait(getPerfectDelayDM(THICKNESS) * 5)
-end
-
+-- getRndMinDM: Returns a random integer of a number where the minimum is influenced by the difficulty multiplier
 function getRndMinDM(mNum)
-    return u_rndInt(math.floor(mNum - (u_getDifficultyMult() ^ 3)), math.ceil(mNum))
+	return math.random(math.floor(mNum - (u_getDifficultyMult() ^ 3)), math.ceil(mNum))
 end
 
+-- getRndMaxDM: Returns a random integer of a number where the maximum is influenced by the difficulty multiplier
 function getRndMaxDM(mNum)
-    return u_rndInt(math.floor(mNum), math.ceil(mNum + (u_getDifficultyMult() ^ 2.25)))
+	return math.random(math.floor(mNum), math.ceil(mNum + (u_getDifficultyMult() ^ 2.25)))
 end
 
-function hmcDefSpinnerSpiralAcc()
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-    local side = getRandomSide()
+-- The function to call when wanting to sync curving walls with the rotation speed.
+-- mRndMin (OPTIONAL): Sets the syncRndMin const to this value
+-- mRndMax (OPTIONAL): Sets the syncRndMax const to this value
+function syncCurveWithRotationSpeed(mRndMin, mRndMax)
+	sync = true
+	syncRndMin = mRndMin or 0
+	syncRndMax = mRndMax or 0
+end
 
-    local acc = u_rndInt(getRndMinDM(50), getRndMaxDM(100)) / 1000.0 * getRandomDir()
-    local minimum = u_rndInt(getRndMinDM(12), getRndMaxDM(28)) / 10.0 * -1
-    local maximum = u_rndInt(getRndMinDM(12), getRndMaxDM(28)) / 10.0
+-- The function to call when wanting to alter curveMult constant
+-- mMult: Sets the curveMult const to this value
+function setCurveMult(mMult)
+	curveMult = mMult
+end
 
+-- Creates a curving wall, adhering to the constants presented by this script.
+-- mSide: The side to spawn the curving wall on
+-- mCurve: The curving speed the wall will travel at
+-- mCurveAcc: How much acceleration to apply to the curving wall
+-- mCurveMin: The lowest curving speed the wall is allowed to go
+-- mCurveMax: The highest curving speed the wall is allowed to go
+-- mCurvePingPong: If accelerated to mCurveMin or mCurveMax, should the acceleration switch directions and go the other way?
+-- mThickness (OPTIONAL): The thickness of the curving wall.
+function wallHMCurveAcc(mSide, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong, mThickness)
+	mThickness = mThickness or THICKNESS
+	if sync == true then
+		mCurve = l_getRotationSpeed() * (10.0 / syncCurveToSideDistance())
+		mCurve = mCurve + (math.random(syncRndMin, syncRndMax) / 100.0)
+	end
+	w_wallHModCurveData(globalHueModifier, mSide, mThickness, mCurve * (u_getDifficultyMult() ^ 0.25) * curveMult * syncCurveToSideDistance(), mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+end
 
+-- A simplification of wallHMCurve, only allowing customization of the curve speed
+-- mSide: The side to spawn the curving wall on
+-- mCurve: The curving speed the wall will travel at
+-- mThickness (OPTIONAL): The thickness of the curving wall.
+function wallHMCurve(mSide, mCurve, mThickness)
+	mThickness = mThickness or THICKNESS
+	wallHMCurveAcc(mSide, mCurve, 0, 0, 0, false, mThickness)
+end
 
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
+-- A preset of wallHMCurveAcc where getPerfectCurveDecel is used to spawn a wall to stop acceleration on a side panel.
+-- mSide: The side that the wall will stop on.
+-- mOffset: How much offset from mSide the wall will have when spawned. A higher offset will make a faster wall.
+-- mThickness (OPTIONAL): The thickness of the curving wall.
+function wallHMStop(mSide, mOffset, mThickness)
+	mThickness = mThickness or THICKNESS
+	local curveAcc = getPerfectCurveDecel();
+	if (getSign(mOffset) == -1) then
+		wallHMCurveAcc(mSide + mOffset, 2 * -mOffset, curveAcc * mOffset / 100, 0, 2 * -mOffset, false, mThickness);
+	else
+		wallHMCurveAcc(mSide + mOffset, -2 * mOffset, curveAcc * mOffset / 100, -2 * mOffset, 0, false, mThickness);
+	end
+end
 
-    for i = 0, u_rndInt(4, 8) do
-        hmcSimpleSpinnerSAcc(side, 0, acc, minimum, maximum, true)
-        t_wait(getPerfectDelay(THICKNESS) * 0.8)
+------------------------------------------------------
+-- BEGINNING OF HMC FUNCTIONS (Hue Modified Common) --
+------------------------------------------------------
+
+-- A barrage with additional adjacent mNeighbors that composes of curving walls.
+-- mSide: The side to spawn the curving wall on
+-- mNeighbors: The expansion of the barrage opening by this many adjacent neighbors
+-- mCurve: The curving speed the wall will travel at
+-- mCurveAcc: How much acceleration to apply to the curving wall
+-- mCurveMin: The lowest curving speed the wall is allowed to go
+-- mCurveMax: The highest curving speed the wall is allowed to go
+-- mCurvePingPong: If accelerated to mCurveMin or mCurveMax, should the acceleration switch directions and go the other way?
+function hmcBarrageN(mSide, mNeighbors, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+	for i = mNeighbors, l_getSides() - 2 - mNeighbors, 1 do
+		wallHMCurveAcc(mSide + i + 1, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+	end
+end
+
+-- hmcBarrageS: hmcBarrageN, but there are no additional neighbors, and the gap is only 1 side wide.
+function hmcBarrageS(mSide, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+	hmcBarrageN(mSide, 0, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong);
+end
+
+-- hmcBarrage: hmcBarrageS, but the side is chosen at random for you.
+function hmcBarrage(mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+	hmcBarrageS(getRandomSide(), mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong);
+end
+
+-- hmcBarrageStop: A barrage that comes to a full stop, similar to how wallHMStop works.
+function hmcBarrageStop(mSide, mOffset, mNeighbors)
+	mNeighbors = mNeighbors or 0
+	local curveAcc = getPerfectCurveDecel();
+	if (getSign(mOffset) == -1) then
+		hmcBarrageN(mSide + mOffset, mNeighbors, 2 * -mOffset, curveAcc * mOffset / 100, 0, 2 * -mOffset, false); 
+	else
+		hmcBarrageN(mSide + mOffset, mNeighbors, -2 * mOffset, curveAcc * mOffset / 100, -2 * mOffset, 0, false); 
+	end
+end
+
+-- A simple curving barrage.
+-- mSide (OPTIONAL, BUT HIGHLY RECOMMENDED): The side the barrage starts at
+-- mCurve (OPTIONAL): The constant curving speed the barrage will travel
+-- mNeighbors (OPTIONAL): The expansion of the barrage opening by this many adjacent neighbors
+function hmcSimpleBarrage(mSide, mCurve, mNeighbors)
+	mSide = mSide or 0
+	mCurve = mCurve or 0
+	mNeighbors = mNeighbors or 0
+	hmcBarrageN(mSide, mNeighbors, mCurve, 0, 0, 0, false);
+end
+
+-- Compatibility mappings for legacy functions that did the same thing.
+hmcSimpleBarrageS = hmcSimpleBarrage
+hmcSimpleBarrageSNeigh = hmcSimpleBarrage
+
+-- A series of barrages that curve at mCurve speed, increasing each iteration by mCurveAdd to recreate a barrage spiral
+-- mTimes: How many repetitions of barrages there should be
+-- mCurve: The starting curve speed for the pattern
+-- mCurveAdd: How much to add to the curving speed each iteration
+function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
+	local startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 5.7
+	local currentCurve = mCurve
+
+	for i = 0, mTimes do
+		hmcSimpleBarrageS(startSide, currentCurve)
+		currentCurve = currentCurve + mCurveAdd
+		t_wait(delay)
+	end
+end
+
+-- A wall that curves at mCurve speed, with an opposing wall that travel towards it,
+-- "caging" the player if not aware of the movements.
+-- mCurve: The curve speed for the pattern
+-- mDir: The direction of the curving for the opposing wall.
+-- mSide (OPTIONAL): Which side the pattern spawns on. 
+function hmcSimpleCage(mCurve, mDir, mSide)
+	mSide = mSide or getRandomSide()
+	local oppositeSide = mSide + getHalfSides()
+
+	wallHMCurve(mSide, mCurve)
+	wallHMCurve(oppositeSide, mCurve * mDir)
+end
+
+hmcSimpleCageS = hmcSimpleCage
+
+-- An alt barrage that travels at a constant curving speed (Don't ask. Vee came up with the name).
+-- mSide: The side the spinner starts at
+-- mCurve: The constant curving speed the spinner will travel
+-- mStep (OPTIONAL): How much to iterate before spawning the next wall
+function hmcSimpleSpinner(mSide, mCurve, mStep)
+	mStep = mStep or 2
+	for i = 0, l_getSides(), mStep do
+		wallHMCurve(mSide + i, mCurve)
+	end
+end
+
+hmcSimpleSpinnerS = hmcSimpleSpinner
+
+-- hmcSimpleSpinnerSAcc: A spinner but with more options in regards to accelerating the walls.
+function hmcSimpleSpinnerSAcc(mSide, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+	for i = 0, l_getSides() / 2, 1 do
+		wallHMCurveAcc(mSide + i * 2, mCurve, mCurveAcc, mCurveMin, mCurveMax, mCurvePingPong)
+	end
+end
+
+-- hmcGrowBarrage: Given a specific position to pivot, all walls will spawn there and spread out from that position to make a barrage.
+function hmcGrowBarrage(mSide, mPivot)
+	for i = 0, l_getSides() - 2 do
+		wallHMStop(mSide + i + 1, mPivot - i);
+	end
+end
+
+-- hmcAssembleBarrage: All individual walls will be randomly offset and then assemble together to create a barrage.
+function hmcAssembleBarrage(mSide, mLower, mUpper)
+	mLower = mLower or 1
+	mUpper = mUpper or l_getSides()
+	for i = 0, l_getSides() - 2 do
+		wallHMStop(mSide + i + 1, math.random(mLower, mUpper) * getRandomDir());
+	end
+end
+
+-- hmcDef2Cage: Spawns a series of hmcSimpleCage to create a trailing effect
+function hmcDef2Cage()
+	local side = getRandomSide()
+	local rndspd = math.random(1, 5)
+
+	t_wait(getPerfectDelayDM(THICKNESS) * 5.2)
+	hmcSimpleCageS(rndspd, -1, side)
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	hmcSimpleCageS(rndspd, -1, side)
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	hmcSimpleCageS(rndspd, -1, side)
+	t_wait(getPerfectDelayDM(THICKNESS) * 5.3)
+end
+
+-- hmcDef2CageD: A doubled version of hmcDef2Cage, creating another one opposite of the first pattern
+function hmcDef2CageD()
+	local side = getRandomSide()
+	local oppositeSide = getHalfSides() + side
+	local rndspd = math.random(1, 5)
+
+	t_wait(getPerfectDelayDM(THICKNESS) * 5.2)
+	hmcSimpleCageS(rndspd, -1, side)
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	hmcSimpleCageS(rndspd, -1, side)
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	hmcSimpleCageS(rndspd, -1, side)
+	t_wait(getPerfectDelayDM(THICKNESS) * 6.0)
+	hmcSimpleCageS(rndspd, -1, oppositeSide)
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	hmcSimpleCageS(rndspd, -1, oppositeSide)
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	hmcSimpleCageS(rndspd, -1, oppositeSide)
+	t_wait(getPerfectDelayDM(THICKNESS) * 9.2)
+end
+
+-- A barrage spiral that travels at a constant curving speed.
+-- mTimes: The amount of barrages to spawn during a barrage
+-- mDelayMult: A custom delay multiplier used to customize spacing between barrages
+-- mStep: How much sides to increment from barrage to barrage
+-- mCurve: The curve speed for the pattern
+-- mNeighbors (OPTIONAL): The expansion of the barrage opening by this many adjacent neighbors
+function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
+	mNeighors = mNeighbors or 0
+	local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
+	local startSide = getRandomSide()
+	local loopDir = mStep * getRandomDir()
+	local j = 0
+
+	for i = 0, mTimes do
+		hmcSimpleBarrageSNeigh(startSide + j, mCurve, mNeighbors)
+		j = j + loopDir
+		t_wait(delay)
+		if(l_getSides() < 6) then t_wait(delay * 0.7) end
+	end
+
+	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+end
+
+-- getPerfectDelayDM now has the same implementation as getPerfectDelay, so this pattern is now redundant.
+hmcSimpleBarrageSpiralStatic = hmcSimpleBarrageSpiral
+
+-- hmcBarrageInv: pInverseBarrage but with curving walls.
+function hmcBarrageInv(mMinCurve, mMaxCurve)
+	t_wait(getPerfectDelayDM(THICKNESS) * 2.0)
+	local delay = getPerfectDelayDM(THICKNESS) * 8
+	local side = getRandomSide()
+	local rndSpd = math.random(mMinCurve, mMaxCurve);
+	local oppositeSide = getRandomSide() + getHalfSides()
+
+	hmcSimpleBarrageSNeigh(side, rndSpd * getRandomDir(), 0)
+	t_wait(delay)
+
+	hmcSimpleBarrageSNeigh(oppositeSide, rndSpd * getRandomDir(), 0)
+	t_wait(delay)
+end
+
+-- hmcTunnelDynamic: A single segment tunnel piece where the tunnel (the thick wall) moves into a random position.
+function hmcTunnelDynamic(mBarrageSide, mTunnelSide, mOffset)
+	local offset = mOffset or math.random(3, l_getSides());
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 4
+	
+	cBarrage(mBarrageSide);
+	t_wait(getPerfectDelay(THICKNESS) - 1)
+	wallHMStop(mTunnelSide % l_getSides(), offset, myThickness + 6 * u_getSpeedMultDM() * delay - myThickness * 2)
+	t_wait(delay)
+end
+
+-- hmcTurnaroundSector: Spawns a segment with two openings. One of the openings will have a dead end and force the player to swap.
+-- mReveal determines whether the dead end should reveal itself from a hidden spot.
+function hmcTurnaroundSector(mSide, mReveal)
+	mReveal = mReveal or false;
+	
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelay(myThickness) * 2.5
+	
+	if (mReveal) then
+		wallHMStop(mSide, math.random(1, l_getSides()) * getRandomDir());
+	else
+		cWall(mSide)
+	end
+	for i = 1, getHalfSides() - 1 do
+		w_wall(mSide + i, myThickness + 3.8 * u_getSpeedMultDM() * delay)
+		w_wall(mSide + i, -myThickness * 1.5)
+	end
+	for i = getHalfSides() + 1, l_getSides() - 1 do
+		w_wall(mSide + i, myThickness + 3.8 * u_getSpeedMultDM() * delay)
+		w_wall(mSide + i, -myThickness * 1.5)
+	end
+	t_wait(delay)
+end
+
+--------------------------------------------------------
+-- BEGINNING OF HMP FUNCTIONS (Hue Modified Patterns) --
+--------------------------------------------------------
+
+-- A patternized hmcSimpleBarrage, with a randomized side placement and optional speed randomization set by the user
+-- mMin (OPTIONAL): The lowest speed the barrage can travel
+-- mMax (OPTIONAL): The highest speed the barrage can travel
+function hmpBarrage(mMin, mMax)
+	mMin = mMin or 1;
+	mMax = mMax or l_getSides() - 1;
+	hmcSimpleBarrage(getRandomSide(), math.random(mMin, mMax) * getRandomDir())
+	t_wait(getPerfectDelayDM(THICKNESS) * 8.1)
+end
+
+-- A patternized hmcBarrageStop, with a randomized side placement and optional offset randomization set by the user
+-- mOffsetMin (OPTIONAL): The lowest offset a barrage can be placed
+-- mOffsetMax (OPTIONAL): The highest offset a barrage can be placed
+function hmpBarrageStop(mOffsetMin, mOffsetMax)
+	mOffsetMin = mOffsetMin or 2;
+	mOffsetMax = mOffsetMax or l_getSides() * 2;
+	hmcBarrageStop(getRandomSide(), math.random(mOffsetMin, mOffsetMax) * getRandomDir());
+	t_wait(getPerfectDelayDM(THICKNESS) * 9)
+end
+
+-- A patternized hmcSimpleSpinner, with a randomized side placement and optional speed randomization set by the user
+-- mMin (OPTIONAL): The lowest speed the barrage can travel
+-- mMax (OPTIONAL): The highest speed the barrage can travel
+function hmpSpinner(mMin, mMax)
+	mMin = mMin or 1;
+	mMax = mMax or l_getSides() - 1;
+	hmcSimpleSpinner(getRandomSide(), math.random(mMin, mMax) * getRandomDir())
+	t_wait(getPerfectDelayDM(THICKNESS) * 9.1)
+end
+
+-- hmpTwirl: A patternized hmcSimpleTwirl that has a shorter delay between barrages and curve and curveAdd must go in the same direction.
+function hmpTwirl(mTimes, mCurve, mCurveAdd)
+	local startSide = getRandomSide()
+	local delay = getPerfectDelayDM(THICKNESS) * 4
+	local dir = getRandomDir()
+	local currentCurve = mCurve * dir
+
+	for i = 0, mTimes do
+		hmcSimpleBarrageS(startSide, currentCurve)
+		currentCurve = currentCurve + mCurveAdd * dir
+		t_wait(delay)
+	end
+	t_wait(delay * 1.5)
+end
+
+-- A patternized hmcSimpleBarrageSpiral, with a randomized side placement and optional speed randomization set by the user
+-- mTimes (OPTIONAL): The amount of barrages to spawn
+-- mMinCurve (OPTIONAL): The lowest speed the pattern can travel
+-- mMaxCurve (OPTIONAL): The highest speed the pattern can travel
+function hmpBarrageSpiral(mTimes, mMinCurve, mMaxCurve)
+	mTimes = mTimes or math.random(1, 3);
+	mMinCurve = mMinCurve or 1;
+	mMaxCurve = mMaxCurve or l_getSides() - 1;
+	hmcSimpleBarrageSpiral(mTimes, 1, 1, math.random(mMinCurve, mMaxCurve) * getRandomDir(), 0)
+end
+
+-- An hmcSimpleBarrageSpiral, but it uses hmcBarrageStop instead of normal hmcBarrages.
+-- mTimes (OPTIONAL): The amount of barrages to spawn
+-- mMinCurve (OPTIONAL): The lowest offset each barrage can travel
+-- mMaxCurve (OPTIONAL): The highest offset each barrage can travel
+function hmpBarrageSpiralStop(mTimes, mMinCurve, mMaxCurve)
+	mTimes = mTimes or math.random(1, 3);
+	mMinCurve = mMinCurve or 1;
+	mMaxCurve = mMaxCurve or l_getSides() - 1;
+	
+	local side = getRandomSide()
+	local loopDir = getRandomDir()
+	local delay = getPerfectDelayDM(THICKNESS) * 6.2
+
+	for i = 0, mTimes do
+		hmcBarrageStop(side + i * loopDir, math.random(mMinCurve, mMaxCurve) * getRandomDir());
+		t_wait(delay)
+		if(l_getSides() < 6) then t_wait(delay * 0.7) end
+	end
+
+	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+end
+
+-- hmpBarrageSpiralSpin: A subset of hmcSimpleBarrageSpiral to spawn barrages with 25% the normal delay
+function hmpBarrageSpiralSpin(mTimes, mMinCurve, mMaxCurve)
+	mTimes = mTimes or math.random(7, 14);
+	mMinCurve = mMinCurve or 1;
+	mMaxCurve = mMaxCurve or l_getSides() - 1;
+	hmcSimpleBarrageSpiralStatic(mTimes, 0.25, 1, math.random(mMinCurve, mMaxCurve) * getRandomDir(), 2)
+end
+
+-- hmpDefAccelBarrage: A barrage that is randomized in curving speed, minimum, and maximum accelerations.
+function hmpDefAccelBarrage()
+	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
+	local c = math.random(50, 100) / 1000.0 * getRandomDir()
+	local minimum = math.random(5, 35) / 10.0 * -1
+	local maximum = math.random(5, 35) / 10.0
+	hmcBarrage(0, c, minimum, maximum, true)
+	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+end
+
+-- hmpTunnelDynamic: A segment of hmcTunnelDynamics in a single pattern, written to avoid impossible outcomes.
+function hmpTunnelDynamic(mTimes, mLower, mUpper)
+	mLower = mLower or 2
+	mUpper = mUpper or l_getSides();
+	local barrageSide, prevSide, tunnelSide;
+	for i = 1, mTimes + 1 do
+		if (prevSide ~= nil) then
+			repeat barrageSide = getRandomSide() until barrageSide ~= prevSide;
+		else
+			barrageSide = getRandomSide();
+		end
+		repeat tunnelSide = getRandomSide() until tunnelSide ~= barrageSide;
+		if (i < mTimes + 1) then
+			hmcTunnelDynamic(barrageSide, tunnelSide, math.random(mLower, mUpper) * getRandomDir());
+		else
+			cBarrage(barrageSide);
+		end
+		prevSide = tunnelSide;
+	end
+	
+	t_wait(getPerfectDelay(getPerfectThickness(THICKNESS)) * 5.6)
+end
+
+-- hmpStripeSnakeBarrage: Given a specific offset, this pattern creates repetitions of a barrage with a given offset to drift from.
+function hmpStripeSnakeBarrage(mSide, mRepetitions, mLower, mUpper)
+	mLower = mLower or l_getSides()
+	mUpper = mUpper or l_getSides() * 2
+	local offset = math.random(mLower, mUpper) * getRandomDir()
+	local delay = getPerfectDelay(THICKNESS)
+	for r = 0, mRepetitions do
+		for i = 0, l_getSides() - 2 do
+			wallHMStop(mSide + i + 1, offset)
+		end
+		t_wait(delay)
+	end
+	t_wait(delay * 7)
+end
+
+-- hmpStripeSnakeBarrage: Given a specific offset, this pattern creates repetitions of a single alt barrage with a given offset to drift from.
+function hmpStripeSnakeAltBarrage(mRepetitions, mStep, mLower, mUpper)
+	mLower = mLower or l_getSides()
+	mUpper = mUpper or l_getSides() * 2
+	local side = getRandomSide()
+	local offset = math.random(mLower, mUpper) * getRandomDir()
+	local delay = getPerfectDelay(THICKNESS)
+	for r = 0, mRepetitions do
+		for i = 0, l_getSides(), mStep do
+			wallHMStop(side + i, offset)
+		end
+		t_wait(delay)
+	end
+	t_wait(delay * 7)
+end
+
+-- hmpGrowTunnel: A tunnel pattern where the barrages consist of hmcGrowBarrages instead of regular ones.
+function hmpGrowTunnel(mTimes)
+	local myThickness = getPerfectThickness(THICKNESS)
+    local delay = getPerfectDelay(myThickness) * 4.5
+    local startSide = getRandomSide()
+	local barrageSide, offset;
+	
+	for i = 0, mTimes do
+		repeat barrageSide = getRandomSide() until barrageSide ~= startSide
+		offset = (l_getSides() - (barrageSide - startSide + 1)) % (l_getSides())
+		hmcGrowBarrage(barrageSide, offset)
+		w_wall(startSide, -myThickness) -- Wall to prevent visual artifacts
+		if i < mTimes then
+			w_wall(startSide, myThickness + 5 * u_getSpeedMultDM() * delay)
+		else
+			w_wall(startSide, myThickness)
+        end
+		t_wait(delay)
+	end
+end
+
+-- hmpAssembleTunnel: A tunnel pattern where the barrages consist of hmcAssembleBarrages instead of regular ones.
+function hmpAssembleTunnel(mTimes, mLower, mUpper)
+	mLower = mLower or 1
+	mUpper = mUpper or getHalfSides()
+	
+	local myThickness = getPerfectThickness(THICKNESS)
+    local delay = getPerfectDelay(myThickness) * 4.5
+    local startSide = getRandomSide()
+	local barrageSide;
+	
+	for i = 0, mTimes do
+		repeat barrageSide = getRandomSide() until barrageSide ~= startSide
+		hmcAssembleBarrage(barrageSide, mLower, mUpper)
+		w_wall(startSide, -myThickness) -- Wall to prevent visual artifacts
+		if i < mTimes then
+			w_wall(startSide, myThickness + 5 * u_getSpeedMultDM() * delay)
+		else
+			w_wall(startSide, myThickness)
+        end
+		t_wait(delay)
+	end
+end
+
+-- hmpChaserAltBarrage: pAltBarrage, but a huge tunnel curving wall moves throughout the pattern, restricting where the player moves.
+function hmpChaserAltBarrage(mTimes, mStep, mSpeed, mTail)
+	mSpeed = mSpeed or math.random(getHalfSides(), l_getSides());
+	mTail = mTail or false -- If true, the tunnel extends past the last alt barrage. Done for connectivity purposes
+	mTail = mTail and 1 or 0 -- Convert boolean to integer
+	local myThickness = getPerfectThickness(THICKNESS)
+	local delay = getPerfectDelayDM(myThickness) * 3
+
+	-- Create the tunnel wall (chaser)
+	-- For the side, we want to make sure that the chaser is on one of the first alt barrage walls (which is odd numbers)
+	-- This makes the pattern slightly easier to predict and doesn't close out one of the openings.
+	wallHMCurveAcc((getRandomSide() * 2 + 1 - mSpeed), mSpeed * getRandomDir(), 0, 0, 0, false, (THICKNESS * (mTimes - 1 + mTail)) + delay * 12.5 * (u_getDifficultyMult() ^ .65) * (mTimes - 1 + mTail));
+	for i = 1, mTimes do
+        cAltBarrage(i, mStep)
+        t_wait(delay)
     end
+end
 
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.3)
+-- hmpAlternate: A simple pattern involving one spinning barrage and one normal barrage.
+function hmpAlternate()
+	local curveSide = getRandomSide();
+	local force = math.random(2, 4);
+	
+	hmcSimpleBarrageS(curveSide, force * getRandomDir())
+	t_wait(getPerfectDelay(THICKNESS) * 10)
+	cBarrage(getRandomSide());
+	t_wait(getPerfectDelay(THICKNESS) * 10)
+end
+
+-- hmpTunnelSpinner: A typical tunnel pattern that contains spinners (curving alt barrages)
+function hmpTunnelSpinner(mTimes, mLower, mUpper)
+	mLower = mLower or 1
+	mUpper = mUpper or getHalfSides()
+	
+	local myThickness = getPerfectThickness(THICKNESS)
+    local delay = getPerfectDelay(myThickness) * 4.5
+    local startSide = getRandomSide()
+	
+	for i = 0, mTimes do
+		hmcSimpleSpinner(getRandomSide(), math.random(mLower, mUpper) * getRandomDir())
+		w_wall(startSide, -myThickness) -- Wall to prevent visual artifacts
+		if i < mTimes then
+			w_wall(startSide, myThickness + 5 * u_getSpeedMultDM() * delay)
+		else
+			w_wall(startSide, myThickness)
+        end
+		t_wait(delay)
+	end
+end
+
+-- hmpSwarm: A pattern that sends a flurry of single curving walls segments for the player to avoid.
+-- The pattern takes in 3 parameters to allow which walls should be contained in the swarm or not.
+-- An optional delay parameter can be supplied to lower or raise the delay between segments
+function hmpSwarm(mLower, mUpper, mDecel, mConstant, mAccel, mDelayMult)
+	mDecel = mDecel or true
+	mConstant = mConstant or false
+	mAccel = mAccel or false
+	mDelayMult = mDelayMult or 1
+	local delay = getPerfectDelayDM(getPerfectThickness(THICKNESS)) * 2 * mDelayMult
+	
+	-- Constuct wall pool
+	local wall_pool = {}
+	if mDecel then
+		wall_pool[#wall_pool + 1] = "d"
+	end
+	if mConstant then
+		wall_pool[#wall_pool + 1] = "c"
+	end
+	if mAccel then
+		wall_pool[#wall_pool + 1] = "a"
+	end
+	-- If all patterns are false, abruptly end the function
+	if (#wall_pool == 0) then
+		return
+	end
+	for i = 1, 10 do
+		local option = wall_pool[math.random(1, #wall_pool)]
+		local offset = math.random(mLower, mUpper) * getRandomDir()
+		if (option == "d") then
+			wallHMStop(getRandomSide(), offset)
+		elseif (option == "c") then
+			wallHMCurveAcc(getRandomSide(), offset, 0, 0, 0, false)
+		elseif (option == "a") then
+			local c = math.random(100, 300) / 500.0 * getRandomDir()
+			wallHMCurveAcc(getRandomSide(), 0, c, -offset, offset, true)
+		end
+		t_wait(delay)
+	end
 end

--- a/_RELEASE/Packs/base/Scripts/evolutionpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/evolutionpatterns.lua
@@ -157,7 +157,7 @@ hmcSimpleBarrageSNeigh = hmcSimpleBarrage
 -- mCurveAdd: How much to add to the curving speed each iteration
 function hmcSimpleTwirl(mTimes, mCurve, mCurveAdd)
 	local startSide = getRandomSide()
-	local delay = getPerfectDelayDM(THICKNESS) * 5.7
+	local delay = getPerfectDelay(THICKNESS) * 5.7
 	local currentCurve = mCurve
 
 	for i = 0, mTimes do
@@ -223,13 +223,13 @@ function hmcDef2Cage()
 	local side = getRandomSide()
 	local rndspd = math.random(1, 5)
 
-	t_wait(getPerfectDelayDM(THICKNESS) * 5.2)
+	t_wait(getPerfectDelay(THICKNESS) * 5.2)
 	hmcSimpleCageS(rndspd, -1, side)
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	t_wait(getPerfectDelay(THICKNESS) * 1.1)
 	hmcSimpleCageS(rndspd, -1, side)
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	t_wait(getPerfectDelay(THICKNESS) * 1.1)
 	hmcSimpleCageS(rndspd, -1, side)
-	t_wait(getPerfectDelayDM(THICKNESS) * 5.3)
+	t_wait(getPerfectDelay(THICKNESS) * 5.3)
 end
 
 -- hmcDef2CageD: A doubled version of hmcDef2Cage, creating another one opposite of the first pattern
@@ -238,19 +238,19 @@ function hmcDef2CageD()
 	local oppositeSide = getHalfSides() + side
 	local rndspd = math.random(1, 5)
 
-	t_wait(getPerfectDelayDM(THICKNESS) * 5.2)
+	t_wait(getPerfectDelay(THICKNESS) * 5.2)
 	hmcSimpleCageS(rndspd, -1, side)
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	t_wait(getPerfectDelay(THICKNESS) * 1.1)
 	hmcSimpleCageS(rndspd, -1, side)
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	t_wait(getPerfectDelay(THICKNESS) * 1.1)
 	hmcSimpleCageS(rndspd, -1, side)
-	t_wait(getPerfectDelayDM(THICKNESS) * 6.0)
+	t_wait(getPerfectDelay(THICKNESS) * 6.0)
 	hmcSimpleCageS(rndspd, -1, oppositeSide)
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	t_wait(getPerfectDelay(THICKNESS) * 1.1)
 	hmcSimpleCageS(rndspd, -1, oppositeSide)
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.1)
+	t_wait(getPerfectDelay(THICKNESS) * 1.1)
 	hmcSimpleCageS(rndspd, -1, oppositeSide)
-	t_wait(getPerfectDelayDM(THICKNESS) * 9.2)
+	t_wait(getPerfectDelay(THICKNESS) * 9.2)
 end
 
 -- A barrage spiral that travels at a constant curving speed.
@@ -261,7 +261,7 @@ end
 -- mNeighbors (OPTIONAL): The expansion of the barrage opening by this many adjacent neighbors
 function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
 	mNeighors = mNeighbors or 0
-	local delay = getPerfectDelayDM(THICKNESS) * 6.2 * mDelayMult
+	local delay = getPerfectDelay(THICKNESS) * 6.2 * mDelayMult
 	local startSide = getRandomSide()
 	local loopDir = mStep * getRandomDir()
 	local j = 0
@@ -273,16 +273,16 @@ function hmcSimpleBarrageSpiral(mTimes, mDelayMult, mStep, mCurve, mNeighbors)
 		if(l_getSides() < 6) then t_wait(delay * 0.7) end
 	end
 
-	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+	t_wait(getPerfectDelay(THICKNESS) * 6.1)
 end
 
--- getPerfectDelayDM now has the same implementation as getPerfectDelay, so this pattern is now redundant.
+-- getPerfectDelay now has the same implementation as getPerfectDelay, so this pattern is now redundant.
 hmcSimpleBarrageSpiralStatic = hmcSimpleBarrageSpiral
 
 -- hmcBarrageInv: pInverseBarrage but with curving walls.
 function hmcBarrageInv(mMinCurve, mMaxCurve)
-	t_wait(getPerfectDelayDM(THICKNESS) * 2.0)
-	local delay = getPerfectDelayDM(THICKNESS) * 8
+	t_wait(getPerfectDelay(THICKNESS) * 2.0)
+	local delay = getPerfectDelay(THICKNESS) * 8
 	local side = getRandomSide()
 	local rndSpd = math.random(mMinCurve, mMaxCurve);
 	local oppositeSide = getRandomSide() + getHalfSides()
@@ -341,7 +341,7 @@ function hmpBarrage(mMin, mMax)
 	mMin = mMin or 1;
 	mMax = mMax or l_getSides() - 1;
 	hmcSimpleBarrage(getRandomSide(), math.random(mMin, mMax) * getRandomDir())
-	t_wait(getPerfectDelayDM(THICKNESS) * 8.1)
+	t_wait(getPerfectDelay(THICKNESS) * 8.1)
 end
 
 -- A patternized hmcBarrageStop, with a randomized side placement and optional offset randomization set by the user
@@ -351,7 +351,7 @@ function hmpBarrageStop(mOffsetMin, mOffsetMax)
 	mOffsetMin = mOffsetMin or 2;
 	mOffsetMax = mOffsetMax or l_getSides() * 2;
 	hmcBarrageStop(getRandomSide(), math.random(mOffsetMin, mOffsetMax) * getRandomDir());
-	t_wait(getPerfectDelayDM(THICKNESS) * 9)
+	t_wait(getPerfectDelay(THICKNESS) * 9)
 end
 
 -- A patternized hmcSimpleSpinner, with a randomized side placement and optional speed randomization set by the user
@@ -361,13 +361,13 @@ function hmpSpinner(mMin, mMax)
 	mMin = mMin or 1;
 	mMax = mMax or l_getSides() - 1;
 	hmcSimpleSpinner(getRandomSide(), math.random(mMin, mMax) * getRandomDir())
-	t_wait(getPerfectDelayDM(THICKNESS) * 9.1)
+	t_wait(getPerfectDelay(THICKNESS) * 9.1)
 end
 
 -- hmpTwirl: A patternized hmcSimpleTwirl that has a shorter delay between barrages and curve and curveAdd must go in the same direction.
 function hmpTwirl(mTimes, mCurve, mCurveAdd)
 	local startSide = getRandomSide()
-	local delay = getPerfectDelayDM(THICKNESS) * 4
+	local delay = getPerfectDelay(THICKNESS) * 4
 	local dir = getRandomDir()
 	local currentCurve = mCurve * dir
 
@@ -401,7 +401,7 @@ function hmpBarrageSpiralStop(mTimes, mMinCurve, mMaxCurve)
 	
 	local side = getRandomSide()
 	local loopDir = getRandomDir()
-	local delay = getPerfectDelayDM(THICKNESS) * 6.2
+	local delay = getPerfectDelay(THICKNESS) * 6.2
 
 	for i = 0, mTimes do
 		hmcBarrageStop(side + i * loopDir, math.random(mMinCurve, mMaxCurve) * getRandomDir());
@@ -409,7 +409,7 @@ function hmpBarrageSpiralStop(mTimes, mMinCurve, mMaxCurve)
 		if(l_getSides() < 6) then t_wait(delay * 0.7) end
 	end
 
-	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+	t_wait(getPerfectDelay(THICKNESS) * 6.1)
 end
 
 -- hmpBarrageSpiralSpin: A subset of hmcSimpleBarrageSpiral to spawn barrages with 25% the normal delay
@@ -422,12 +422,12 @@ end
 
 -- hmpDefAccelBarrage: A barrage that is randomized in curving speed, minimum, and maximum accelerations.
 function hmpDefAccelBarrage()
-	t_wait(getPerfectDelayDM(THICKNESS) * 1.5)
+	t_wait(getPerfectDelay(THICKNESS) * 1.5)
 	local c = math.random(50, 100) / 1000.0 * getRandomDir()
 	local minimum = math.random(5, 35) / 10.0 * -1
 	local maximum = math.random(5, 35) / 10.0
 	hmcBarrage(0, c, minimum, maximum, true)
-	t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+	t_wait(getPerfectDelay(THICKNESS) * 6.1)
 end
 
 -- hmpTunnelDynamic: A segment of hmcTunnelDynamics in a single pattern, written to avoid impossible outcomes.
@@ -534,7 +534,7 @@ function hmpChaserAltBarrage(mTimes, mStep, mSpeed, mTail)
 	mTail = mTail or false -- If true, the tunnel extends past the last alt barrage. Done for connectivity purposes
 	mTail = mTail and 1 or 0 -- Convert boolean to integer
 	local myThickness = getPerfectThickness(THICKNESS)
-	local delay = getPerfectDelayDM(myThickness) * 3
+	local delay = getPerfectDelay(myThickness) * 3
 
 	-- Create the tunnel wall (chaser)
 	-- For the side, we want to make sure that the chaser is on one of the first alt barrage walls (which is odd numbers)
@@ -586,7 +586,7 @@ function hmpSwarm(mLower, mUpper, mDecel, mConstant, mAccel, mDelayMult)
 	mConstant = mConstant or false
 	mAccel = mAccel or false
 	mDelayMult = mDelayMult or 1
-	local delay = getPerfectDelayDM(getPerfectThickness(THICKNESS)) * 2 * mDelayMult
+	local delay = getPerfectDelay(getPerfectThickness(THICKNESS)) * 2 * mDelayMult
 	
 	-- Constuct wall pool
 	local wall_pool = {}

--- a/_RELEASE/Packs/base/Scripts/nextpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/nextpatterns.lua
@@ -3,162 +3,370 @@ u_execScript("commonpatterns.lua")
 u_execScript("utils.lua")
 u_execScript("alternativepatterns.lua")
 
+-- getPerfectAccelDM: Returns a constant that is used to perfectly adjust wallAcc acceleration to speed and difficulty multiplier
+function getPerfectAccelDM()
+	local requiredDecel = (u_getSpeedMultDM() ^ 2.02);
+	local diffAdjust = (u_getDifficultyMult() ^ 0.65);
+	if (u_getDifficultyMult() < 1) then
+		if (u_getDifficultyMult() < 0.5) then
+			diffAdjust = 1.2 * (0.256289 * math.sin(u_getDifficultyMult()) - 36.5669 * math.cos(u_getDifficultyMult()) + 36.5674);
+		else
+			diffAdjust = 1 - (-2 * u_getDifficultyMult() + 2) ^ 2 / 2.7;
+		end
+	end
+	return diffAdjust * requiredDecel
+end
+
+-- wallSAdj: Returns a wall with common THICKNESS and multiplies the speed by mAdj
 function wallSAdj(mSide, mAdj) w_wallAdj(mSide, THICKNESS, mAdj) end
-function wallSAcc(mSide, mAdj, mAcc, mMinSpd, mMaxSpd) w_wallAcc(mSide, THICKNESS, mAdj, mAcc * (u_getDifficultyMult()), mMinSpd, mMaxSpd) end
 
+-- wallSAcc: Returns a wallAcc perfectly adjusted to speed and difficulty multiplier
+function wallSAcc(mSide, mAdj, mAcc, mMinSpd, mMaxSpd) 
+	local speedMult = u_getSpeedMultDM()
+	local adjust = getPerfectAccelDM()
+	w_wallAcc(mSide, THICKNESS, mAdj * speedMult, mAcc * adjust, mMinSpd, mMaxSpd) 
+end
+
+-- wallSHAcc: Creates a wallHModSpeedData adjusted the perfect acceleration adjustment
+function wallSHAcc(mHMod, mSide, mAdj, mAcc, mMinSpd, mMaxSpd, mPingPong) 
+	local speedMult = u_getSpeedMultDM()
+	local adjust = getPerfectAccelDM()
+	w_wallHModSpeedData(mHMod, mSide, THICKNESS, mAdj * speedMult, mAcc * adjust, mMinSpd, mMaxSpd, mPingPong) 
+end
+
+-----------------------------------------
+-- TRAP PATTERN FUNCTIONS (POLYHEDRUG) --
+-----------------------------------------
+-- These are patterns that have openings, but after a specified amount of delay, a faster wall spawns to speed through the gap.
+-- This tells the player to not immediately orient their cursor to the gap, and they must wait before they can.
+
+-- A trap version of a barrage
+-- mSide: The side the pattern will spawn on
 function pTrapBarrage(mSide)
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+		
+	cBarrage(mSide)
+	t_wait(delay * 3)
+	wallSAdj(mSide, 1.9)
 
-    cBarrage(mSide)
-    t_wait(delay * 3)
-    wallSAdj(mSide, 1.9)
-
-    t_wait(delay * 2.5)
+	t_wait(delay * 2.5)
 end
 
+-- A trap barrage with two gaps, both on opposing sides of each other
+-- mSide: The side the pattern will spawn on
 function pTrapBarrageDouble(mSide)
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local side2 = mSide + getHalfSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local side2 = mSide + getHalfSides();
+	
+	for i = 0, l_getSides() - 1 do
+		local currentSide = mSide + i
+		if((currentSide ~= mSide) and (currentSide ~= side2)) then cWall(currentSide) end
+	end
 
-    for i = 0, l_getSides() - 1 do
-        local currentSide = mSide + i
-        if((currentSide ~= mSide) and (currentSide ~= side2)) then cWall(currentSide) end
-    end
-
-    t_wait(delay * 3)
-    wallSAdj(mSide, 1.9)
-    wallSAdj(side2, 1.9)
-
-    t_wait(delay * 2.5)
+	t_wait(delay * 3)
+	wallSAdj(mSide, 1.9)
+	wallSAdj(side2, 1.9)
+	
+	t_wait(delay * 2.5)
 end
 
+-- pTrapBarrage, but the whole barrage is speeding instead of the "trap".
+-- mSide: The side the pattern will spawn on
 function pTrapBarrageInverse(mSide)
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	
+	cWall(mSide)	
+	t_wait(delay * 3)
 
-    cWall(mSide)
-    t_wait(delay * 3)
+	for i = 0, l_getSides() - 1 do
+		local currentSide = mSide + i
+		if(currentSide ~= mSide) then wallSAdj(currentSide, 1.9) end
+	end
 
-    for i = 0, l_getSides() - 1 do
-        local currentSide = mSide + i
-        if(currentSide ~= mSide) then wallSAdj(currentSide, 1.9) end
-    end
-
-    t_wait(delay * 2.5)
+	t_wait(delay * 2.5)
 end
 
+-- A trap version of an alt barrage
+-- mSide: The side the pattern will spawn on
 function pTrapBarrageAlt(mSide)
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
 
-    for i = 0, l_getSides() - 1 do
-        local currentSide = mSide + i
-        if(currentSide % 2 ~= 0) then cWall(currentSide) end
-    end
+	for i = 0, l_getSides() - 1 do
+		local currentSide = mSide + i
+		if(currentSide % 2 ~= 0) then cWall(currentSide) end
+	end
 
-    t_wait(delay * 3)
+	t_wait(delay * 3)
 
-    for i = 0, l_getSides() - 1 do
-        local currentSide = mSide + i
-        if(currentSide % 2 == 0) then wallSAdj(currentSide, 1.9) end
-    end
+	for i = 0, l_getSides() - 1 do
+		local currentSide = mSide + i
+		if(currentSide % 2 == 0) then wallSAdj(currentSide, 1.9) end
+	end
 
-    t_wait(delay * 2.5)
+	t_wait(delay * 2.5)
 end
 
-function pTrapSpiral(mSide)
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local loopDir = getRandomDir()
+--------------------------------------------
+-- RANDOM CONTROL PATTERNS (Incongruence) --
+--------------------------------------------
 
-    if(l_getSides() < 6) then delay = delay + 4 end
-
-    for i = 0, l_getSides() + getHalfSides() do
-        local currentSide = (mSide + i) * loopDir
-        for j = 0, getHalfSides() do wallSAdj(currentSide + j, 1.2 + (i / 7.9)) end
-        t_wait((delay * 0.75) - (i * 0.45) + 3)
-    end
-
-    t_wait(delay * 2.5)
-end
-
-function pRCBarrage()
-    local currentSides = l_getSides()
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local startSide = u_rndInt(0, 10)
-
-    for i = 0, currentSides - 2 do
-        local currentSide = startSide + i
-        cWall(currentSide)
-    end
-    t_wait(delay * 2.5)
-end
-
+-- Spawns a barrage with two opposing holes instead of one
 function pRCBarrageDouble()
-    local currentSides = l_getSides()
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local startSide = u_rndInt(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = getRandomSide()
 
-    for i = 0, currentSides - 2 do
-        local currentSide = startSide + i
-        local holeSide = startSide + i + (currentSides / 2)
-        if(i ~= holeSide) then cWall(currentSide) end
-    end
-    t_wait(delay * 2.5)
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + i
+		local holeSide = startSide + i + (currentSides / 2)
+		if(i ~= holeSide) then cWall(currentSide) end
+	end
+	t_wait(delay * 2.5)
 end
 
-function pRCBarrageSpin()
-    local currentSides = l_getSides()
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local startSide = u_rndInt(0, 10)
-    local loopDir = getRandomDir()
-
-    for j = 0, 2 do
-        for i = 0, currentSides - 2 do
-            local currentSide = startSide + i
-            cWall(currentSide + (j * loopDir))
-        end
-        t_wait(delay + 1)
-    end
-    t_wait(delay * 2.5)
+-- Summons a series of barrages, but with the side count ascending, adding one new side for each barrage summoned.
+-- This as a result can cause the barrages to either spiral or stay still, depending on the side it spawns on
+-- This pattern can be unpredictable in it's nature.
+function pRCAscendBarrage(mSide, mStartSides, mEndSides)
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6
+	for i = mStartSides, mEndSides do
+		t_eval([[l_setSides(]]..i..[[)]])
+		for r = 0, i - 2 do
+			cWall(r + mSide)
+		end
+		t_wait(delay)
+	end
+	t_wait(delay)
 end
 
-function pACBarrage()
-    local currentSides = l_getSides()
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local startSide = u_rndInt(0, 10)
-
-    for i = 0, currentSides - 2 do
-        local currentSide = startSide + i
-        wallSAcc(currentSide, 9 + u_rndInt(0, 1), -1.1, 1, 12)
-    end
-    t_wait(delay * 2.5)
+-- Summons a series of barrages in randomized positions, with the side count ascending per barrage
+-- mStartSides: The starting number of sides for the pattern
+-- mEndSides: The ending number of sides for the pattern
+function pRCAscendBarrageRandom(mStartSides, mEndSides)
+	local delay = getPerfectDelayDM(THICKNESS) * 8.5
+	for i = mStartSides, mEndSides do
+		t_eval([[l_setSides(]]..i..[[)]])
+		local offset = math.random(1, i)
+		for r = 0, i - 2 do
+			cWall(r + offset)
+		end
+		t_wait(delay)
+	end
+	t_wait(delay)
 end
 
+-- Summons a series of alt barrages, but the side count randomizes per alt barrage to make the pattern much harder to navigate
+-- mStep: How many sides to move per wall spawn.
+-- mTimes: How many alt barrage segments to make
+-- mLowerSides: The lowest side count to select at random
+-- mUpperSides: The highest side count to select at random
+function pRCDynamicAltBarrage(mStep, mTimes, mLowerSides, mUpperSides)
+	local delay = getPerfectDelayDM(THICKNESS) * 5.6
+	local prevSides = 0
+	
+	for r = 0, mTimes do
+		local sides = math.random(mLowerSides, mUpperSides)
+		if (sides ~= prevSides) then
+			t_eval([[l_setSides(]]..sides..[[)]])
+		end
+		prevSides = sides
+		for i = 0, sides, mStep do
+			cWall(i + r)
+		end
+		t_wait(delay)
+	end
+	t_wait(delay)
+end
+
+-------------------------------------------
+-- ACCELERATING PATTERNS (ACCELERADIANT) --
+-------------------------------------------
+
+-- pACBarrageAccelerate: A barrage that will slowly increase in speed over time, accelerating.
+function pACBarrageAccelerate()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = getRandomSide()
+
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + i
+		wallSAcc(currentSide, 2, 0.015, 1, 10)
+	end
+	t_wait(delay * 2.5)
+end
+
+-- pACBarrageDecelerate: A barrage that will quickly approach the player and decelerate.
+function pACBarrageDecelerate()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = getRandomSide()
+
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + i
+		wallSAcc(currentSide, 10, -0.22, 0.6, 10)
+	end
+	t_wait(delay * 3.5)
+end
+
+-- pACBarrageDeception: A barrage that never interacts with the player, going in and out of the view, tricking the player.
+function pACBarrageDeception(mAdjMult, mAccMult)
+	mAdjMult = mAdjMult or 1;
+	mAccMult = mAccMult or 1;
+	
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = getRandomSide()
+
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + i
+		wallSAcc(currentSide, 2.8 * mAdjMult, -0.05 * mAccMult, -2, 5)
+	end
+	t_wait(delay * 4)
+end
+
+-- pACInverseBarrage: Two decelerating barrages, one slower than the other to create an inverse barrage
+function pACInverseBarrage()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = getRandomSide()
+	
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + i
+		wallSAcc(currentSide, 10, -0.21, 0.6, 10)
+	end
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + getHalfSides() + i
+		wallSAcc(currentSide, 10, -0.28, 0.6, 10)
+	end
+	t_wait(delay * 6.5)
+end
+
+-- pACBarrageMulti: A decelerating barrage, followed by a trail of accelerating barrages for visual effect
 function pACBarrageMulti()
-    local currentSides = l_getSides()
-    local delay = getPerfectDelayDM(THICKNESS) * 3.7
-    local startSide = u_rndInt(0, 10)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local startSide = math.random(0, 10)
 
-    for i = 0, currentSides - 2 do
-        local currentSide = startSide + i
-        wallSAcc(currentSide, 10, -1.09, 0.31, 10)
-        wallSAcc(currentSide, 0, 0.05, 0, 4.0)
-        wallSAcc(currentSide, 0, 0.09, 0, 4.0)
-        wallSAcc(currentSide, 0, 0.12, 0, 4.0)
-    end
-    t_wait(delay * 8)
+	for i = 0, currentSides - 2 do
+		local currentSide = startSide + i
+		wallSAcc(currentSide, 10, -0.21, 0.31, 10)
+		wallSAcc(currentSide, 0, 0.01, 0, 2.0)
+		wallSAcc(currentSide, 0, 0.02, 0, 2.0)
+		wallSAcc(currentSide, 0, 0.025, 0, 2.0)
+	end
+	t_wait(delay * 8)
 end
 
-function pACBarrageMultiAltDir()
-    local currentSides = l_getSides()
-    local delay = getPerfectDelayDM(THICKNESS) * 4
-    local mdiff = 1 + math.abs(1 - u_getDifficultyMult())
-    local startSide = u_rndInt(0, 10)
-    local loopDir = getRandomDir()
+-- pACSpiral: A pSpiral that decelerates, followed by an accelerating barrage similar to pACBarrageMulti
+function pACSpiral()
+	local currentSides = l_getSides()
+	local oldThickness = THICKNESS;
+	THICKNESS = getPerfectThickness(THICKNESS);
+	local delay = getPerfectDelayDM(THICKNESS) * 3
+	local startSide = math.random(0, 10)
+	local loopDir = getRandomDir()
 
-    for i = 0, currentSides + getHalfSides() do
-        local currentSide = startSide + i * loopDir
-        wallSAcc(currentSide, 10, -1.095, 0.40, 10)
-        t_wait((delay / 2.21) * (mdiff * 1.29))
-        wallSAcc(currentSide + (getHalfSides() * loopDir), 0, 0.128, 0, 1.4)
-    end
-    t_wait(delay * 8)
+	for i = 0, currentSides + getHalfSides() do
+		local currentSide = startSide + i * loopDir
+		wallSAcc(currentSide, 10, -0.2, 0.40, 10)
+		t_wait((delay / 2.1))
+		wallSAcc(currentSide + (getHalfSides() * loopDir), 0, 0.128, 0, 1.4)
+	end
+	THICKNESS = oldThickness;
+	t_wait(delay * 3)
+end
+
+-- A series of alt barrages that decelerate.
+-- mTimes: The number of alt barrage series to create
+function pACAltBarrage(mTimes)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	
+	for t = 1, mTimes do
+		for i = 1, currentSides, 2 do
+			wallSAcc(i, 10, -0.21, 0.6, 10)
+		end
+		t_wait(delay * 1.6);
+		for i = 0, currentSides - 1, 2 do
+			wallSAcc(i, 10, -0.21, 0.6, 10)
+		end
+		t_wait(delay * 1.6);
+	end
+	
+	t_wait(delay * 3.5)
+end
+
+-- pACAltBarrageMulti: Alt Barrage with similar behavior to pACBarrageMulti
+function pACAltBarrageMulti()
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local offset = math.random(0, 1);
+	
+	for i = 1, currentSides, 2 do
+		wallSAcc(i + offset, 10, -0.2, 0.5, 10)
+		wallSAcc(i + offset, 0, 0.01, 0, 4.0)
+		wallSAcc(i + offset, 0, 0.015, 0, 4.0)
+		wallSAcc(i + offset, 0, 0.02, 0, 4.0)
+	end
+	
+	t_wait(delay * 8)
+end
+
+-- Reveals randomly positioned Alt Barrages for the player to navigate
+-- mTimes: The number of alt barrages to create
+function pACAltBarrageReveal(mTimes)
+	local currentSides = l_getSides()
+	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local chooser = 0;
+	
+	for t = 1, mTimes do
+		chooser = math.random(0, 1);
+		for i = 1, currentSides do
+			if (i % 2 == chooser) then
+				wallSAcc(i, 10, -0.21, 0.6, 10)
+			else
+				wallSAcc(i, 10, -0.21, -2, 10)
+			end
+		end
+		t_wait(delay * 1.6);
+	end
+	
+	t_wait(delay * 3.5)
+end
+
+-- A tunnel pattern that reveals random barrages for the player to navigate
+-- mTimes: The number of tunnel segments to create
+function pACTunnelReveal(mTimes)
+	local currentSides = l_getSides()
+	local oldThickness = THICKNESS
+	local myThickness = getPerfectThickness(THICKNESS);
+	local delay = getPerfectDelayDM(myThickness) * 5
+	local startSide = getRandomSide()
+	local loopDir = getRandomDir()
+	
+	for t = 0, mTimes do
+		THICKNESS = myThickness + 5 * u_getSpeedMultDM() * delay
+		if t < mTimes then
+			wallSAcc(startSide, 10, -0.22, 0.6, 10)
+		end
+		
+		THICKNESS = oldThickness
+		
+		local revealSide = math.random(0, currentSides - 1)
+		if (revealSide == startSide) then
+			revealSide = (revealSide + getRandomDir()) % currentSides;
+		end
+		for i = 0, currentSides - 1 do
+			if (i == revealSide) then
+				wallSAcc(i, 10, -0.22, -2, 10)
+			else
+				wallSAcc(i, 10, -0.22, 0.6, 10)
+			end
+		end
+		t_wait(delay)
+		loopDir = loopDir * -1
+	end
+	
+	THICKNESS = oldThickness;
+	t_wait(delay)
 end

--- a/_RELEASE/Packs/base/Scripts/nextpatterns.lua
+++ b/_RELEASE/Packs/base/Scripts/nextpatterns.lua
@@ -43,7 +43,7 @@ end
 -- A trap version of a barrage
 -- mSide: The side the pattern will spawn on
 function pTrapBarrage(mSide)
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 		
 	cBarrage(mSide)
 	t_wait(delay * 3)
@@ -55,7 +55,7 @@ end
 -- A trap barrage with two gaps, both on opposing sides of each other
 -- mSide: The side the pattern will spawn on
 function pTrapBarrageDouble(mSide)
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local side2 = mSide + getHalfSides();
 	
 	for i = 0, l_getSides() - 1 do
@@ -73,7 +73,7 @@ end
 -- pTrapBarrage, but the whole barrage is speeding instead of the "trap".
 -- mSide: The side the pattern will spawn on
 function pTrapBarrageInverse(mSide)
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	
 	cWall(mSide)	
 	t_wait(delay * 3)
@@ -89,7 +89,7 @@ end
 -- A trap version of an alt barrage
 -- mSide: The side the pattern will spawn on
 function pTrapBarrageAlt(mSide)
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 
 	for i = 0, l_getSides() - 1 do
 		local currentSide = mSide + i
@@ -113,7 +113,7 @@ end
 -- Spawns a barrage with two opposing holes instead of one
 function pRCBarrageDouble()
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local startSide = getRandomSide()
 
 	for i = 0, currentSides - 2 do
@@ -128,7 +128,7 @@ end
 -- This as a result can cause the barrages to either spiral or stay still, depending on the side it spawns on
 -- This pattern can be unpredictable in it's nature.
 function pRCAscendBarrage(mSide, mStartSides, mEndSides)
-	local delay = getPerfectDelayDM(THICKNESS) * 5.6
+	local delay = getPerfectDelay(THICKNESS) * 5.6
 	for i = mStartSides, mEndSides do
 		t_eval([[l_setSides(]]..i..[[)]])
 		for r = 0, i - 2 do
@@ -143,7 +143,7 @@ end
 -- mStartSides: The starting number of sides for the pattern
 -- mEndSides: The ending number of sides for the pattern
 function pRCAscendBarrageRandom(mStartSides, mEndSides)
-	local delay = getPerfectDelayDM(THICKNESS) * 8.5
+	local delay = getPerfectDelay(THICKNESS) * 8.5
 	for i = mStartSides, mEndSides do
 		t_eval([[l_setSides(]]..i..[[)]])
 		local offset = math.random(1, i)
@@ -161,7 +161,7 @@ end
 -- mLowerSides: The lowest side count to select at random
 -- mUpperSides: The highest side count to select at random
 function pRCDynamicAltBarrage(mStep, mTimes, mLowerSides, mUpperSides)
-	local delay = getPerfectDelayDM(THICKNESS) * 5.6
+	local delay = getPerfectDelay(THICKNESS) * 5.6
 	local prevSides = 0
 	
 	for r = 0, mTimes do
@@ -185,7 +185,7 @@ end
 -- pACBarrageAccelerate: A barrage that will slowly increase in speed over time, accelerating.
 function pACBarrageAccelerate()
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local startSide = getRandomSide()
 
 	for i = 0, currentSides - 2 do
@@ -198,7 +198,7 @@ end
 -- pACBarrageDecelerate: A barrage that will quickly approach the player and decelerate.
 function pACBarrageDecelerate()
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local startSide = getRandomSide()
 
 	for i = 0, currentSides - 2 do
@@ -214,7 +214,7 @@ function pACBarrageDeception(mAdjMult, mAccMult)
 	mAccMult = mAccMult or 1;
 	
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local startSide = getRandomSide()
 
 	for i = 0, currentSides - 2 do
@@ -227,7 +227,7 @@ end
 -- pACInverseBarrage: Two decelerating barrages, one slower than the other to create an inverse barrage
 function pACInverseBarrage()
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local startSide = getRandomSide()
 	
 	for i = 0, currentSides - 2 do
@@ -244,7 +244,7 @@ end
 -- pACBarrageMulti: A decelerating barrage, followed by a trail of accelerating barrages for visual effect
 function pACBarrageMulti()
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local startSide = math.random(0, 10)
 
 	for i = 0, currentSides - 2 do
@@ -262,7 +262,7 @@ function pACSpiral()
 	local currentSides = l_getSides()
 	local oldThickness = THICKNESS;
 	THICKNESS = getPerfectThickness(THICKNESS);
-	local delay = getPerfectDelayDM(THICKNESS) * 3
+	local delay = getPerfectDelay(THICKNESS) * 3
 	local startSide = math.random(0, 10)
 	local loopDir = getRandomDir()
 
@@ -280,7 +280,7 @@ end
 -- mTimes: The number of alt barrage series to create
 function pACAltBarrage(mTimes)
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	
 	for t = 1, mTimes do
 		for i = 1, currentSides, 2 do
@@ -299,7 +299,7 @@ end
 -- pACAltBarrageMulti: Alt Barrage with similar behavior to pACBarrageMulti
 function pACAltBarrageMulti()
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local offset = math.random(0, 1);
 	
 	for i = 1, currentSides, 2 do
@@ -316,7 +316,7 @@ end
 -- mTimes: The number of alt barrages to create
 function pACAltBarrageReveal(mTimes)
 	local currentSides = l_getSides()
-	local delay = getPerfectDelayDM(THICKNESS) * 3.7
+	local delay = getPerfectDelay(THICKNESS) * 3.7
 	local chooser = 0;
 	
 	for t = 1, mTimes do
@@ -340,7 +340,7 @@ function pACTunnelReveal(mTimes)
 	local currentSides = l_getSides()
 	local oldThickness = THICKNESS
 	local myThickness = getPerfectThickness(THICKNESS);
-	local delay = getPerfectDelayDM(myThickness) * 5
+	local delay = getPerfectDelay(myThickness) * 5
 	local startSide = getRandomSide()
 	local loopDir = getRandomDir()
 	

--- a/_RELEASE/Packs/cube/Scripts/Levels/apeirogon.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/apeirogon.lua
@@ -20,7 +20,7 @@ function addPattern(mKey)
         mKey = 7
     end
 
-        if mKey == 0 then pAltBarrage(u_rndInt(2, 3), 2)
+        if mKey == 0 then pAltBarrage(u_rndInt(3, 4), 2)
     elseif mKey == 1 then pBarrageSpiral(3, 0.6, 1)
     elseif mKey == 2 then pInverseBarrage(0)
     elseif mKey == 3 then pTunnel(u_rndInt(1, 3))

--- a/_RELEASE/Packs/cube/Scripts/Levels/commando.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/commando.lua
@@ -18,7 +18,7 @@ end
 -- onStep should contain your pattern spawning logic
 function onStep()
     rWallEx(getRandomSide(), extra)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6)
+    t_wait(getPerfectDelay(THICKNESS) * 6)
 end
 
 -- onInit is an hardcoded function that is called when the level is first loaded

--- a/_RELEASE/Packs/cube/Scripts/Levels/euclideanpc.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/euclideanpc.lua
@@ -5,7 +5,7 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey ==  0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey ==  0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey ==  1 then pMirrorSpiral(u_rndInt(3, 6), 0)
     elseif mKey ==  2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
     elseif mKey ==  3 then pBarrageSpiral(u_rndInt(0, 2), 1.2, 2)

--- a/_RELEASE/Packs/cube/Scripts/Levels/flatteringshape.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/flatteringshape.lua
@@ -29,7 +29,7 @@ function addPattern(mKey)
         mKey = 5
     end
 
-        if mKey == 0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey == 0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey == 1 then
         adjustThicknessForLowDM(2)
         pMirrorSpiral(u_rndInt(3, 6), 0)

--- a/_RELEASE/Packs/cube/Scripts/Levels/goldenratio.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/goldenratio.lua
@@ -19,8 +19,8 @@ function addPattern(mKey)
         local ot = THICKNESS
         local rd = getRandomDir()
         THICKNESS = THICKNESS * 0.85
-        pSpiralDir(rd, l_getSides(), 1)
-        pSpiralDir(rd * -1, l_getSides(), 1)
+        pSpiral(l_getSides(), 1, rd)
+        pSpiral(l_getSides(), 1, rd * -1)
         THICKNESS = ot
     end
 

--- a/_RELEASE/Packs/cube/Scripts/Levels/labyrinth.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/labyrinth.lua
@@ -18,7 +18,7 @@ end
 -- onStep should contain your pattern spawning logic
 function onStep()
     cBarrage(getRandomSide())
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.55)
+    t_wait(getPerfectDelay(THICKNESS) * 6.55)
 end
 
 -- onInit is an hardcoded function that is called when the level is first loaded

--- a/_RELEASE/Packs/cube/Scripts/Levels/pointless.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/pointless.lua
@@ -24,7 +24,7 @@ function addPattern(mKey)
         mKey = 5
     end
 
-        if mKey == 0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey == 0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey == 1 then
         adjustThicknessForLowDM(3)
         pMirrorSpiral(u_rndInt(2, 5), getHalfSides() - 3)

--- a/_RELEASE/Packs/cube/Scripts/Levels/seconddimension.lua
+++ b/_RELEASE/Packs/cube/Scripts/Levels/seconddimension.lua
@@ -15,7 +15,7 @@ function addPattern(mKey)
         mKey = 5
     end
 
-        if mKey ==  0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey ==  0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey ==  1 then pMirrorSpiral(u_rndInt(3, 6), 0)
     elseif mKey ==  2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
     elseif mKey ==  3 then pBarrageSpiral(u_rndInt(0, 2), 1.2, 2)

--- a/_RELEASE/Packs/experimental/Scripts/Levels/3D_required.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/3D_required.lua
@@ -5,7 +5,7 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey ==  0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey ==  0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey ==  1 then pMirrorSpiral(u_rndInt(3, 6), 0)
     elseif mKey ==  2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
     elseif mKey ==  3 then pBarrageSpiral(u_rndInt(0, 2), 1.2, 2)

--- a/_RELEASE/Packs/experimental/Scripts/Levels/autotest0.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/autotest0.lua
@@ -42,7 +42,7 @@ end
 -- onStep should contain your pattern spawning logic
 function onStep()
     hmcSimpleBarrageSNeigh(getRandomSide(), 3, 4)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6)
+    t_wait(getPerfectDelay(THICKNESS) * 6)
 end
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented

--- a/_RELEASE/Packs/experimental/Scripts/Levels/curvetest.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/curvetest.lua
@@ -34,7 +34,7 @@ end
 
 function hmcDefSpinner()
     hmcSimpleSpinner(u_rndInt(10, 45) / 10.0 * getRandomDir())
-    t_wait(getPerfectDelayDM(THICKNESS) * 1.2)
+    t_wait(getPerfectDelay(THICKNESS) * 1.2)
 end
 
 -- onInit is an hardcoded function that is called when the level is first loaded

--- a/_RELEASE/Packs/experimental/Scripts/Levels/curvetest2.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/curvetest2.lua
@@ -43,7 +43,7 @@ end
 -- onStep should contain your pattern spawning logic
 function onStep()
     hmcSimpleBarrageSNeigh(getRandomSide(), 3, 0)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6)
+    t_wait(getPerfectDelay(THICKNESS) * 6)
 end
 
 

--- a/_RELEASE/Packs/experimental/Scripts/Levels/cw.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/cw.lua
@@ -7,7 +7,7 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatter
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then pAltBarrage(u_rndInt(1, 3), 2)
+        if mKey == 0 then pAltBarrage(u_rndInt(2, 4), 2)
     elseif mKey == 1 then pMirrorSpiral(u_rndInt(2, 4), 0)
     elseif mKey == 2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
     elseif mKey == 3 then pBarrageSpiral(u_rndInt(0, 2), 1.2, 2)

--- a/_RELEASE/Packs/experimental/Scripts/Levels/negative_pulse.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/negative_pulse.lua
@@ -5,7 +5,7 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey ==  0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey ==  0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey ==  1 then pMirrorSpiral(u_rndInt(3, 6), 0)
     elseif mKey ==  2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
     elseif mKey ==  3 then pBarrageSpiral(u_rndInt(0, 2), 1.2, 2)

--- a/_RELEASE/Packs/experimental/Scripts/Levels/stress1.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/stress1.lua
@@ -44,7 +44,7 @@ end
 -- onStep should contain your pattern spawning logic
 function onStep()
     hmcSimpleBarrageSNeigh(getRandomSide(), 3, 0)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6)
+    t_wait(getPerfectDelay(THICKNESS) * 6)
 end
 
 

--- a/_RELEASE/Packs/hypercube/Levels/acceleradiant.json
+++ b/_RELEASE/Packs/hypercube/Levels/acceleradiant.json
@@ -1,12 +1,12 @@
 {
-    "id": "acceleradiant",
-    "name": "acceleradiant",
-    "description": "dunno lol",
-    "author": "vittorio romeo",
-    "menuPriority": 20,
-    "selectable": true,
-    "styleId": "acceleradiant",
-    "musicId": "mrGawne",
-    "luaFile": "Scripts/Levels/acceleradiant.lua",
-    "difficultyMults": [0.85, 1.25, 1.4, 1.8]
+	"id": "acceleradiant",
+	"name": "acceleradiant",
+	"description": "dunno lol",
+	"author": "vittorio romeo",	
+	"menuPriority": 10,
+	"selectable": true,
+	"styleId": "acceleradiant",
+	"musicId": "mrGawne",
+	"luaFile": "Scripts/Levels/acceleradiant.lua",
+	"difficultyMults": [0.85, 1.8, 2.4]
 }

--- a/_RELEASE/Packs/hypercube/Levels/centrifugal.json
+++ b/_RELEASE/Packs/hypercube/Levels/centrifugal.json
@@ -1,12 +1,12 @@
 {
-    "id": "centrifugal",
-    "name": "centrifugal force",
-    "description": "insert cool description here",
-    "author": "vittorio romeo",
-    "menuPriority": 71,
-    "selectable": true,
-    "styleId": "centrifugal",
-    "musicId": "tengil",
-    "luaFile": "Scripts/Levels/centrifugal.lua",
-    "difficultyMults": [1.2, 1.4, 1.6, 0.6, 0.3]
+	"id": "centrifugal",
+	"name": "centrifugal force",
+	"description": "insert cool description here",
+	"author": "vittorio romeo",	
+	"menuPriority": 80,
+	"selectable": true,
+	"styleId": "centrifugal",
+	"musicId": "tengil",
+	"luaFile": "Scripts/Levels/centrifugal.lua",
+	"difficultyMults": [1.2, 1.4, 1.6, 0.6, 0.3]
 }

--- a/_RELEASE/Packs/hypercube/Levels/disc-o.json
+++ b/_RELEASE/Packs/hypercube/Levels/disc-o.json
@@ -1,12 +1,12 @@
 {
-    "id": "disc-o",
-    "name": "disc-o",
-    "description": "dance!",
-    "author": "vittorio romeo",
-    "menuPriority": 10,
-    "selectable": true,
-    "styleId": "disc-o",
-    "musicId": "dischipo",
-    "luaFile": "Scripts/Levels/disc-o.lua",
-    "difficultyMults": [1.6, 2.2, 2.8, 0.6, 0.4]
+	"id": "disc-o",
+	"name": "disc-o",
+	"description": "dance!",
+	"author": "vittorio romeo",	
+	"menuPriority": 40,
+	"selectable": true,
+	"styleId": "disc-o",
+	"musicId": "dischipo",
+	"luaFile": "Scripts/Levels/disc-o.lua",
+	"difficultyMults": [2, 2.8, 0.5]
 }

--- a/_RELEASE/Packs/hypercube/Levels/evotutorial.json
+++ b/_RELEASE/Packs/hypercube/Levels/evotutorial.json
@@ -1,12 +1,12 @@
 {
-    "id": "evotutorial",
-    "name": "evotutorial",
-    "description": "learn new game mechanics here!",
-    "author": "vittorio romeo",
-    "menuPriority": 0,
-    "selectable": true,
-    "styleId": "evotutorial",
-    "musicId": "gmoomh",
-    "luaFile": "Scripts/Levels/evotutorial.lua",
+	"id": "evotutorial",
+	"name": "evotutorial",
+	"description": "learn new game mechanics here!",
+	"author": "vittorio romeo",	
+	"menuPriority": 0,
+	"selectable": true,
+	"styleId": "evotutorial",
+	"musicId": "gmoomh",
+	"luaFile": "Scripts/Levels/evotutorial.lua",
     "unscored": true
 }

--- a/_RELEASE/Packs/hypercube/Levels/g-force.json
+++ b/_RELEASE/Packs/hypercube/Levels/g-force.json
@@ -1,12 +1,12 @@
 {
-    "id": "g-force",
-    "name": "g-force",
-    "description": "beware the acceleration",
-    "author": "vittorio romeo",
-    "menuPriority": 30,
-    "selectable": true,
-    "styleId": "g-force",
-    "musicId": "cpumood",
-    "luaFile": "Scripts/Levels/g-force.lua",
-    "difficultyMults": [1.6, 2.2, 2.8, 0.4, 0.6]
+	"id": "g-force",
+	"name": "g-force",
+	"description": "beware the acceleration",
+	"author": "vittorio romeo",	
+	"menuPriority": 60,
+	"selectable": true,
+	"styleId": "g-force",
+	"musicId": "cpumood",
+	"luaFile": "Scripts/Levels/g-force.lua",
+	"difficultyMults": [1.6, 2.2, 2.8, 0.4, 0.6]
 }

--- a/_RELEASE/Packs/hypercube/Levels/incongruence.json
+++ b/_RELEASE/Packs/hypercube/Levels/incongruence.json
@@ -1,12 +1,12 @@
 {
-    "id": "incongruence",
-    "name": "incongruence",
-    "description": "choose your side...",
-    "author": "vittorio romeo",
-    "menuPriority": 40,
-    "selectable": true,
-    "styleId": "incongruence",
-    "musicId": "flirtFlirt",
-    "luaFile": "Scripts/Levels/incongruence.lua",
-    "difficultyMults": [0.75, 1.25, 1.5, 1.8]
+	"id": "incongruence",
+	"name": "incongruence",
+	"description": "choose your side...",
+	"author": "vittorio romeo",	
+	"menuPriority": 20,
+	"selectable": true,
+	"styleId": "incongruence",
+	"musicId": "flirtFlirt",
+	"luaFile": "Scripts/Levels/incongruence.lua",
+	"difficultyMults": [0.5, 1.25, 1.8]
 }

--- a/_RELEASE/Packs/hypercube/Levels/massacre.json
+++ b/_RELEASE/Packs/hypercube/Levels/massacre.json
@@ -1,12 +1,12 @@
 {
-    "id": "massacre",
-    "name": "massacre",
-    "description": "you >will< die",
-    "author": "vittorio romeo",
-    "menuPriority": 80,
-    "selectable": true,
-    "styleId": "massacre",
-    "musicId": "massacrev2",
-    "luaFile": "Scripts/Levels/massacre.lua",
-    "difficultyMults": [1.3, 1.6, 0.3, 0.6]
+	"id": "massacre",
+	"name": "massacre",
+	"description": "you >will< die",
+	"author": "vittorio romeo",	
+	"menuPriority": 70,
+	"selectable": true,
+	"styleId": "massacre",
+	"musicId": "massacrev2",
+	"luaFile": "Scripts/Levels/massacre.lua",
+	"difficultyMults": [1.3, 1.6, 0.5]
 }

--- a/_RELEASE/Packs/hypercube/Levels/polyhedrug.json
+++ b/_RELEASE/Packs/hypercube/Levels/polyhedrug.json
@@ -1,12 +1,12 @@
 {
-    "id": "polyhedrug",
-    "name": "polyhedrug",
-    "description": "ready to experience something different?",
-    "author": "vittorio romeo",
-    "menuPriority": 60,
-    "selectable": true,
-    "styleId": "polyhedrug",
-    "musicId": "johnnyDerp",
-    "luaFile": "Scripts/Levels/polyhedrug.lua",
-    "difficultyMults": [0.75, 1.25, 1.5, 1.8]
+	"id": "polyhedrug",
+	"name": "polyhedrug",
+	"description": "ready to experience something different?",
+	"author": "vittorio romeo",	
+	"menuPriority": 30,
+	"selectable": true,
+	"styleId": "polyhedrug",
+	"musicId": "johnnyDerp",
+	"luaFile": "Scripts/Levels/polyhedrug.lua",
+	"difficultyMults": [0.75, 1.8]
 }

--- a/_RELEASE/Packs/hypercube/Levels/reppaws.json
+++ b/_RELEASE/Packs/hypercube/Levels/reppaws.json
@@ -1,12 +1,12 @@
 {
-    "id": "reppaws",
-    "name": "reppaws",
-    "description": "180 degrees of awesomeness",
-    "author": "vittorio romeo",
-    "menuPriority": 70,
-    "selectable": true,
-    "styleId": "reppaws",
-    "musicId": "minimal",
-    "luaFile": "Scripts/Levels/reppaws.lua",
-    "difficultyMults": [1.2, 1.4, 1.6, 0.6, 0.3]
+	"id": "reppaws",
+	"name": "reppaws",
+	"description": "180 degrees of awesomeness",
+	"author": "vittorio romeo",	
+	"menuPriority": 90,
+	"selectable": true,
+	"styleId": "reppaws",
+	"musicId": "minimal",
+	"luaFile": "Scripts/Levels/reppaws.lua",
+	"difficultyMults": [1.5, 1.8, 0.5]
 }

--- a/_RELEASE/Packs/hypercube/Levels/slither.json
+++ b/_RELEASE/Packs/hypercube/Levels/slither.json
@@ -1,12 +1,12 @@
 {
-    "id": "slither",
-    "name": "slither",
-    "description": "sssssss",
-    "author": "vittorio romeo",
-    "menuPriority": 50,
-    "selectable": true,
-    "styleId": "slither",
-    "musicId": "pep",
-    "luaFile": "Scripts/Levels/slither.lua",
-    "difficultyMults": [0.5, 1.5, 2]
+	"id": "slither",
+	"name": "slither",
+	"description": "sssssss",
+	"author": "vittorio romeo",
+	"menuPriority": 50,
+	"selectable": true,
+	"styleId": "slither",
+	"musicId": "pep",
+	"luaFile": "Scripts/Levels/slither.lua",
+	"difficultyMults": [0.5, 1.5, 2]
 }

--- a/_RELEASE/Packs/hypercube/Music/cpumood.json
+++ b/_RELEASE/Packs/hypercube/Music/cpumood.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "cpumood",
+	// Music data id
+	"id": "cpumood",
 
-    // Music file
-    "file_name": "cpumood.ogg",
+	// Music file
+	"file_name": "cpumood.ogg",
 
-    // Music information
-    "name": "CPU Mood",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
+	// Music information
+	"name": "CPU Mood",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
     "segments":
     [
         { "time": 9.341 },

--- a/_RELEASE/Packs/hypercube/Music/dischipo.json
+++ b/_RELEASE/Packs/hypercube/Music/dischipo.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "dischipo",
+	// Music data id
+	"id": "dischipo",
 
-    // Music file
-    "file_name": "gmoomh.ogg",
+	// Music file
+	"file_name": "gmoomh.ogg",
 
-    // Music information
-    "name": "Dischipo",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
+	// Music information
+	"name": "Dischipo",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
     "segments":
     [
         { "time": 15.172 },

--- a/_RELEASE/Packs/hypercube/Music/flirtFlirt.json
+++ b/_RELEASE/Packs/hypercube/Music/flirtFlirt.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "flirtFlirt",
+	// Music data id
+	"id": "flirtFlirt",
 
-    // Music file
-    "file_name": "flirtFlirt.ogg",
+	// Music file
+	"file_name": "flirtFlirt.ogg",
 
-    // Music information
-    "name": "Flirt Flirt Oh It Hurts",
-    "album": "Caps On, Hats Off",
-    "author": "BOSSFIGHT",
-
-    // Segments
+	// Music information
+	"name": "Flirt Flirt Oh It Hurts",
+	"album": "Caps On, Hats Off",
+	"author": "BOSSFIGHT",
+	
+	// Segments
     "segments":
     [
         { "time": 17.200 },

--- a/_RELEASE/Packs/hypercube/Music/gmoomh.json
+++ b/_RELEASE/Packs/hypercube/Music/gmoomh.json
@@ -1,20 +1,20 @@
 {
-    // Music data id
-    "id": "gmoomh",
+	// Music data id
+	"id": "gmoomh",
 
-    // Music file
-    "file_name": "gmoomh.ogg",
+	// Music file
+	"file_name": "gmoomh.ogg",
 
-    // Music information
-    "name": "Getting melodies out of my head",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
-    "segments":
-    [
-        { "time": 2 },
-        { "time": 65 },
-        { "time": 123 }
-    ]
+	// Music information
+	"name": "Getting melodies out of my head",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
+	"segments":
+	[
+		{ "time": 2 },
+		{ "time": 65 },
+		{ "time": 123 }
+	]
 }

--- a/_RELEASE/Packs/hypercube/Music/johnnyDerp.json
+++ b/_RELEASE/Packs/hypercube/Music/johnnyDerp.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "johnnyDerp",
+	// Music data id
+	"id": "johnnyDerp",
 
-    // Music file
-    "file_name": "johnnyDerp.ogg",
+	// Music file
+	"file_name": "johnnyDerp.ogg",
 
-    // Music information
-    "name": "Pablo Minibar",
-    "album": "Call Me Katla, Baby",
-    "author": "Dunderpatrullen",
+	// Music information
+	"name": "Pablo Minibar",
+	"album": "Call Me Katla, Baby",
+	"author": "Dunderpatrullen",
 
-    // Segments
+	// Segments
     "segments":
     [
         { "time": 6.792 },

--- a/_RELEASE/Packs/hypercube/Music/massacrev2.json
+++ b/_RELEASE/Packs/hypercube/Music/massacrev2.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "massacrev2",
+	// Music data id
+	"id": "massacrev2",
 
-    // Music file
-    "file_name": "massacrev2.ogg",
+	// Music file
+	"file_name": "massacrev2.ogg",
 
-    // Music information
-    "name": "Massacre (version 2)",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
+	// Music information
+	"name": "Massacre (version 2)",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
     "segments":
     [
         { "time": 15.280 },

--- a/_RELEASE/Packs/hypercube/Music/minimal.json
+++ b/_RELEASE/Packs/hypercube/Music/minimal.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "minimal",
+	// Music data id
+	"id": "minimal",
 
-    // Music file
-    "file_name": "minimal.ogg",
+	// Music file
+	"file_name": "minimal.ogg",
 
-    // Music information
-    "name": "Minimal",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
+	// Music information
+	"name": "Minimal",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
     "segments":
     [
         { "time": 12.895 },

--- a/_RELEASE/Packs/hypercube/Music/mrGawne.json
+++ b/_RELEASE/Packs/hypercube/Music/mrGawne.json
@@ -1,20 +1,20 @@
 {
-    // Music data id
-    "id": "mrGawne",
+	// Music data id
+	"id": "mrGawne",
 
-    // Music file
-    "file_name": "mrGawne.ogg",
+	// Music file
+	"file_name": "mrGawne.ogg",
 
-    // Music information
-    "name": "Be Gone Mr. Gawne",
-    "album": "Caps On, Hats Off",
-    "author": "BOSSFIGHT",
-
-    // Segments
-    "segments":
-    [
-        { "time": 18 },
-        { "time": 42 },
-        { "time": 90 }
-    ]
+	// Music information
+	"name": "Be Gone Mr. Gawne",
+	"album": "Caps On, Hats Off",
+	"author": "BOSSFIGHT",
+	
+	// Segments
+	"segments":
+	[
+		{ "time": 18 },
+		{ "time": 42 },
+		{ "time": 90 }
+	]
 }

--- a/_RELEASE/Packs/hypercube/Music/pep.json
+++ b/_RELEASE/Packs/hypercube/Music/pep.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "pep",
+	// Music data id
+	"id": "pep",
 
-    // Music file
-    "file_name": "pep.ogg",
+	// Music file
+	"file_name": "pep.ogg",
 
-    // Music information
-    "name": "Platforms and Pitfalls",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
+	// Music information
+	"name": "Platforms and Pitfalls",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
     "segments":
     [
         { "time": 13.300 },

--- a/_RELEASE/Packs/hypercube/Music/tengil.json
+++ b/_RELEASE/Packs/hypercube/Music/tengil.json
@@ -1,16 +1,16 @@
 {
-    // Music data id
-    "id": "tengil",
+	// Music data id
+	"id": "tengil",
 
-    // Music file
-    "file_name": "tengil.ogg",
+	// Music file
+	"file_name": "tengil.ogg",
 
-    // Music information
-    "name": "Tengil",
-    "album": "",
-    "author": "Fantomenk",
-
-    // Segments
+	// Music information
+	"name": "Tengil",
+	"album": "",
+	"author": "Fantomenk",
+	
+	// Segments
     "segments":
     [
         { "time": 56.791 },

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/acceleradiant.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/acceleradiant.lua
@@ -6,46 +6,51 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "nextpatterns.lu
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then pACBarrage()
-    elseif mKey == 1 then pACBarrageMulti()
-    elseif mKey == 2 then pACBarrageMultiAltDir()
-    end
+		if mKey == 0 then pACBarrageDecelerate()
+	elseif mKey == 1 then pACBarrageMulti()
+	elseif mKey == 2 then pACSpiral()
+	elseif mKey == 3 and u_getDifficultyMult() >= 1 then pACBarrageDeception()
+	elseif mKey == 4 then pACAltBarrage(math.random(2, 3))
+	elseif mKey == 5 then pACAltBarrageMulti()
+	elseif mKey == 6 then pACAltBarrageReveal(math.random(3, 4))
+	elseif mKey == 7 then pACInverseBarrage();
+	elseif mKey == 8 then pACTunnelReveal(math.random(2, 4));
+	end
 end
 
 -- shuffle the keys, and then call them to add all the patterns
 -- shuffling is better than randomizing - it guarantees all the patterns will be called
-keys = { 0, 0, 1, 1, 2, 2, 0, 0, 0, 0, 0 }
+keys = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 7, 8}
 shuffle(keys)
 index = 0
 achievementUnlocked = false
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(2.25)
-    l_setSpeedInc(0.045)
-    l_setSpeedMax(2.35);
-    l_setRotationSpeed(0.27)
-    l_setRotationSpeedMax(0.45)
-    l_setRotationSpeedInc(0.045)
-    l_setDelayMult(1.1)
-    l_setDelayInc(-0.01)
-    l_setDelayMin(1.07)
-    l_setFastSpin(71.0)
-    l_setSides(6)
-    l_setSidesMin(5)
-    l_setSidesMax(7)
-    l_setIncTime(15)
+	l_setSpeedMult(2.2)
+	l_setSpeedInc(0.1)
+	l_setSpeedMax(4.5);
+	l_setRotationSpeed(0.27)
+	l_setRotationSpeedMax(0.45)
+	l_setRotationSpeedInc(0.045)
+	l_setDelayMult(1.1)
+	l_setFastSpin(71.0)
+	l_setSides(6)
+	l_setSidesMin(5)
+	l_setSidesMax(7)
+	l_setIncTime(15)
 
-    l_setPulseMin(64)
-    l_setPulseMax(84)
-    l_setPulseSpeed(1.05)
-    l_setPulseSpeedR(1.34)
-    l_setPulseDelayMax(7)
+	l_setPulseMin(64)
+	l_setPulseMax(84)
+	l_setPulseSpeed(1.05)
+	l_setPulseSpeedR(1.34)
+	l_setPulseDelayMax(7)
+	
+	l_setBeatPulseMax(15)
+	l_setBeatPulseDelayMax(21.8)
 
-    l_setBeatPulseMax(15)
-    l_setBeatPulseDelayMax(21.8)
-
-    enableSwapIfDMGreaterThan(1.4)
+	enableSwapIfDMGreaterThan(1.4)
+	l_setSwapCooldownMult(1 / u_getDifficultyMult());
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
@@ -55,13 +60,13 @@ end
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    addPattern(keys[index])
-    index = index + 1
+	addPattern(keys[index])
+	index = index + 1
 
-    if index - 1 == #keys then
-        index = 1
-        shuffle(keys)
-    end
+	if index - 1 == #keys then
+		index = 1
+		shuffle(keys)
+	end
 end
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
@@ -76,25 +81,25 @@ end
 dirChangeTime = 400
 hueIMin = 0.0
 hueIMax = 22.0
-hueIStep = 0.0065
+hueIStep = 6.5
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    dirChangeTime = dirChangeTime - mFrameTime;
-    if dirChangeTime < 0 then
-        -- do not change direction while fast spinning
-        if u_isFastSpinning() == false then
-            l_setRotationSpeed(l_getRotationSpeed() * -1.0)
-            dirChangeTime = 400
-        end
-    end
+	dirChangeTime = dirChangeTime - mFrameTime;
+	if dirChangeTime < 0 then
+		-- do not change direction while fast spinning
+		if u_isFastSpinning() == false then
+			l_setRotationSpeed(l_getRotationSpeed() * -1.0)
+			dirChangeTime = 400
+		end
+	end
 
-    if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a13_acceleradiant")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a13_acceleradiant")
+		achievementUnlocked = true
+	end
 
-    s_setHueInc(s_getHueInc() + hueIStep)
-    if(s_getHueInc() > hueIMax) then hueIStep = hueIStep * -1 end
-    if(s_getHueInc() < hueIMin) then hueIStep = hueIStep * -1 end
+	s_setHueInc(s_getHueInc() + hueIStep * mFrameTime/FPS)
+	if(s_getHueInc() > hueIMax) then hueIStep = hueIStep * -1 end
+	if(s_getHueInc() < hueIMin) then hueIStep = hueIStep * -1 end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/centrifugal.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/centrifugal.lua
@@ -5,57 +5,65 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "nextpatterns.lua")
 u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatterns.lua")
 
-curveSpeed = 1
+curveSpeed = 15
 achievementUnlocked = false
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(2.91)
-    l_setSpeedInc(0.0)
-    l_setRotationSpeed(0.0)
-    l_setRotationSpeedMax(0.0)
-    l_setRotationSpeedInc(0.0)
-    l_setDelayMult(1.35)
-    l_setDelayInc(0.0)
-    l_setFastSpin(0.0)
-    l_setSides(30)
-    l_setSidesMin(30)
-    l_setSidesMax(30)
-    l_setIncTime(10)
+	l_setSpeedMult(2.8)
+	l_setSpeedInc(0.0)
+	l_setRotationSpeed(0.0)
+	l_setRotationSpeedMax(0.0)
+	l_setRotationSpeedInc(0.0)
+	l_setDelayMult(1.35)
+	l_setDelayInc(0.0)
+	l_setFastSpin(0.0)
+	l_setSides(30)
+	l_setSidesMin(30)
+	l_setSidesMax(30)
+	l_setIncTime(10)
 
-    l_setWallSkewLeft(0)
+	l_setWallSkewLeft(0)
 
-    l_setPulseMin(60)
-    l_setPulseMax(60)
-    l_setPulseSpeed(0)
-    l_setPulseSpeedR(0)
-    l_setPulseDelayMax(6.8)
+	l_setPulseMin(60)
+	l_setPulseMax(60)
+	l_setPulseSpeed(0)
+	l_setPulseSpeedR(0)
+	l_setPulseDelayMax(6.8)
 
-    l_setBeatPulseMax(19)
-    l_setBeatPulseDelayMax(28.346)
+	l_setBeatPulseMax(20)
+	l_setBeatPulseDelayMax(27.2)
 
-    l_setSwapEnabled(true)
-    l_addTracked("curveSpeed", "curve speed")
+	l_setSwapEnabled(true)
+	l_setSwapCooldownMult(0.8/u_getDifficultyMult())
+	l_addTracked("curveSpeed", "curve speed")
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
+	if (u_getDifficultyMult() > 1) then
+		e_messageAdd("Difficulty > 1\nWalls travel constantly!", 120)
+	end
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    hmcSimpleBarrageSNeigh(getRandomSide(), getRandomDir() * curveSpeed, 4)
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.22)
+	if (u_getDifficultyMult() > 1) then
+		hmcSimpleBarrageSNeigh(getRandomSide(), getRandomDir() * curveSpeed / 1.5, 4)
+		t_wait(getPerfectDelay(THICKNESS) * 7.5)
+	else
+		hmcBarrageStop(getRandomSide(), getRandomDir() * curveSpeed, 4)
+		t_wait(getPerfectDelay(THICKNESS) * 7)
+	end
+	
 end
 
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    if curveSpeed < 3 then
-        curveSpeed = curveSpeed + 0.4
-        e_messageAddImportant("Curve speed: "..curveSpeed, 120)
-    end
+	curveSpeed = curveSpeed + 5
+	e_messageAddImportant("Curve speed: "..curveSpeed, 120)
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted
@@ -64,8 +72,8 @@ end
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    if not achievementUnlocked and l_getLevelTime() > 45 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a19_centrifugalforce")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 45 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a19_centrifugalforce")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/disc-o.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/disc-o.lua
@@ -7,59 +7,82 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatter
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then pAltBarrage(u_rndInt(1, 3), 2)
-    elseif mKey == 1 then pMirrorSpiral(u_rndInt(2, 4), 0)
-    elseif mKey == 2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
-    elseif mKey == 3 then pBarrageSpiral(u_rndInt(0, 2), 1.2, 2)
-    elseif mKey == 4 then pBarrageSpiral(2, 0.7, 1)
-    elseif mKey == 5 then pInverseBarrage(0)
-    elseif mKey == 6 then hmcDefBarrageSpiral()
-    elseif mKey == 7 then pMirrorWallStrip(1, 0)
-    elseif mKey == 8 then hmcDefSpinner()
-    elseif mKey == 9 then hmcDefBarrage()
-    elseif mKey == 10 then hmcDef2Cage()
-    elseif mKey == 11 then hmcDefBarrageSpiralSpin()
-    end
+	-- Normal Palette
+		if mKey == 0 then pAltBarrage(math.random(2, 4), 2)
+	elseif mKey == 1 then pMirrorSpiral(math.random(2, 4), 0)
+	elseif mKey == 2 then pBarrageSpiral(math.random(0, 3), 1, 1)
+	elseif mKey == 3 then pBarrageSpiral(math.random(0, 2), 1.2, 2)
+	elseif mKey == 4 then pBarrageSpiral(2, 0.7, 1)
+	elseif mKey == 5 then pInverseBarrage(0)
+	elseif mKey == 6 then hmpBarrageSpiral(math.random(1, 3), 2, clamp(level + 1, 2, 6))
+	elseif mKey == 7 then pMirrorWallStrip(1, 0)
+	elseif mKey == 8 then hmpSpinner(1, clamp(level, 1, 6))
+	elseif mKey == 9 then hmpBarrage(1, clamp(level, 1, 6))
+	elseif mKey == 10 then hmcDef2Cage()
+	elseif mKey == 11 then hmpBarrageSpiralSpin(math.random(7, 14), 2, clamp(level + 1, 2, 6))
+	elseif mKey == 12 then hmpGrowTunnel(math.random(2, 3))
+	elseif mKey == 13 then 
+		hmcGrowBarrage(getRandomSide(), getRandomSide())
+		t_wait(getPerfectDelay(getPerfectThickness(THICKNESS)) * 4.5)
+	elseif mKey == 14 then pSwapBarrage(getRandomSide())
+	elseif mKey == 15 then pSwapCorridor(math.random(2, 3))
+	elseif mKey == 16 then hmpTwirl(math.random(2, 4), clamp(level + 1, 2, 5), 1)
+	-- Specials Palette
+	elseif mKey == 101 then 
+		hmpBarrageStop(3, 12)
+		if (u_getDifficultyMult() > 1) then
+			t_wait(getPerfectDelay(THICKNESS) * 3)
+		end
+	elseif mKey == 102 then hmpSwarm(clamp(level, 1, 6), 3 * clamp(level, 1, 6), true, level > 10, false)
+	end
 end
+
+--globalHueModifier = 0
+level = 1;
 
 -- shuffle the keys, and then call them to add all the patterns
 -- shuffling is better than randomizing - it guarantees all the patterns will be called
-keys = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 10, 10, 8, 8, 9, 9, 9, 9, 6, 11, 11, 10, 10 }
+keys = { 0, 0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 11, 12, 13, 13, 14, 14, 15, 16, 16 }
+specialKeys = {} -- For specials.
 shuffle(keys)
-index = 0
+index = 1
+specialIndex = 1
 achievementUnlocked = false
 
-specials = { "cage", "spinner", "barrage" }
+specials = { "spinner", "barrage", "grow", "swarm" }
+shuffle(specials)
+currSpecial = 1
 special = "none"
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(1.7)
-    l_setSpeedInc(0.15)
-    l_setSpeedMax(2.9)
-    l_setRotationSpeed(0.1)
-    l_setRotationSpeedMax(0.415)
-    l_setRotationSpeedInc(0.035)
-    l_setDelayMult(1.2)
-    l_setDelayInc(0.0)
-    l_setFastSpin(0.0)
-    l_setSides(6)
-    l_setSidesMin(6)
-    l_setSidesMax(6)
-    l_setIncTime(15)
+	l_setSpeedMult(1.7)
+	l_setSpeedInc(0)
+	l_setSpeedMax(3.5)
+	l_setRotationSpeed(0.1)
+	l_setRotationSpeedMax(0.415)
+	l_setRotationSpeedInc(0)
+	l_setDelayMult(1.2)
+	l_setDelayInc(0.0)
+	l_setFastSpin(0.0)
+	l_setSides(6)
+	l_setSidesMin(6)
+	l_setSidesMax(6)
+	l_setIncTime(15)
 
-    l_setPulseMin(77)
-    l_setPulseMax(95)
-    l_setPulseSpeed(1.937)
-    l_setPulseSpeedR(0.524)
-    l_setPulseDelayMax(13.05)
+	l_setPulseMin(77)
+	l_setPulseMax(95)
+	l_setPulseSpeed(1.937)
+	l_setPulseSpeedR(0.524)
+	l_setPulseDelayMax(13.05)
     l_setPulseInitialDelay(28.346) -- skip a beat to match with the clap
 
-    l_setBeatPulseMax(17)
-    l_setBeatPulseDelayMax(28.346)
+	l_setBeatPulseMax(17)
+	l_setBeatPulseDelayMax(28.346)
 
-    l_setSwapEnabled(true)
-    l_addTracked("special", "special")
+	l_setSwapEnabled(true)
+	l_setSwapCooldownMult(1.4/u_getSpeedMultDM());
+	l_addTracked("special", "special")
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
@@ -69,34 +92,64 @@ end
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    if special == "none" then
-        addPattern(keys[index])
-        index = index + 1
-
-        if index - 1 == #keys then
-            index = 1
-            shuffle(keys)
-        end
-    elseif special == "cage" then
-        addPattern(10)
-    elseif special == "spinner" then
-        addPattern(8)
-    elseif special == "barrage" then
-        addPattern(9)
-    end
+	if (special == "none") then
+		addPattern(keys[index])
+		index = index + 1
+		if index - 1 == #keys then
+			index = 1
+			shuffle(keys)
+		end
+	else
+		addPattern(specialKeys[specialIndex])
+		if (#specialKeys > 1) then
+			specialIndex = specialIndex + 1;
+			
+			if specialIndex - 1 == #specialKeys then
+				specialIndex = 1
+				shuffle(specialKeys)
+			end
+		end
+	end
 end
 
+local constantFlag = false
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    shuffle(specials)
-
-    if special == "none" then
-        special = specials[1]
-        e_messageAddImportant("Special: "..special, 120)
-    else
-        special = "none"
-    end
+	if special == "none" then
+		special = specials[currSpecial]
+		e_messageAddImportant("Special: "..special, 120)
+		currSpecial = currSpecial + 1
+		if (currSpecial - 1 == #specials) then
+			currSpecial = 1
+			shuffle(specials)
+		end
+		specialIndex = 1
+		if (special == "cage") then
+			specialKeys = {10};
+		elseif (special == "spinner") then
+			specialKeys = {8};
+		elseif (special == "barrage") then
+			specialKeys = {101};
+		elseif (special == "grow") then
+			specialKeys = {13};
+		elseif (special == "swarm") then
+			specialKeys = {102};
+			if (level > 10 and not constantFlag) then
+				e_messageAddImportant("Constant Speed Enabled!", 90)
+				constantFlag = true
+			end
+		end
+		shuffle(specialKeys)
+		l_setSpeedInc(0.1)
+		l_setRotationSpeedInc(0.035)
+	else
+		special = "none"
+		level = level + 1;
+		l_setSpeedInc(0)
+		l_setRotationSpeedInc(0)
+	end
+	l_setSwapCooldownMult(1.7/u_getSpeedMultDM());
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted
@@ -105,8 +158,8 @@ end
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a12_disco")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a12_disco")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/evotutorial.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/evotutorial.lua
@@ -7,10 +7,10 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatter
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then cBarrage(0)
-    elseif mKey == 1 then hmcBarrageN(0, 0, 0, 0.05, -3.8, 2.7, true); t_wait(55)
-    elseif mKey == 2 then hmcBarrageN(0, 0, 0, -0.05, -2.7, 3.8, true); t_wait(55)
-    end
+		if mKey == 0 then cBarrage(0)
+	elseif mKey == 1 then hmcBarrageN(0, 0, 0, 0.05, -3.8, 2.7, true); t_wait(55)
+	elseif mKey == 2 then hmcBarrageN(0, 0, 0, -0.05, -2.7, 3.8, true); t_wait(55)
+	end
 end
 
 -- shuffle the keys, and then call them to add all the patterns
@@ -22,132 +22,161 @@ achievementUnlocked = false
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(1.1)
-    l_setSpeedInc(0.045)
-    l_setRotationSpeed(0.1)
-    l_setRotationSpeedMax(0.4)
-    l_setRotationSpeedInc(0.045)
-    l_setDelayMult(1.0)
-    l_setDelayInc(0.0)
-    l_setFastSpin(71.0)
-    l_setSides(6)
-    l_setSidesMin(5)
-    l_setSidesMax(7)
-    l_setIncTime(0)
+	l_setSpeedMult(1.1)
+	l_setSpeedInc(0.045)
+	l_setRotationSpeed(0.1)
+	l_setRotationSpeedMax(0.4)
+	l_setRotationSpeedInc(0.045)
+	l_setDelayMult(1.0)
+	l_setDelayInc(0.0)
+	l_setFastSpin(71.0)
+	l_setSides(6)
+	l_setSidesMin(5)
+	l_setSidesMax(7)
+	l_setIncTime(0)
 
-    l_setWallSkewLeft(18)
+	l_setWallSkewLeft(18)
 
-    l_setPulseMin(68)
-    l_setPulseMax(82.93)
-    l_setPulseSpeed(1.521)
-    l_setPulseSpeedR(1.4)
-    l_setPulseDelayMax(7)
+	l_setPulseMin(64)
+	l_setPulseMax(84)
+	l_setPulseSpeed(1.05)
+	l_setPulseSpeedR(1.35)
+	l_setPulseDelayMax(7)
 
-    l_setBeatPulseMax(15)
-    l_setBeatPulseDelayMax(27.48)
+	l_setBeatPulseMax(15)
+	l_setBeatPulseDelayMax(110)
 
-    l_setSwapEnabled(true)
+	l_setSwapEnabled(true)
 
-    l_setTutorialMode(true)
-    l_setIncEnabled(false)
+	l_setTutorialMode(true)
+	l_setIncEnabled(false)
 end
 
 swappedOnce = false
+swapTime = false
 
 -- onCursorSwap is executed whenever the player executes a successful 180° swap
 function onCursorSwap()
-    if swappedOnce == false then
-        u_log("swap detected!")
-        swappedOnce = true
-    end
+	if (swapTime and not swappedOnce) then
+		swappedOnce = true
+		e_clearMessages()
+	end
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-    e_messageAddImportant("welcome to the evolution tutorial", 120)
-    e_messageAddImportant("today you'll be introduced to...", 120)
-    e_messageAddImportant("1. swapping!", 100)
-    e_messageAddImportant("2. curving walls!", 100)
-    e_messageAddImportant("", 120)
-    e_messageAddImportant("press space or middle mouse button\nto swap", 250)
-    e_messageAddImportant("it allows you to rotate 180 degrees!", 200)
-    e_messageAddImportant("", 120)
+	e_waitS(1)
+	e_messageAddImportant("Welcome to the evolution tutorial", 150)
+	e_messageAddImportant("Today you'll be introduced to...", 120)
+	e_messageAddImportant("swapping, accelerating walls, and curving walls!", 300)
+	e_wait(570 + 120)
+	e_messageAddImportant("Swapping allows you to instantly rotate 180 degrees!", 200)
+	e_messageAddImportant("You can only swap when your player\nblinks red and yellow!", 250)
+	e_wait(450)
+	
+	e_eval([[swapTime = true]])
+	e_messageAddImportant("Try swapping now!\nPress space or middle mouse button to swap", 10000)
+end
 
-    e_messageAddImportant("now: curving walls", 120)
-    e_messageAddImportant("they can be simple...", 120)
-    e_messageAddImportant("", 120 * 3 + 80)
+function partTwo()
+	e_messageAddImportant("Awesome!", 120)
+	e_messageAddImportant("After swapping, you must wait before\nswapping again!", 250)
+	e_messageAddImportant("Let's introduce a swap pattern.", 180);
+	e_messageAddImportant("For this pattern, you must swap to survive", 180)
+	e_messageAddImportant("Swap at the right moment!", 180)
+	e_wait(180 * 3 + 120 + 250 + 120)
+	e_messageAddImportant("Excellent! You know how to swap!", 120)
+	t_wait(610)
+	pSwapBarrage(getRandomSide(), 2)
+	
+	e_messageAddImportant("Let's talk about accelerating walls", 180);
+	e_messageAddImportant("These walls can change speed over time", 180);
+	e_messageAddImportant("They can either accelerate...", 180);
+	e_messageAddImportant("Decelerate...", 180);
+	e_messageAddImportant("Or go completely backwards to trick you!", 180);
+	e_wait(180 * 5 + 120 + 120)
+	
+	t_wait(760);
+	pACBarrageAccelerate();
+	t_wait(120);
+	pACBarrageDecelerate();
+	t_wait(100);
+	pACBarrageDeception(3, 1);
 
-    t_wait(135 * 8)
-    hmcSimpleBarrage(1)
-    t_wait(100)
-    hmcSimpleBarrage(-1)
-    t_wait(50)
-    hmcSimpleBarrage(1)
-    t_wait(100)
-    hmcSimpleBarrage(-2.5)
-    t_wait(80)
-    hmcSimpleBarrage(2.5)
-    t_wait(80)
-    hmcSimpleBarrage(3)
+	e_messageAddImportant("But wait, it gets crazier!", 120);
+	e_messageAddImportant("Let's focus on curving walls", 120)
+	e_messageAddImportant("they can be simple...", 120)
+	e_wait(300 + 410)
+	
+	t_wait(300)
+	hmcSimpleBarrage(0, 1)
+	t_wait(100)
+	hmcSimpleBarrage(0, -1)
+	t_wait(50)
+	hmcSimpleBarrage(0, math.random(1, 6))
+	t_wait(100)
+	hmcSimpleBarrage(0, -math.random(1, 6))
+	t_wait(80)
+	hmcSimpleBarrage(0, math.random(1, 6))
+	t_wait(80)
+	hmcSimpleBarrage(0, math.random(-6, 6))
 
-    t_wait(50)
-    e_messageAddImportant("...in various patterns...", 130)
-    e_messageAddImportant("", 120 * 5 + 80)
-    t_wait(130)
+	t_wait(50)
+	e_messageAddImportant("...in various patterns...", 130)
+	e_wait(100 + 120 * 5 + 80)
+	t_wait(130)
 
-    hmcSimpleTwirl(5, 1, 0)
-    t_wait(50)
-    hmcSimpleTwirl(5, -2.5, 0.3)
+	hmcSimpleTwirl(5, math.random(-3, 3), 0)
+	t_wait(50)
+	hmcSimpleTwirl(5, -2, 1)
 
-    e_messageAddImportant("...or can accellerate!", 130)
-    e_messageAddImportant("", 120 * 4 + 40)
-    t_wait(130)
+	e_messageAddImportant("...or can accelerate!", 130)
+	e_wait(130 + 340)
+	t_wait(130)
 
-    hmcBarrage(0, 0.05, -1.5, 3, true)
-    t_wait(80)
-    hmcBarrage(0, -0.05, -3, 3, true)
-    t_wait(100)
-    hmcBarrage(0, 0.1, -2, 2, true)
-    t_wait(100)
-    hmcBarrage(0, 0.1, -3, 3, true)
-    t_wait(200)
+	hmcBarrage(0, 0.05, -1.5, 3, true)
+	t_wait(80)
+	hmcBarrage(0, -0.05, -3, 3, true)
+	t_wait(100)
+	hmcBarrage(0, 0.1, -2, 2, true)
+	t_wait(100)
+	hmcBarrage(0, 0.1, -3, 3, true)
+	t_wait(200)
 
-    e_messageAddImportant("they can also do crazy stuff!", 130)
-    e_messageAddImportant("", 120 * 8 + 50)
+	e_messageAddImportant("they can also do crazy stuff!", 180)
+	e_wait(120 * 9)
 
-    hmcSimpleCage(2.5, 1)
-    t_wait(80)
-    hmcSimpleCage(2.5, -1)
-    t_wait(100)
-    hmcSimpleCage(2.5, 1)
-    hmcSimpleCage(2.5, 1)
-    t_wait(100)
-    hmcSimpleCage(2.5, 1)
-    hmcSimpleCage(2.5, -1)
-    t_wait(100)
-    hmcSimpleSpinner(1)
-    t_wait(100)
-    hmcSimpleSpinner(-2)
-    t_wait(100)
-    hmcSimpleSpinner(3)
-    t_wait(100)
-    hmcSimpleCage(1.5, 1)
-    hmcSimpleCage(2.5, 1)
-    t_wait(100)
-    hmcSimpleCage(1.5, 1)
-    hmcSimpleCage(2.5, -1)
-    t_wait(100)
-    hmcSimpleSpinner(1)
-    hmcSimpleSpinner(1.2)
-    t_wait(100)
-    hmcSimpleSpinner(1)
-    hmcSimpleSpinner(-1.2)
-    t_wait(500)
+	hmcSimpleCage(2, 1)
+	t_wait(80)
+	hmcSimpleCage(2, -1)
+	t_wait(100)
+	hmcSimpleCage(2, 1)
+	hmcSimpleCage(2, 1)
+	t_wait(100)
+	hmcSimpleCage(2, 1)
+	hmcSimpleCage(2, -1)
+	t_wait(100)
+	hmcSimpleSpinner(getRandomSide(), 1)
+	t_wait(100)
+	hmcGrowBarrage(getRandomSide(), 0)
+	t_wait(100)
+	hmcGrowBarrage(getRandomSide(), 3)
+	t_wait(100)
+	hmcGrowBarrage(getRandomSide(), 6)
+	t_wait(100)
+	hmcAssembleBarrage(getRandomSide())
+	t_wait(100)
+	hmcAssembleBarrage(getRandomSide())
+	t_wait(100)
+	hmcAssembleBarrage(getRandomSide())
+	t_wait(700)
 
-    e_messageAddImportant("now play some real levels!", 138)
-    e_messageAddImportant("good luck!", 130)
-
-    t_kill()
+	e_messageAddImportant("Well done!", 130)
+	e_messageAddImportant("You should be prepared to take on Hypercube!", 300)
+	e_messageAddImportant("Have fun!", 1000)
+	
+	e_wait(340)
+	e_kill()
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
@@ -168,17 +197,22 @@ dirChangeTime = 600
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    dirChangeTime = dirChangeTime - mFrameTime;
-    if dirChangeTime < 0 then
-        -- do not change direction while fast spinning
-        if u_isFastSpinning() == false then
-            l_setRotationSpeed(l_getRotationSpeed() * -1.0)
-            dirChangeTime = 400
-        end
-    end
+	--print(l_getPulse());
+	if (swappedOnce and swapTime) then
+		partTwo()
+		swapTime = false
+	end
+	dirChangeTime = dirChangeTime - mFrameTime;
+	if dirChangeTime < 0 then
+		-- do not change direction while fast spinning
+		if u_isFastSpinning() == false then
+			l_setRotationSpeed(l_getRotationSpeed() * -1.0)
+			dirChangeTime = 400
+		end
+	end
 
-    if not achievementUnlocked and l_getLevelTime() > 69 then
-        steam_unlockAchievement("a11_evotutorial")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 69 then
+		steam_unlockAchievement("a11_evotutorial")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/g-force.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/g-force.lua
@@ -6,21 +6,21 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "nextpatterns.lu
 u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatterns.lua")
 
 function gforceBarrage()
-    cBarrage(getRandomSide())
-    t_wait(getPerfectDelayDM(THICKNESS) * 6.1)
+	cBarrage(getRandomSide())
+	t_wait(getPerfectDelay(THICKNESS) * 6.1)
 end
 
 function gforceBarrageAssault()
-    cBarrage(getRandomSide())
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
+	cBarrage(getRandomSide())
+	t_wait(getPerfectDelay(THICKNESS) * 3.5)
 end
 
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then hmcDefAccelBarrage()
-    elseif mKey == 1 then gforceBarrage()
-    end
+		if mKey == 0 then hmpDefAccelBarrage()
+	elseif mKey == 1 then gforceBarrage()
+	end
 end
 
 -- shuffle the keys, and then call them to add all the patterns
@@ -31,27 +31,29 @@ index = 0
 achievementUnlocked = false
 
 specials = { "double", "assault", "incongruence", "dizzy" }
+shuffle(specials)
+currSpecial = 1
 special = "none"
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(2.1)
-    l_setSpeedInc(0.16)
-    l_setSpeedMax(3.9)
-    l_setRotationSpeed(0.12)
-    l_setRotationSpeedMax(0.6)
-    l_setRotationSpeedInc(0.035)
-    l_setDelayMult(1.9)
-    l_setDelayInc(0.0)
-    l_setFastSpin(0.0)
-    l_setSides(4)
-    l_setSidesMin(4)
-    l_setSidesMax(4)
-    l_setIncTime(10)
+	l_setSpeedMult(2.1)
+	l_setSpeedInc(0) -- Disable it for right now
+	l_setSpeedMax(3.9)
+	l_setRotationSpeed(0.12)
+	l_setRotationSpeedMax(0.65)
+	l_setRotationSpeedInc(0.0175)
+	l_setDelayMult(1.9)
+	l_setDelayInc(0.0)
+	l_setFastSpin(0.0)
+	l_setSides(4)
+	l_setSidesMin(4)
+	l_setSidesMax(4)
+	l_setIncTime(10)
 
-    l_setWallSkewLeft(-15)
+	l_setWallSkewLeft(-15)
 
-    l_setPulseInitialDelay(13.953 * 2)
+	l_setPulseInitialDelay(13.953 * 2)
     l_setPulseMin(67.62)
     l_setPulseMax(95)
     l_setPulseSpeed(2.791)
@@ -61,8 +63,9 @@ function onInit()
     l_setBeatPulseMax(17)
     l_setBeatPulseDelayMax(13.953)
 
-    l_setSwapEnabled(true)
-    l_addTracked("special", "special")
+	l_setSwapEnabled(true)
+	l_setSwapCooldownMult(1.9/u_getSpeedMultDM())
+	l_addTracked("special", "special")
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
@@ -72,48 +75,58 @@ end
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    if special == "incongruence" then
-        l_setSides(u_rndInt(4, 5))
-    else
-        l_setSides(4)
-    end
+	if special == "incongruence" then
+		l_setSides(u_rndInt(4, 5))
+	else
+		l_setSides(4)
+	end
 
-    if special == "assault" then
-        gforceBarrageAssault()
-        return
-    end
+	if special == "assault" then
+		gforceBarrageAssault()
+		return
+	end
 
-    if special == "dizzy" then
-        addPattern(0)
-        return
-    end
+	if special == "dizzy" then
+		addPattern(0)
+		return
+	end
 
-    if special ~= "double" then
-        addPattern(keys[index])
-    else
-        addPattern(keys[index])
-        addPattern(keys[index])
-    end
+	if special ~= "double" then
+		addPattern(keys[index])
+	else
+		addPattern(keys[index])
+		addPattern(keys[index])
+	end
 
-    index = index + 1
+	index = index + 1
 
-    if index - 1 == #keys then
-        index = 1
-        shuffle(keys)
-    end
+	if index - 1 == #keys then
+		index = 1
+		shuffle(keys)
+	end
 end
 
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    shuffle(specials)
-
-    if special == "none" then
-        special = specials[1]
-        e_messageAddImportant("Special: "..special, 120)
-    else
-        special = "none"
-    end
+	if special == "none" then
+		special = specials[currSpecial]
+		currSpecial = currSpecial + 1
+		if (currSpecial - 1 == #specials) then
+			currSpecial = 1
+			shuffle(specials)
+		end
+		e_messageAddImportant("Special: "..special, 120)
+		l_setSpeedInc(0.16)
+	else
+		special = "none"
+		l_setSpeedInc(0)
+	end
+	if (special == "assault") then
+		l_setSwapCooldownMult(1/u_getSpeedMultDM()) -- Assault has tighter spacing so we need lower swap cooldown.
+	else
+		l_setSwapCooldownMult(1.9/u_getSpeedMultDM())
+	end
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted
@@ -122,8 +135,8 @@ end
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a14_gforce")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a14_gforce")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/incongruence.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/incongruence.lua
@@ -6,15 +6,25 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "nextpatterns.lu
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then pRCBarrage()
-    elseif mKey == 1 then pRCBarrageDouble()
-    elseif mKey == 2 then pRCBarrageSpin()
-    end
+		if mKey == 0 then pBarrage()
+	elseif mKey == 1 then pRCBarrageDouble()
+	elseif mKey == 2 then pBarrageSpiral(math.random(1, 2), 0.8)
+	elseif mKey == 3 then 
+		if (l_getSides() > 8) then
+			pAltBarrage(math.random(2, 3), 3, 0.75)
+		else
+			pAltBarrage(math.random(2, 3), 2, 0.75)
+		end
+	-- "Dynamic" Patterns
+	elseif mKey == 4 then pRCAscendBarrageRandom(lowerBound, upperBound)
+	elseif mKey == 5 then pRCAscendBarrage(getRandomSide(), lowerBound, upperBound)
+	elseif mKey == 6 then pRCDynamicAltBarrage(2, math.random(3, 4), lowerBound, upperBound)
+	end
 end
 
 -- shuffle the keys, and then call them to add all the patterns
 -- shuffling is better than randomizing - it guarantees all the patterns will be called
-keys = { 0, 0, 1, 1, 2 }
+keys = { 0, 0, 0, 1, 1, 2, 3 }
 shuffle(keys)
 index = 0
 lowerBound = 4
@@ -23,60 +33,71 @@ achievementUnlocked = false
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(2.7)
-    l_setSpeedInc(0.11)
-    l_setSpeedMax(3.14) -- A lot of the difficulty is coming from the changing sides. Speed isn't too important here.
-    l_setRotationSpeed(0.27)
-    l_setRotationSpeedMax(0.5)
-    l_setRotationSpeedInc(0.045)
-    l_setDelayMult(1.1)
-    l_setDelayInc(-0.04)
-    l_setDelayMin(0.86)
-    l_setFastSpin(71.0)
-    l_setSides(6)
-    l_setSidesMin(0)
-    l_setSidesMax(0)
-    l_setIncTime(15)
+	l_setSpeedMult(2.7)
+	l_setSpeedInc(0.1)
+	l_setSpeedMax(3.8) -- A lot of the difficulty is coming from the changing sides. Speed isn't too important here.
+	l_setRotationSpeed(0.27)
+	l_setRotationSpeedMax(0.5)
+	l_setRotationSpeedInc(0.045)
+	l_setDelayMult(1.1)
+	l_setDelayInc(0)
+	l_setFastSpin(71.0)
+	l_setSides(6)
+	l_setSidesMin(0)
+	l_setSidesMax(0)
+	l_setIncTime(15)
 
-    l_setPulseMin(62.27)
-    l_setPulseMax(100.22)
-    l_setPulseSpeed(1.971)
-    l_setPulseSpeedR(0.71)
-    l_setPulseDelayMax(13.01)
+	l_setPulseMin(64)
+	l_setPulseMax(84)
+	l_setPulseSpeed(1.05)
+	l_setPulseSpeedR(1.34)
+	l_setPulseDelayMax(1.74)
 
-    l_setBeatPulseMax(15)
-    l_setBeatPulseDelayMax(21.428)
+	l_setBeatPulseMax(15)
+	l_setBeatPulseDelayMax(21.428)
 
-    l_addTracked("lowerBound", "min")
-    l_addTracked("upperBound", "max")
-    l_enableRndSideChanges(false)
+	l_addTracked("lowerBound", "min")
+	l_addTracked("upperBound", "max")
+	l_enableRndSideChanges(false)
 
-    enableSwapIfDMGreaterThan(1.5)
+	enableSwapIfDMGreaterThan(1.5)
+	l_setSwapCooldownMult(1 / u_getDifficultyMult())
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-    e_messageAddImportant("Sides ("..lowerBound.." / "..upperBound..")", 170)
+	if (u_getDifficultyMult() >= 1) then
+		keys[#keys + 1] = 4
+		keys[#keys + 1] = 4
+		if (u_getDifficultyMult() > 1) then
+			e_messageAdd("Difficulty > 1\n\"Dynamic\" patterns enabled!", 120)
+			keys[#keys + 1] = 5
+			keys[#keys + 1] = 6
+		end
+		shuffle(keys)
+	end
+	e_messageAddImportant("Sides: "..lowerBound.." - "..upperBound, 120)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    l_setSides(u_rndInt(lowerBound, upperBound))
-    addPattern(keys[index])
-    index = index + 1
+	l_setSides(u_rndInt(lowerBound, upperBound))
+	addPattern(keys[index])
+	index = index + 1
 
-    if index - 1 == #keys then
-        index = 1
-        shuffle(keys)
-    end
+	if index - 1 == #keys then
+		index = 1
+		shuffle(keys)
+	end
 end
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    lowerBound = u_rndInt(4, 6)
-    upperBound = lowerBound + u_rndInt(1, 3)
-    e_messageAddImportant("Sides ("..lowerBound.." / "..upperBound..")", 170)
+	lowerBound = math.floor(u_rndInt(4, 6))
+	upperBound = math.floor(lowerBound + u_rndInt(1, 4))
+	e_messageAddImportant("Sides: "..lowerBound.." - "..upperBound, 120)
+	t_clear()
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted
@@ -86,26 +107,26 @@ end
 -- continuous direction change (even if not on level increment)
 dirChangeTime = 400
 hueIMin = 0.0
-hueIMax = 22.0
+hueIMax = 15.0
 hueIStep = 0.0065
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    dirChangeTime = dirChangeTime - mFrameTime;
-    if dirChangeTime < 0 then
-        -- do not change direction while fast spinning
-        if u_isFastSpinning() == false then
-            l_setRotationSpeed(l_getRotationSpeed() * -1.0)
-            dirChangeTime = 400
-        end
-    end
+	dirChangeTime = dirChangeTime - mFrameTime;
+	if dirChangeTime < 0 then
+		-- do not change direction while fast spinning
+		if u_isFastSpinning() == false then
+			l_setRotationSpeed(l_getRotationSpeed() * -1.0)
+			dirChangeTime = 400
+		end
+	end
 
-    if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a15_incongruence")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 90 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a15_incongruence")
+		achievementUnlocked = true
+	end
 
-    s_setHueInc(s_getHueInc() + hueIStep)
-    if(s_getHueInc() > hueIMax) then hueIStep = hueIStep * -1 end
-    if(s_getHueInc() < hueIMin) then hueIStep = hueIStep * -1 end
+	s_setHueInc(s_getHueInc() + hueIStep)
+	if(s_getHueInc() > hueIMax) then hueIStep = hueIStep * -1 end
+	if(s_getHueInc() < hueIMin) then hueIStep = hueIStep * -1 end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/massacre.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/massacre.lua
@@ -5,110 +5,182 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "nextpatterns.lua")
 u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatterns.lua")
 
+local side = 0
+local sideSpawn = 0;
+
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then pAltBarrage(u_rndInt(1, 2), 2)
-    elseif mKey == 1 then pBarrageSpiral(2, 0.6, 1)
-    elseif mKey == 2 then pInverseBarrage(0)
-    elseif mKey == 3 then hmcDefBarrageSpiralFast()
-    elseif mKey == 4 then pWallExVortex(0, 1, 1)
-    elseif mKey == 5 then pDMBarrageSpiral(u_rndInt(2, 4), 0.4, 1)
-    elseif mKey == 6 then pRandomBarrage(u_rndInt(1, 3), 2.25)
-    elseif mKey == 7 then pInverseBarrage(0)
-    elseif mKey == 8 then pMirrorWallStrip(1, 0)
-    elseif mKey == 9 then hmcDefSpinner()
-    elseif mKey == 10 then hmcDefBarrageSpiral()
-    elseif mKey == 11 then hmcDef2CageD()
-    elseif mKey == 12 then hmcDefBarrageSpiralSpin()
-    elseif mKey == 13 then hmcDefSpinnerSpiralAcc()
-    elseif mKey == 14 then hmcDefBarrageSpiralRnd()
-    elseif mKey == 15 then hmcDefBarrageInv()
-    end
+		if mKey == 0 then pAltBarrage(math.random(2, 4), 2)
+	elseif mKey == 1 then pBarrageSpiral(2, 0.6, 1)
+	elseif mKey == 2 then pInverseBarrage(0)
+	elseif mKey == 3 then hmpTunnelDynamic(math.random(2, 3))
+	elseif mKey == 4 then pWallExVortex(0, 1, 1)
+	elseif mKey == 5 then pDMBarrageSpiral(math.random(2, 4), 0.4, 1)
+	elseif mKey == 6 then pRandomBarrage(math.random(1, 3), 2.25)
+	elseif mKey == 7 then pInverseBarrage(0)
+	elseif mKey == 8 then pMirrorWallStrip(1, 0)
+	elseif mKey == 9 then hmpSpinner(1, clamp(level, 1, 6))
+	elseif mKey == 10 then hmpBarrageSpiral(math.random(1, 3), 2, clamp(level + 1, 2, 5))
+	elseif mKey == 11 then hmcDef2CageD()
+	elseif mKey == 12 then hmpBarrageSpiralSpin(math.random(4, 8), 2, clamp(level + 1, 2, 5))
+	elseif mKey == 13 then hmpBarrageSpiralStop(math.random(2, 4), 2, 6);
+	elseif mKey == 14 then hmcBarrageInv(1, clamp(level + 1, 2, 5))
+	elseif mKey == 15 then hmpStripeSnakeBarrage(getRandomSide(), math.random(3, 6))
+	elseif mKey == 16 then hmpStripeSnakeAltBarrage(math.random(5, 8), 2)
+	elseif mKey == 17 then hmpGrowTunnel(math.random(2, 3))
+	elseif mKey == 18 then hmpAssembleTunnel(math.random(2, 3))
+	elseif mKey == 19 then pSwapBarrage(getRandomSide())
+	elseif mKey == 20 then pSwapCorridor(math.random(2, 3))
+	elseif mKey == 21 then hmpTwirl(math.random(2, 3), clamp(level + 1, 2, 5), 1)
+	
+	-- Special-exclusive patterns
+	-- Assemble Pattern
+	elseif mKey == 101 then
+		hmcAssembleBarrage(getRandomSide(), 1, 4)
+		t_wait(getPerfectDelay(getPerfectThickness(THICKNESS)) * 4.5)
+	-- Chaser Pattern
+	elseif mKey == 102 then
+		hmpChaserAltBarrage(math.random(1, 3), 2, math.random(getHalfSides(), l_getSides() - 1), true);
+	-- Turnaround pattern
+	elseif mKey == 103 then
+		sideSpawn = side + math.random(0, 1) * getHalfSides();
+		local revealChance = math.random(1, 3)
+		hmcTurnaroundSector(sideSpawn, revealChance == 1)
+	-- Alternate pattern
+	elseif mKey == 104 then
+		hmpAlternate()
+	-- Tunnel exclusive pattern
+	elseif mKey == 105 then
+		hmpTunnelSpinner(math.random(1, 3), 2, clamp(level + 1, 2, 5))
+	elseif mKey == 106 then
+		hmpSwarm(clamp(level, 1, 6), 3 * clamp(level, 1, 6), true, true, level > 14)
+	-- Consistency pattern
+	elseif mKey == 107 then
+		hmpTwirl(10, clamp(level, 1, 4), 1)
+	end
 end
+
+level = 1;
 
 -- shuffle the keys, and then call them to add all the patterns
 -- shuffling is better than randomizing - it guarantees all the patterns will be called
-keys = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }
+keys = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 9, 10, 11, 12, 13, 14, 15, 16, 16, 16, 17, 18, 19, 19, 19, 20, 20, 21, 21 }
+specialKeys = {} -- For specials.
 shuffle(keys)
-index = 0
+index = 1
+specialIndex = 1
 achievementUnlocked = false
 
-specials = { "cage", "spinner", "barrage", "spiral" }
+specials = { "assemble", "turnaround", "alternate", "chaser", "tunnel", "swarm", "consistency"}
+shuffle(specials)
+currSpecial = 1;
 special = "none"
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(2.7)
-    l_setSpeedInc(0.04)
-    l_setSpeedMax(3)
-    l_setRotationSpeed(0.25)
-    l_setRotationSpeedMax(0.4)
-    l_setRotationSpeedInc(0.015)
-    l_setDelayMult(1.35)
-    l_setDelayInc(0.0)
-    l_setFastSpin(71.0)
-    l_setSides(6)
-    l_setSidesMin(6)
-    l_setSidesMax(6)
-    l_setIncTime(10)
+	l_setSpeedMult(2.7)
+	l_setSpeedInc(0)
+	l_setSpeedMax(3.5)
+	l_setRotationSpeed(0.25)
+	l_setRotationSpeedMax(0.7)
+	l_setRotationSpeedInc(0)
+	l_setDelayMult(1.35)
+	l_setDelayInc(0.0)
+	l_setFastSpin(71.0)
+	l_setSides(6)
+	l_setSidesMin(6)
+	l_setSidesMax(6)
+	l_setIncTime(20)
 
-    l_setPulseMin(61.01)
+	l_setPulseMin(61.01)
     l_setPulseMax(80.48)
     l_setPulseSpeed(2.4)
     l_setPulseSpeedR(1.449)
-    l_setPulseDelayMax(6.8)
+	l_setPulseDelayMax(6.8)
 
-    l_setBeatPulseMax(18)
-    l_setBeatPulseDelayMax(28.346)
+	l_setBeatPulseMax(18)
+	l_setBeatPulseDelayMax(28.346)
 
-    l_setSwapEnabled(true)
-    l_addTracked("special", "special")
+	l_setSwapEnabled(true)
+	l_setSwapCooldownMult(0.6)
+	l_addTracked("special", "special")
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-    setCurveMult(0.85)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    if special == "none" then
-        addPattern(keys[index])
-        index = index + 1
-
-        if index - 1 == #keys then
-            index = 1
-            shuffle(keys)
-        end
-    elseif special == "cage" then
-        addPattern(11)
-        addPattern(9)
-    elseif special == "spinner" then
-        addPattern(14)
-        addPattern(9)
-    elseif special == "barrage" then
-        addPattern(3)
-        addPattern(14)
-        addPattern(13)
-        addPattern(15)
-    elseif special == "spiral" then
-        addPattern(12)
-        addPattern(4)
-    end
+	if (special == "none") then
+		addPattern(keys[index])
+		index = index + 1
+		if index - 1 == #keys then
+			index = 1
+			shuffle(keys)
+		end
+	else
+		addPattern(specialKeys[specialIndex])
+		if (#specialKeys > 1) then
+			specialIndex = specialIndex + 1;
+			
+			if specialIndex - 1 == #specialKeys then
+				specialIndex = 1
+				shuffle(specialKeys)
+			end
+		end
+	end
 end
 
+local accelFlag = false
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    shuffle(specials)
-
-    if special == "none" then
-        special = specials[1]
-        e_messageAddImportant("Special: "..special, 120)
-    else
-        special = "none"
-    end
+	if (special == "none") then
+		special = specials[currSpecial]
+		currSpecial = currSpecial + 1
+		if (currSpecial - 1 == #specials) then
+			currSpecial = 1
+			shuffle(specials)
+		end
+		specialIndex = 1
+		-- If branch to set up keys
+		if (special == "turnaround") then
+			side = getRandomSide();
+			specialKeys = {103};
+		elseif (special == "assemble") then
+			specialKeys = {101};
+		elseif (special == "alternate") then
+			specialKeys = {104};
+		elseif (special == "chaser") then
+			specialKeys = {102};
+		elseif (special == "tunnel") then
+			specialKeys = {3, 17, 18, 105};
+		elseif (special == "swarm") then
+			specialKeys = {106};
+			if (level > 14 and not accelFlag) then
+				e_messageAddImportant("Accelerating Speed Enabled!", 90)
+				accelFlag = true
+			end
+		elseif (special == "consistency") then
+			specialKeys = {107}
+		end
+		shuffle(specialKeys);
+		l_setIncTime(10);
+		e_messageAddImportant("Special: "..special, 90);
+		
+		-- Enable the speed and rotation increment
+		l_setSpeedInc(0.05)
+		l_setRotationSpeedInc(0.015)
+	else
+		level = level + 1;
+		special = "none";
+		l_setIncTime(20);
+		-- Disable the speed and rotation increment
+		l_setSpeedInc(0)
+		l_setRotationSpeedInc(0)
+	end
 end
 
 -- continuous direction change (even if not on level increment)
@@ -120,17 +192,17 @@ end
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    dirChangeTime = dirChangeTime - mFrameTime;
-    if dirChangeTime < 0 then
-        -- do not change direction while fast spinning
-        if u_isFastSpinning() == false then
-            l_setRotationSpeed(l_getRotationSpeed() * -1.0)
-            dirChangeTime = 200
-        end
-    end
-
-    if not achievementUnlocked and l_getLevelTime() > 60 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a20_massacre")
-        achievementUnlocked = true
-    end
+	dirChangeTime = dirChangeTime - mFrameTime;
+	if dirChangeTime < 0 then
+		-- do not change direction while fast spinning
+		if u_isFastSpinning() == false then
+			l_setRotationSpeed(l_getRotationSpeed() * -1.0)
+			dirChangeTime = 200
+		end
+	end
+	
+	if not achievementUnlocked and l_getLevelTime() > 60 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a20_massacre")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/polyhedrug.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/polyhedrug.lua
@@ -10,7 +10,7 @@ incrementTime = 10
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then pTrapBarrage(u_rndInt(0, l_getSides()))
+		if mKey == 0 then pTrapBarrage(u_rndInt(0, l_getSides()))
     elseif mKey == 1 then pTrapBarrageDouble(u_rndInt(0, l_getSides()))
     elseif mKey == 2 then pTrapBarrageInverse(u_rndInt(0, l_getSides()))
     elseif mKey == 3 then pTrapBarrageAlt(u_rndInt(0, l_getSides()))
@@ -26,20 +26,20 @@ achievementUnlocked = false
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(2.0)
-    l_setSpeedInc(0.0)
-    l_setRotationSpeed(0.27)
-    l_setRotationSpeedMax(0.4)
-    l_setRotationSpeedInc(0.045)
-    l_setDelayMult(1.1)
-    l_setDelayInc(0.0)
-    l_setFastSpin(71.0)
-    l_setSides(4)
-    l_setSidesMin(0)
-    l_setSidesMax(0)
-    l_setIncTime(10)
+	l_setSpeedMult(2.0)
+	l_setSpeedInc(0.0)
+	l_setRotationSpeed(0.27)
+	l_setRotationSpeedMax(0.4)
+	l_setRotationSpeedInc(0.045)
+	l_setDelayMult(1.1)
+	l_setDelayInc(0.0)
+	l_setFastSpin(71.0)
+	l_setSides(4)
+	l_setSidesMin(0)
+	l_setSidesMax(0)
+	l_setIncTime(10)
 
-    l_setPulseMin(64)
+	l_setPulseMin(64)
     l_setPulseMax(84.99)
     l_setPulseSpeed(1.036)
     l_setPulseSpeedR(1.353)
@@ -48,39 +48,39 @@ function onInit()
     l_setBeatPulseMax(16)
     l_setBeatPulseDelayMax(24.489)
 
-    l_addTracked("level", "level")
-    l_addTracked("lowerBound", "min")
-    l_addTracked("upperBound", "max")
-    l_enableRndSideChanges(false)
+	l_addTracked("level", "level")
+	l_addTracked("lowerBound", "min")
+	l_addTracked("upperBound", "max")
+	l_enableRndSideChanges(false)
 
-    enableSwapIfDMGreaterThan(1.5)
+	enableSwapIfDMGreaterThan(1.5)
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-    e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
+	e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    addPattern(keys[index])
-    index = index + 1
+	addPattern(keys[index])
+	index = index + 1
 
-    if index - 1 == #keys then
-        index = 1
-        shuffle(keys)
-    end
+	if index - 1 == #keys then
+		index = 1
+		shuffle(keys)
+	end
 end
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    extra = extra + 1
-    level = extra + 1
-    incrementTime = incrementTime + 5
-    l_setSides(l_getSides() + 1)
-    l_setIncTime(incrementTime)
-    e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
+	extra = extra + 1
+	level = extra + 1
+	incrementTime = incrementTime + 5
+	l_setSides(l_getSides() + 1)
+	l_setIncTime(incrementTime)
+	e_messageAddImportant("level: "..(extra + 1).." / time: "..incrementTime, 170)
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted
@@ -95,21 +95,21 @@ hueIStep = 0.0065
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    dirChangeTime = dirChangeTime - mFrameTime;
-    if dirChangeTime < 0 then
-        -- do not change direction while fast spinning
-        if u_isFastSpinning() == false then
-            l_setRotationSpeed(l_getRotationSpeed() * -1.0)
-            dirChangeTime = 400
-        end
-    end
+	dirChangeTime = dirChangeTime - mFrameTime;
+	if dirChangeTime < 0 then
+		-- do not change direction while fast spinning
+		if u_isFastSpinning() == false then
+			l_setRotationSpeed(l_getRotationSpeed() * -1.0)
+			dirChangeTime = 400
+		end
+	end
 
-    if not achievementUnlocked and l_getLevelTime() > 60 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a17_polyhedrug")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 60 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a17_polyhedrug")
+		achievementUnlocked = true
+	end
 
-    s_setHueInc(s_getHueInc() + hueIStep)
-    if(s_getHueInc() > hueIMax) then hueIStep = hueIStep * -1 end
-    if(s_getHueInc() < hueIMin) then hueIStep = hueIStep * -1 end
+	s_setHueInc(s_getHueInc() + hueIStep)
+	if(s_getHueInc() > hueIMax) then hueIStep = hueIStep * -1 end
+	if(s_getHueInc() < hueIMin) then hueIStep = hueIStep * -1 end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/reppaws.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/reppaws.lua
@@ -6,92 +6,100 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "nextpatterns.lu
 u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatterns.lua")
 
 gap = 7
-minGap = 3
+minGap = 4
 
 -- this function adds a pattern to the timeline based on a key
 function addPattern(mKey)
-        if mKey == 0 then cBarrageN(getRandomSide(), gap) t_wait(getPerfectDelayDM(THICKNESS) * 6)
-    elseif mKey == 1 then hmcSimpleBarrageSNeigh(getRandomSide(), 0, gap) t_wait(getPerfectDelayDM(THICKNESS) * 6)
-    end
+		if mKey == 0 then cBarrageN(getRandomSide(), gap) t_wait(getPerfectDelay(THICKNESS) * 6)
+	elseif mKey == 1 then hmcSimpleBarrageSNeigh(getRandomSide(), 0, gap) t_wait(getPerfectDelay(THICKNESS) * 6)
+	elseif mKey == 2 then 
+		if (u_getDifficultyMult() < 1) then
+			cSwapBarrageN(getRandomSide(), gap, 1.25) 
+		else
+			cSwapBarrageN(getRandomSide(), gap, .75) 
+		end
+		t_wait(getPerfectDelay(THICKNESS) * 6)
+	end
 end
 
 -- shuffle the keys, and then call them to add all the patterns
 -- shuffling is better than randomizing - it guarantees all the patterns will be called
-keys = { 0, 0, 0, 1, 1, 1 }
+keys = { 0, 0, 0, 1, 1, 1, 2, 2 }
 shuffle(keys)
 index = 0
 achievementUnlocked = false
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(3.0)
-    l_setSpeedInc(0.0)
-    l_setRotationSpeed(0.22)
-    l_setRotationSpeedMax(0.4)
-    l_setRotationSpeedInc(0.0)
-    l_setDelayMult(1.35)
-    l_setDelayInc(0.0)
-    l_setFastSpin(71.0)
-    l_setSides(32)
-    l_setSidesMin(32)
-    l_setSidesMax(32)
-    l_setIncTime(10)
+	l_setSpeedMult(3.0)
+	l_setSpeedInc(0.0)
+	l_setRotationSpeed(0.22)
+	l_setRotationSpeedMax(0.75)
+	l_setRotationSpeedInc(0.03)
+	l_setDelayMult(1.5)
+	l_setDelayInc(0.0)
+	l_setFastSpin(71.0)
+	l_setSides(32)
+	l_setSidesMin(32)
+	l_setSidesMax(32)
+	l_setIncTime(15)
 
-    l_setWallSkewLeft(15)
+	l_setWallSkewLeft(15)
 
-    l_setPulseMin(60.98)
+	l_setPulseMin(60.98)
     l_setPulseMax(80.06)
     l_setPulseSpeed(3.597)
     l_setPulseSpeedR(1.448)
     l_setPulseDelayMax(7.23)
 
-    l_setBeatPulseMax(19)
+	l_setBeatPulseMax(19)
     l_setBeatPulseDelayMax(25.714)
 
-    l_setSwapEnabled(true)
-    l_addTracked("gap", "gap size")
+	l_setSwapEnabled(true)
+	l_setSwapCooldownMult(0.7/u_getDifficultyMult())
+	l_addTracked("gap", "gap size")
 
-    if(u_getDifficultyMult() >= 1.59) then
-        gap = 9
-        minGap = 5
-        l_setSwapCooldownMult(0.8)
-    elseif(u_getDifficultyMult() >= 1.39) then
-        gap = 8
-        minGap = 4
-        l_setSwapCooldownMult(0.9)
-    else
-        gap = 7
-        minGap = 3
-        l_setSwapCooldownMult(1.0)
-    end
+	if(u_getDifficultyMult() >= 1.59) then
+		gap = 9
+		minGap = 5
+	elseif(u_getDifficultyMult() >= 1.39) then
+		gap = 8
+		minGap = 4
+	else
+		gap = 7
+		minGap = 3
+	end
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-    syncCurveWithRotationSpeed(0, 0)
-    e_messageAdd("remember, swap with spacebar!", 120)
+	syncCurveWithRotationSpeed(0, 0)
+	e_messageAdd("Remember to swap!", 120)
+	if (u_getDifficultyMult() > 1) then
+		minGap = 5
+	end
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    addPattern(keys[index])
+	addPattern(keys[index])
 
-    index = index + 1
+	index = index + 1
 
-    if index - 1 == #keys then
-        index = 1
-        shuffle(keys)
-    end
+	if index - 1 == #keys then
+		index = 1
+		shuffle(keys)
+	end
 end
 
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    if gap > minGap then
-        gap = gap -1
-        e_messageAddImportant("Gap size: "..gap, 120)
-    end
+	if gap > minGap then
+		gap = gap -1
+		e_messageAddImportant("Gap size: "..gap, 120)
+	end
 end
 
 -- onUnload is an hardcoded function that is called when the level is closed/restarted
@@ -100,8 +108,8 @@ end
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    if not achievementUnlocked and l_getLevelTime() > 45 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a18_reppaws")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 45 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a18_reppaws")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Scripts/Levels/slither.lua
+++ b/_RELEASE/Packs/hypercube/Scripts/Levels/slither.lua
@@ -7,13 +7,14 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "evolutionpatter
 
 -- shuffle the keys, and then call them to add all the patterns
 -- shuffling is better than randomizing - it guarantees all the patterns will be called
-keys = { 0 }
+keys = { 0, 0, 0, 1, 2 }
 shuffle(keys)
 index = 0
 achievementUnlocked = false
 
 smin = 2
 smax = 2
+completed = false
 
 level = 1
 incrementTime = 10
@@ -21,46 +22,58 @@ incrementTime = 10
 range = "("..(smin * 2).."/"..(smax * 2).."]"
 
 function slitherSpiralAcc()
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-    t_wait(getPerfectDelayDM(THICKNESS) * 2.1)
-    local side = getRandomSide()
+	t_wait(getPerfectDelay(THICKNESS) * 2.1)
+	t_wait(getPerfectDelay(THICKNESS) * 2.1)
+	local side = getRandomSide()
 
-    local acc = u_rndInt(50, 90) / 500.0 * getRandomDir()
-    local minimum = u_rndInt(15, 21) / 10.0 * -1
-    local maximum = -minimum
+	local acc = u_rndInt(50, 90) / 500.0 * getRandomDir()
+	local minimum = u_rndInt(15, 21) / 10.0 * -1
+	local maximum = -minimum
 
-    t_wait(getPerfectDelayDM(THICKNESS) * 3.1)
+	t_wait(getPerfectDelay(THICKNESS) * 3.1)
 
-    for i = 0, u_rndInt(6, 10) do
-        hmcSimpleSpinnerSAcc(side, 0, acc, minimum, maximum, true)
-        t_wait(getPerfectDelay(THICKNESS) * 0.55)
-    end
+	for i = 0, u_rndInt(6, 10) do
+		hmcSimpleSpinnerSAcc(side, 0, acc, minimum, maximum, true)
+		t_wait(getPerfectDelay(THICKNESS) * 0.55)
+	end
 
-    t_wait(getPerfectDelayDM(THICKNESS) * 5.3)
+	t_wait(getPerfectDelay(THICKNESS) * 5.3)
+end
+
+-- this function adds a pattern to the timeline based on a key
+function addPattern(mKey)
+	if (mKey == 0) then slitherSpiralAcc()
+	elseif (mKey == 1) then
+		hmpStripeSnakeBarrage(getRandomSide(), u_rndInt(5, 10), getHalfSides(), l_getSides())
+		t_wait(getPerfectDelay(THICKNESS) * 2)
+	elseif (mKey == 2) then 
+		hmpStripeSnakeAltBarrage(u_rndInt(5, 10), 2, getHalfSides(), l_getSides())
+		t_wait(getPerfectDelay(THICKNESS) * 2)
+	end
 end
 
 -- onInit is an hardcoded function that is called when the level is first loaded
 function onInit()
-    l_setSpeedMult(1.7)
-    l_setSpeedInc(0.1)
-    l_setSpeedMax(2.9)
+	l_setSpeedMult(1.8)
+	l_setSpeedInc(0) -- This will be set later.
+	l_setSpeedMax(2.9)
 
-    l_setRotationSpeed(0.2)
-    l_setRotationSpeedMax(0.4)
-    l_setRotationSpeedInc(0.035)
+	l_setRotationSpeed(0.2)
+	l_setRotationSpeedMax(0.5)
+	l_setRotationSpeedInc(0.035)
 
-    l_setDelayMult(1.1)
-    l_setDelayInc(0.0)
+	l_setDelayMult(1.1)
+	l_setDelayInc(0.0)
 
-    l_setFastSpin(0.0)
+	l_setFastSpin(0.0)
 
-    l_setSides(3)
-    l_setSidesMin(3)
-    l_setSidesMax(3)
+	l_setSides(3)
+	l_setSidesMin(3)
+	l_setSidesMax(3)
 
-    l_setIncTime(10)
+	l_setIncTime(10)
 
-    l_setWallAngleLeft(-25)
+	l_setWallAngleLeft(-25)
 
     l_setPulseMin(49.98)
     l_setPulseMax(88.73)
@@ -71,43 +84,56 @@ function onInit()
     l_setBeatPulseMax(16)
     l_setBeatPulseDelayMax(24.657)
 
-    l_setSwapEnabled(true)
-    l_addTracked("level", "level")
-    l_addTracked("next at", "incrementTime")
-    l_addTracked("range", "range")
+	l_setSwapEnabled(true)
+	l_addTracked("level", "level")
+	l_addTracked("next at", "incrementTime")
+	l_addTracked("range", "range")
 end
 
 -- onLoad is an hardcoded function that is called when the level is started/restarted
 function onLoad()
-    e_messageAdd("remember, you can focus with lshift!", 150)
+	e_messageAdd("remember, you can focus with lshift!", 150)
 end
 
 -- onStep is an hardcoded function that is called when the level timeline is empty
 -- onStep should contain your pattern spawning logic
 function onStep()
-    l_setSides(u_rndInt(smin, smax) * 2)
-    slitherSpiralAcc()
+	l_setSides(math.random(smin, smax) * 2)
+	addPattern(keys[index])
+	index = index + 1
+	if index - 1 == #keys then
+		index = 1
+		shuffle(keys)
+	end
 end
-
 
 -- onIncrement is an hardcoded function that is called when the level difficulty is incremented
 function onIncrement()
-    level = level + 1
-    incrementTime = incrementTime + 5
-    e_messageAddImportant("level: "..(level).." / time: "..incrementTime, 150)
+	level = level + 1
+	e_messageAddImportant("level: "..(level).." / time: "..incrementTime, 120)
+	if (not completed) then
+		incrementTime = incrementTime + 5
+		smin = smin + 1
+		if (smin > smax) then
+			smin = 2
+			smax = smax + 1
+			if (smax > 4) then
+				completed = true
+				l_setSpeedInc(0.1) -- Enable the speed increment
+				incrementTime = 30
+			end
+		end
+	end
+	if (completed) then
+		smin = math.random(2, 3)
+		smax = clamp(smin + math.random(0, 3), smin, 5)
+	end
 
-    if smax < 4 then
-        smax = smax + 1;
-    else
-        smin = smin + 1;
-        smax = smin;
-    end
+	range = "("..(smin * 2).."/"..(smax * 2).."]"
+	e_messageAddImportant("Range: "..range, 100)
 
-    range = "("..(smin * 2).."/"..(smax * 2).."]"
-    e_messageAddImportant("Range: "..range, 100)
-
-    l_setSides(l_getSides() + 2)
-    l_setIncTime(incrementTime)
+	l_setSides(l_getSides() + 2)
+	l_setIncTime(incrementTime)
 end
 
 -- continuous direction change (even if not on level increment)
@@ -119,17 +145,17 @@ end
 
 -- onUpdate is an hardcoded function that is called every frame
 function onUpdate(mFrameTime)
-    dirChangeTime = dirChangeTime - mFrameTime;
-    if dirChangeTime < 0 then
-        -- do not change direction while fast spinning
-        if u_isFastSpinning() == false then
-            l_setRotationSpeed(l_getRotationSpeed() * -1.0)
-            dirChangeTime = 400
-        end
-    end
+	dirChangeTime = dirChangeTime - mFrameTime;
+	if dirChangeTime < 0 then
+		-- do not change direction while fast spinning
+		if u_isFastSpinning() == false then
+			l_setRotationSpeed(l_getRotationSpeed() * -1.0)
+			dirChangeTime = 400
+		end
+	end
 
-    if not achievementUnlocked and l_getLevelTime() > 60 and u_getDifficultyMult() >= 1 then
-        steam_unlockAchievement("a16_slither")
-        achievementUnlocked = true
-    end
+	if not achievementUnlocked and l_getLevelTime() > 60 and u_getDifficultyMult() >= 1 then
+		steam_unlockAchievement("a16_slither")
+		achievementUnlocked = true
+	end
 end

--- a/_RELEASE/Packs/hypercube/Styles/acceleradiant.json
+++ b/_RELEASE/Packs/hypercube/Styles/acceleradiant.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "acceleradiant",
+	// Style data id
+	"id": "acceleradiant",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": false,
-    "hue_increment": 0.5,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": false,
+	"hue_increment": 0.5,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 1.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 3,
+	"3D_skew": 0.17,
+	"3D_spacing": 153.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 5.9,
+	"3D_alpha_falloff": 16.0,
 
-    // 3D options
-    "3D_depth": 3,
-    "3D_skew": 0.17,
-    "3D_spacing": 153.5,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 5.9,
-    "3D_alpha_falloff": 16.0,
+	// Main color
+	"main": { "main": true, "dynamic": true, "value": [255, 155, 155, 230], "pulse": [50, -75, 125, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
-    // Main color
-    "main": { "main": true, "dynamic": true, "value": [255, 155, 155, 230], "pulse": [50, -75, 125, 0] },
-    "cap_color": {"legacy": true, "index": 0},
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 8.7, "value": [0, 0, 0, 0], "pulse": [45, 25, 1, 0]},
-        { "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 9.5, "value": [0, 0, 0, 0], "pulse": [1, 25, 45, 0]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 8.7, "value": [0, 0, 0, 0], "pulse": [45, 25, 1, 0]},
+		{ "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 9.5, "value": [0, 0, 0, 0], "pulse": [1, 25, 45, 0]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/centrifugal.json
+++ b/_RELEASE/Packs/hypercube/Styles/centrifugal.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "centrifugal",
+	// Style data id
+	"id": "centrifugal",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 255,
-    "hue_ping_pong": false,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 255,
+	"hue_ping_pong": false,
+	"hue_increment": 1.0,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 1.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 3,
+	"3D_skew": 0.20,
+	"3D_spacing": 19.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 5.9,
+	"3D_alpha_falloff": 66.0,
+	"3D_override_color": [76, 76, 66, 55],
+	
+	// Main color
+	"main": { "main": true, "dynamic": true, "value": [190, 190, 190, 225], "pulse": [99, 30, 165, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
-    // 3D options
-    "3D_depth": 3,
-    "3D_skew": 0.20,
-    "3D_spacing": 19.5,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 5.9,
-    "3D_alpha_falloff": 66.0,
-    "3D_override_color": [76, 76, 66, 55],
-
-    // Main color
-    "main": { "main": true, "dynamic": true, "value": [190, 190, 190, 225], "pulse": [99, 30, 165, 0] },
-    "cap_color": {"legacy": true, "index": 0},
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 3.0, "value": [0, 0, 0, 255], "pulse": [10, 0, 0, 0], "offset": 0.2, "hue_shift": 0.0}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 3.0, "value": [0, 0, 0, 255], "pulse": [10, 0, 0, 0], "offset": 0.2, "hue_shift": 0.0}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/disc-o.json
+++ b/_RELEASE/Packs/hypercube/Styles/disc-o.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "disc-o",
+	// Style data id
+	"id": "disc-o",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": true,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": true,
+	"hue_increment": 1.0,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 0.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 0.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 7,
+	"3D_skew": 0.15,
+	"3D_spacing": 1.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 0.5,
+	"3D_alpha_falloff": 19.0,
+	
+	// Main color
+	"main": { "main": true, "dynamic": true, "value": [0, 0, 0, 0], "pulse": [25, 25, 25, 0] },
+	"cap_color": "main_darkened",
 
-    // 3D options
-    "3D_depth": 7,
-    "3D_skew": 0.15,
-    "3D_spacing": 1.5,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 0.5,
-    "3D_alpha_falloff": 19.0,
-
-    // Main color
-    "main": { "main": true, "dynamic": true, "value": [0, 0, 0, 0], "pulse": [25, 25, 25, 0] },
-    "cap_color": "main_darkened",
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [80, 75, 75, 255], "pulse": [15, 15, 15, 35]},
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [45, 45, 45, 255], "pulse": [22, 25, 15, 25]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [80, 75, 75, 255], "pulse": [15, 15, 15, 35]},
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [45, 45, 45, 255], "pulse": [22, 25, 15, 25]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/evotutorial.json
+++ b/_RELEASE/Packs/hypercube/Styles/evotutorial.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "evotutorial",
+	// Style data id
+	"id": "evotutorial",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 140,
-    "hue_ping_pong": true,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 140,
+	"hue_ping_pong": true,
+	"hue_increment": 1.0,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 0.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 0.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 7,
+	"3D_skew": 0.15,
+	"3D_spacing": 1.0,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 0.5,
+	"3D_alpha_falloff": 19.0,
+	
+	// Main color
+	"main": { "main": true, "dynamic": false, "value": [45, 25, 25, 255], "pulse": [25, 25, 50, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
-    // 3D options
-    "3D_depth": 7,
-    "3D_skew": 0.15,
-    "3D_spacing": 1.0,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 0.5,
-    "3D_alpha_falloff": 19.0,
-
-    // Main color
-    "main": { "main": true, "dynamic": false, "value": [45, 25, 25, 255], "pulse": [25, 25, 50, 0] },
-    "cap_color": {"legacy": true, "index": 0},
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": true, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [190, 190, 190, 255], "pulse": [15, 15, 15, 0], "offset": 4.7},
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [235, 235, 235, 255], "pulse": [0, 0, 0, 0]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": true, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [190, 190, 190, 255], "pulse": [15, 15, 15, 0], "offset": 4.7},
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [235, 235, 235, 255], "pulse": [0, 0, 0, 0]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/g-force.json
+++ b/_RELEASE/Packs/hypercube/Styles/g-force.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "g-force",
+	// Style data id
+	"id": "g-force",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": true,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": true,
+	"hue_increment": 1.0,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 0.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 0.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 7,
+	"3D_skew": 0.15,
+	"3D_spacing": 1.1,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 0.5,
+	"3D_alpha_falloff": 19.0,
+	
+	// Main color
+	"main": { "main": false, "dynamic": false, "value": [245, 245, 245, 245], "pulse": [25, 25, 25, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
-    // 3D options
-    "3D_depth": 7,
-    "3D_skew": 0.15,
-    "3D_spacing": 1.1,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 0.5,
-    "3D_alpha_falloff": 19.0,
-
-    // Main color
-    "main": { "main": false, "dynamic": false, "value": [245, 245, 245, 245], "pulse": [25, 25, 25, 0] },
-    "cap_color": {"legacy": true, "index": 0},
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 2.7, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]},
-        { "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 3.5, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 2.7, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]},
+		{ "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 3.5, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/incongruence.json
+++ b/_RELEASE/Packs/hypercube/Styles/incongruence.json
@@ -1,33 +1,33 @@
 {
-    // Style data id
-    "id": "incongruence",
+	// Style data id
+	"id": "incongruence",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": false,
-    "hue_increment": 0.5,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": false,
+	"hue_increment": 0.5,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 1.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 3,
+	"3D_skew": 0.20,
+	"3D_spacing": 253.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 5.9,
+	"3D_alpha_falloff": 16.0,
 
-    // 3D options
-    "3D_depth": 3,
-    "3D_skew": 0.20,
-    "3D_spacing": 253.5,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 5.9,
-    "3D_alpha_falloff": 16.0,
+	// Main color
+	"main": { "main": true, "dynamic": true, "value": [255, 155, 155, 230], "pulse": [50, -75, 125, 0] },
+	"cap_color": "main_darkened",
 
-    // Main color
-    "main": { "main": true, "dynamic": true, "value": [255, 155, 155, 230], "pulse": [50, -75, 125, 0] },
-    "cap_color": "main_darkened",
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/massacre.json
+++ b/_RELEASE/Packs/hypercube/Styles/massacre.json
@@ -1,35 +1,35 @@
 {
-    // Style data id
-    "id": "massacre",
+	// Style data id
+	"id": "massacre",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": false,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": false,
+	"hue_increment": 1.0,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1.8,
+	"pulse_increment": 0.027,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 1.8,
-    "pulse_increment": 0.027,
+	// 3D options
+	"3D_depth": 12,
+	"3D_skew": 0.15,
+	"3D_spacing": 0.9,
+	"3D_darken_multiplier": 1.1,
+	"3D_alpha_multiplier": 0.4,
+	"3D_alpha_falloff": 1.0,
+	"3D_override_color": [166, 166, 166, 255],
+	
+	// Main color
+	"main": { "main": true, "dynamic": false, "value": [253, 253, 200, 255], "pulse": [0, 0, 0, 0] },
+	"cap_color": {"legacy": true, "index": 0},
 
-    // 3D options
-    "3D_depth": 12,
-    "3D_skew": 0.15,
-    "3D_spacing": 0.9,
-    "3D_darken_multiplier": 1.1,
-    "3D_alpha_multiplier": 0.4,
-    "3D_alpha_falloff": 1.0,
-    "3D_override_color": [166, 166, 166, 255],
-
-    // Main color
-    "main": { "main": true, "dynamic": false, "value": [253, 253, 200, 255], "pulse": [0, 0, 0, 0] },
-    "cap_color": {"legacy": true, "index": 0},
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [0, 73, 73, 255], "pulse": [0, 0, 0, 0]},
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [11, 11, 11, 255], "pulse": [0, 0, 0, 0]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [0, 73, 73, 255], "pulse": [0, 0, 0, 0]},
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 1.0, "value": [11, 11, 11, 255], "pulse": [0, 0, 0, 0]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/polyhedrug.json
+++ b/_RELEASE/Packs/hypercube/Styles/polyhedrug.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "polyhedrug",
+	// Style data id
+	"id": "polyhedrug",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": false,
-    "hue_increment": 0.5,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": false,
+	"hue_increment": 0.5,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 1.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 3,
+	"3D_skew": 0.20,
+	"3D_spacing": 453.5,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 5.9,
+	"3D_alpha_falloff": 16.0,
 
-    // 3D options
-    "3D_depth": 3,
-    "3D_skew": 0.20,
-    "3D_spacing": 453.5,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 5.9,
-    "3D_alpha_falloff": 16.0,
+	// Main color
+	"main": { "main": true, "dynamic": true, "value": [255, 0, 0, 255], "pulse": [-80, 75, 65, 0] },
+	"cap_color": "main",
 
-    // Main color
-    "main": { "main": true, "dynamic": true, "value": [255, 0, 0, 255], "pulse": [-80, 75, 65, 0] },
-    "cap_color": "main",
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 8.7, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]},
-        { "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 9.5, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 8.7, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]},
+		{ "dynamic": true, "dynamic_offset": false, "dynamic_darkness": 9.5, "value": [0, 0, 0, 0], "pulse": [0, 0, 0, 0]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/reppaws.json
+++ b/_RELEASE/Packs/hypercube/Styles/reppaws.json
@@ -1,32 +1,32 @@
 {
-    // Style data id
-    "id": "reppaws",
+	// Style data id
+	"id": "reppaws",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 255,
-    "hue_ping_pong": false,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 255,
+	"hue_ping_pong": false,
+	"hue_increment": 1.0,
+	
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 1.5,
+	"pulse_increment": 0.025,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 1.5,
-    "pulse_increment": 0.025,
+	// 3D options
+	"3D_depth": 4,
+	"3D_skew": 0.15,
+	"3D_spacing": 1.4,
 
-    // 3D options
-    "3D_depth": 4,
-    "3D_skew": 0.15,
-    "3D_spacing": 1.4,
+	// Main color
+	"main": { "main": true, "dynamic": true, "value": [0, 0, 0, 225], "pulse": [99, 30, 165, 0] },
+	"cap_color": "main_darkened",
 
-    // Main color
-    "main": { "main": true, "dynamic": true, "value": [0, 0, 0, 225], "pulse": [99, 30, 165, 0] },
-    "cap_color": "main_darkened",
-
-    // Background colors
-    "colors":
-    [
-        { "dynamic": false, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [63, 60, 60, 255], "pulse": [10, 0, 0, 0], "offset": 4.2, "hue_shift": 25.0},
-        { "dynamic": false, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [75, 75, 75, 255], "pulse": [0, 10, 0, 0], "offset": 4.2, "hue_shift": 50.0},
-        { "dynamic": false, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [87, 95, 90, 255], "pulse": [0, 0, 10, 0], "offset": 4.2, "hue_shift": 75.0}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [63, 60, 60, 255], "pulse": [10, 0, 0, 0], "offset": 4.2, "hue_shift": 25.0},
+		{ "dynamic": false, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [75, 75, 75, 255], "pulse": [0, 10, 0, 0], "offset": 4.2, "hue_shift": 50.0},
+		{ "dynamic": false, "dynamic_offset": true, "dynamic_darkness": 1.0, "value": [87, 95, 90, 255], "pulse": [0, 0, 10, 0], "offset": 4.2, "hue_shift": 75.0}
+	]
 }

--- a/_RELEASE/Packs/hypercube/Styles/slither.json
+++ b/_RELEASE/Packs/hypercube/Styles/slither.json
@@ -1,34 +1,34 @@
 {
-    // Style data id
-    "id": "slither",
+	// Style data id
+	"id": "slither",
 
-    // Hue options
-    "hue_min": 0,
-    "hue_max": 360,
-    "hue_ping_pong": true,
-    "hue_increment": 1.0,
+	// Hue options
+	"hue_min": 0,
+	"hue_max": 360,
+	"hue_ping_pong": true,
+	"hue_increment": 1.0,
 
-    // Pulse options
-    "pulse_min": 0.0,
-    "pulse_max": 0.5,
-    "pulse_increment": 0.025,
+	// Pulse options
+	"pulse_min": 0.0,
+	"pulse_max": 0.5,
+	"pulse_increment": 0.025,
 
-    // 3D options
-    "3D_depth": 7,
-    "3D_skew": 0.15,
-    "3D_spacing": 1.1,
-    "3D_darken_multiplier": 1.5,
-    "3D_alpha_multiplier": 0.5,
-    "3D_alpha_falloff": 19.0,
+	// 3D options
+	"3D_depth": 7,
+	"3D_skew": 0.15,
+	"3D_spacing": 1.1,
+	"3D_darken_multiplier": 1.5,
+	"3D_alpha_multiplier": 0.5,
+	"3D_alpha_falloff": 19.0,
 
-    // Main color
-    "main": { "main": true, "dynamic": false, "value": [230, 230, 230, 230], "pulse": [25, 25, 25, 0] },
-    "cap_color": { "legacy": false, "dynamic": false, "value": [25, 25, 25, 240], "pulse": [25, 25, 25, 0] },
+	// Main color
+	"main": { "main": true, "dynamic": false, "value": [230, 230, 230, 230], "pulse": [25, 25, 25, 0] },
+	"cap_color": { "legacy": false, "dynamic": false, "value": [25, 25, 25, 240], "pulse": [25, 25, 25, 0] },
 
-    // Background colors
-    "colors":
-    [
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [80, 125, 75, 255], "pulse": [15, 45, 15, 35]},
-        { "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [45, 90, 45, 255], "pulse": [22, 45, 15, 25]}
-    ]
+	// Background colors
+	"colors":
+	[
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [80, 125, 75, 255], "pulse": [15, 45, 15, 35]},
+		{ "dynamic": false, "dynamic_offset": false, "dynamic_darkness": 0.0, "value": [45, 90, 45, 255], "pulse": [22, 45, 15, 25]}
+	]
 }

--- a/_RELEASE/Packs/hypercube/pack.json
+++ b/_RELEASE/Packs/hypercube/pack.json
@@ -1,11 +1,11 @@
 {
-    "disambiguator": "ohvrvanilla",
-    "name": "hypercube",
-    "author": "vittorio romeo",
-    "version": 1,
-    "priority": -99999.01,
-
-    "dependencies":
+	"disambiguator": "ohvrvanilla",
+	"name": "hypercube",
+	"author": "vittorio romeo",
+	"version": 1,
+	"priority": -99999.01,
+	
+	"dependencies":
     [
         {
             "disambiguator": "ohvrvanilla",

--- a/_RELEASE/Packs/orthoplex/Scripts/Levels/bipolarity.lua
+++ b/_RELEASE/Packs/orthoplex/Scripts/Levels/bipolarity.lua
@@ -170,7 +170,7 @@ function addPattern(mKey)
             setDirection(direction + getRandomDir())
         end
 
-        -- local delay = getPerfectDelayDM(THICKNESS) * 5.6
+        -- local delay = getPerfectDelay(THICKNESS) * 5.6
         -- t_wait(delay)
 
         beat = getBPMToBeatPulseDelay(180) / getMusicDMSyncFactor()

--- a/_RELEASE/Packs/tutorial/Scripts/Levels/babysteps.lua
+++ b/_RELEASE/Packs/tutorial/Scripts/Levels/babysteps.lua
@@ -7,7 +7,7 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 function addPattern(mKey)
     if mKey == 0 then pBarrageSpiral(u_rndInt(1, 2), 1, 1)
     elseif mKey == 1 then pInverseBarrage(0)
-    elseif mKey == 2 then pAltBarrage(u_rndInt(1, 3), 2)
+    elseif mKey == 2 then pAltBarrage(u_rndInt(2, 4), 2)
     elseif mKey == 3 then pSpiral(12, 0)
     end
 end

--- a/_RELEASE/Packs/workshopexample/Scripts/Levels/examplelevel.lua
+++ b/_RELEASE/Packs/workshopexample/Scripts/Levels/examplelevel.lua
@@ -6,7 +6,7 @@ u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "commonpatterns.
 
 -- This function adds a pattern to the level "timeline" based on a numeric key.
 function addPattern(mKey)
-        if mKey == 0 then pAltBarrage(u_rndInt(2, 4), 2)
+        if mKey == 0 then pAltBarrage(u_rndInt(3, 5), 2)
     elseif mKey == 1 then pMirrorSpiral(u_rndInt(2, 5), getHalfSides() - 3)
     elseif mKey == 2 then pBarrageSpiral(u_rndInt(0, 3), 1, 1)
     elseif mKey == 3 then pInverseBarrage(0)


### PR DESCRIPTION
An overdue update to say the least, this is the finalized iteration of Hypercube. Here's a change log below of all the changes I made since the third iteration.

General:
- Updated the core files with the new patterns
- Deleted patterns that were redundant / unused
- Levels now rely on the core dependencies
- Improved documentation on the core files
- Resynced music timestamps to reflect the updated old Hypercube

Acceleradiant:
- Removed 0.5x, as per majority decision

Incongruence:
- Slightly redid the delay for some of the patterns
- Fixed sides not changing per pattern
- Increased speed cap

Polyhedrug:
- Scrapped Overdose concept and new patterns. It just wasn't meant to be.

Disc-O:
- Added "Twirl" Pattern, a pattern that was never used (except for Evotutorial). 

Slither:
- Scrapped the Slither barrage. Sorry Vee
- Reintroduced 2x

Massacre:
- Added "Twirl" Pattern
- Added "Consistency" Special (Yes, there's a ton of specials I know)

Centrifugal Force:
- Difficulties greater than 1x now use constant speed instead of decelerating speed, bringing back the original challenge that Centrifugal force had.

Reppaws:
- There was a split between the swap barrage. It will be retained as it helps with the level's purpose of swapping.