### PR TITLE
docs: Fix a few typos

### DIFF
--- a/public/sqlite/shell.c
+++ b/public/sqlite/shell.c
@@ -12995,7 +12995,7 @@ static void explain_data_prepare(ShellState *p, sqlite3_stmt *pSql){
     /* Grow the p->aiIndent array as required */
     if( iOp>=nAlloc ){
       if( iOp==0 ){
-        /* Do further verfication that this is explain output.  Abort if
+        /* Do further verification that this is explain output.  Abort if
         ** it is not */
         static const char *explainCols[] = {
            "addr", "opcode", "p1", "p2", "p3", "p4", "p5", "comment" };

--- a/public/sqlite/sqlite3.h
+++ b/public/sqlite/sqlite3.h
@@ -3561,7 +3561,7 @@ SQLITE_API int sqlite3_open_v2(
 ** as F) must be one of:
 ** <ul>
 ** <li> A database filename pointer created by the SQLite core and
-** passed into the xOpen() method of a VFS implemention, or
+** passed into the xOpen() method of a VFS implementation, or
 ** <li> A filename obtained from [sqlite3_db_filename()], or
 ** <li> A new filename constructed using [sqlite3_create_filename()].
 ** </ul>


### PR DESCRIPTION
There are small typos in:
- public/sqlite/shell.c
- public/sqlite/sqlite3.c
- public/sqlite/sqlite3.h

Fixes:
- Should read `implementation` rather than `implemention`.
- Should read `number` rather than `nubmer`.
- Should read `accumulated` rather than `accumuated`.
- Should read `warning` rather than `warnning`.
- Should read `verification` rather than `verfication`.
- Should read `slowly` rather than `slowely`.
- Should read `indexes` rather than `indexs`.
- Should read `implicitly` rather than `implicity`.
- Should read `demonstrate` rather than `demonstrat`.
- Should read `constraint` rather than `contraint`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md